### PR TITLE
feat: document chunk nodes with incremental updates

### DIFF
--- a/cmd/codegraph/main.go
+++ b/cmd/codegraph/main.go
@@ -1377,7 +1377,7 @@ to the specific code functions that implement them.`,
 
 		// Display results
 		fmt.Printf("\n📊 FEATURE LINKING RESULTS\n")
-		fmt.Printf("=" + strings.Repeat("=", 50) + "\n\n")
+		fmt.Println("=" + strings.Repeat("=", 50) + "\n")
 
 		totalFeatures := len(results)
 		totalLinks := 0
@@ -1411,7 +1411,7 @@ to the specific code functions that implement them.`,
 
 		// Summary statistics
 		fmt.Printf("🎉 SUMMARY\n")
-		fmt.Printf("=" + strings.Repeat("=", 30) + "\n")
+		fmt.Println("=" + strings.Repeat("=", 30))
 		fmt.Printf("Features Processed: %d\n", totalFeatures)
 		fmt.Printf("Total Candidates Evaluated: %d\n", totalCandidates)
 		fmt.Printf("Total IMPLEMENTS Links Created: %d\n", totalLinks)

--- a/pkg/indexer/documents/indexer.go
+++ b/pkg/indexer/documents/indexer.go
@@ -76,6 +76,16 @@ func (di *DocumentIndexer) IndexDocument(ctx context.Context, filePath string) e
 		}
 	}
 
+	// Create document chunks
+	docNodeKey := models.DocumentNodeKey(doc.SourceURL)
+	chunkStats, err := di.createDocumentChunks(ctx, docID, docNodeKey, doc.Content)
+	if err != nil {
+		fmt.Printf("Warning: failed to create document chunks: %v\n", err)
+	} else {
+		fmt.Printf("Chunks: %d total, %d created, %d unchanged, %d updated\n",
+			chunkStats.Total, chunkStats.Created, chunkStats.Unchanged, chunkStats.Updated)
+	}
+
 	// Create relationships to code symbols using intelligent or simple linking
 	if err := di.linkToCodeSymbols(ctx, docID, doc.Content); err != nil {
 		fmt.Printf("Warning: failed to link to code symbols: %v\n", err)
@@ -83,6 +93,118 @@ func (di *DocumentIndexer) IndexDocument(ctx context.Context, filePath string) e
 
 	fmt.Printf("Successfully indexed document: %s\n", doc.Title)
 	return nil
+}
+
+// chunkStats tracks incremental chunk update statistics.
+type chunkStats struct {
+	Total     int
+	Created   int
+	Updated   int
+	Unchanged int
+}
+
+// createDocumentChunks creates DocumentChunk nodes linked to the parent Document via HAS_CHUNK.
+// Uses textHash for incremental updates — only changed chunks are written.
+func (di *DocumentIndexer) createDocumentChunks(ctx context.Context, docID, docNodeKey, content string) (chunkStats, error) {
+	chunks := di.parser.ChunkDocumentWithMeta(content)
+	var stats chunkStats
+	stats.Total = len(chunks)
+
+	// Load existing chunk hashes for this document to detect changes.
+	existingHashes, err := di.loadExistingChunkHashes(ctx, docNodeKey)
+	if err != nil {
+		// Non-fatal: just index all chunks.
+		fmt.Printf("Warning: could not load existing chunk hashes: %v\n", err)
+		existingHashes = map[string]string{}
+	}
+
+	for _, chunk := range chunks {
+		chunkNodeKey := models.DocumentChunkNodeKey(docNodeKey, chunk.ChunkIndex)
+
+		// Check if chunk already exists with the same hash.
+		if existingHash, exists := existingHashes[chunkNodeKey]; exists && existingHash == chunk.TextHash {
+			stats.Unchanged++
+			delete(existingHashes, chunkNodeKey) // Mark as still present.
+			continue
+		}
+
+		if _, exists := existingHashes[chunkNodeKey]; exists {
+			stats.Updated++
+		} else {
+			stats.Created++
+		}
+		delete(existingHashes, chunkNodeKey)
+
+		chunkProps := map[string]any{
+			"documentKey": docNodeKey,
+			"chunkIndex":  chunk.ChunkIndex,
+			"headingPath": chunk.HeadingPath,
+			"content":     chunk.Content,
+			"textHash":    chunk.TextHash,
+			"startOffset": chunk.StartOffset,
+			"endOffset":   chunk.EndOffset,
+			"nodeKey":     chunkNodeKey,
+			"scope":       di.scopeCtx.Scope,
+			"scopeId":     di.scopeCtx.ScopeID,
+		}
+
+		chunkID, err := di.client.MergeNode(ctx, []string{"DocumentChunk"},
+			map[string]any{"nodeKey": chunkNodeKey, "scopeId": di.scopeCtx.ScopeID}, chunkProps)
+		if err != nil {
+			return stats, fmt.Errorf("failed to create chunk %d: %w", chunk.ChunkIndex, err)
+		}
+
+		// Create HAS_CHUNK relationship from Document to DocumentChunk.
+		_, err = di.client.MergeRelationship(ctx, docID, chunkID, "HAS_CHUNK",
+			map[string]any{"chunkIndex": chunk.ChunkIndex},
+			map[string]any{"chunkIndex": chunk.ChunkIndex})
+		if err != nil {
+			return stats, fmt.Errorf("failed to create HAS_CHUNK for chunk %d: %w", chunk.ChunkIndex, err)
+		}
+	}
+
+	// Remove stale chunks that no longer exist in the document.
+	for staleKey := range existingHashes {
+		di.deleteStaleChunk(ctx, staleKey)
+	}
+
+	return stats, nil
+}
+
+// loadExistingChunkHashes queries Neo4j for existing DocumentChunk nodes for this document and scope.
+func (di *DocumentIndexer) loadExistingChunkHashes(ctx context.Context, docNodeKey string) (map[string]string, error) {
+	cypher := `MATCH (c:DocumentChunk {documentKey: $docKey, scopeId: $scopeId})
+RETURN c.nodeKey AS nodeKey, c.textHash AS textHash`
+	params := map[string]any{
+		"docKey":  docNodeKey,
+		"scopeId": di.scopeCtx.ScopeID,
+	}
+	results, err := di.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, err
+	}
+	hashes := make(map[string]string, len(results))
+	for _, record := range results {
+		m := record.AsMap()
+		nk, _ := m["nodeKey"].(string)
+		th, _ := m["textHash"].(string)
+		if nk != "" {
+			hashes[nk] = th
+		}
+	}
+	return hashes, nil
+}
+
+// deleteStaleChunk removes a DocumentChunk node that no longer corresponds to any chunk in the document.
+func (di *DocumentIndexer) deleteStaleChunk(ctx context.Context, chunkNodeKey string) {
+	cypher := `MATCH (c:DocumentChunk {nodeKey: $nodeKey, scopeId: $scopeId}) DETACH DELETE c`
+	params := map[string]any{
+		"nodeKey": chunkNodeKey,
+		"scopeId": di.scopeCtx.ScopeID,
+	}
+	if _, err := di.client.ExecuteQuery(ctx, cypher, params); err != nil {
+		fmt.Printf("Warning: failed to delete stale chunk %s: %v\n", chunkNodeKey, err)
+	}
 }
 
 // IndexDirectory recursively indexes all documents in a directory

--- a/pkg/indexer/documents/parser.go
+++ b/pkg/indexer/documents/parser.go
@@ -1,6 +1,8 @@
 package documents
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +12,16 @@ import (
 
 	"github.com/context-maximiser/code-graph/pkg/models"
 )
+
+// ChunkMeta holds metadata for a document chunk produced by the parser.
+type ChunkMeta struct {
+	Content     string // The chunk text
+	HeadingPath string // Heading hierarchy, e.g. "Architecture > Components"
+	StartOffset int    // Byte offset in original document
+	EndOffset   int    // Byte offset end
+	ChunkIndex  int    // 0-based index within document
+	TextHash    string // SHA-256 hex of Content
+}
 
 // DocumentParser handles parsing and feature extraction from documents
 type DocumentParser struct {
@@ -87,6 +99,106 @@ func (dp *DocumentParser) ChunkDocument(content string) []string {
 	}
 
 	return chunks
+}
+
+// ChunkDocumentWithMeta breaks a document into chunks with heading paths, offsets, and text hashes.
+func (dp *DocumentParser) ChunkDocumentWithMeta(content string) []ChunkMeta {
+	headingRe := regexp.MustCompile(`(?m)^(#{1,6})\s+(.+)$`)
+
+	// Split into paragraphs (double newline separated).
+	paragraphs := strings.Split(content, "\n\n")
+
+	var chunks []ChunkMeta
+	var currentText strings.Builder
+	wordCount := 0
+	chunkStart := 0 // byte offset of the start of the current chunk
+	bytePos := 0    // running byte offset
+	chunkIndex := 0
+
+	// Track heading stack: headings[0] = h1, headings[1] = h2, etc.
+	headings := make([]string, 6)
+
+	flushChunk := func() {
+		text := currentText.String()
+		if strings.TrimSpace(text) == "" {
+			return
+		}
+		h := sha256.Sum256([]byte(text))
+		chunks = append(chunks, ChunkMeta{
+			Content:     text,
+			HeadingPath: buildHeadingPath(headings),
+			StartOffset: chunkStart,
+			EndOffset:   chunkStart + len(text),
+			ChunkIndex:  chunkIndex,
+			TextHash:    hex.EncodeToString(h[:]),
+		})
+		chunkIndex++
+		currentText.Reset()
+		wordCount = 0
+	}
+
+	for i, paragraph := range paragraphs {
+		paragraph = strings.TrimSpace(paragraph)
+		if paragraph == "" {
+			// Account for the double-newline separator.
+			if i < len(paragraphs)-1 {
+				bytePos += 2
+			}
+			continue
+		}
+
+		// Check if this paragraph is/contains a heading and update the stack.
+		for _, line := range strings.Split(paragraph, "\n") {
+			if m := headingRe.FindStringSubmatch(line); m != nil {
+				level := len(m[1]) - 1 // 0-indexed
+				headings[level] = strings.TrimSpace(m[2])
+				// Clear deeper headings.
+				for j := level + 1; j < 6; j++ {
+					headings[j] = ""
+				}
+			}
+		}
+
+		paragraphWords := len(strings.Fields(paragraph))
+
+		// If adding this paragraph would exceed chunk size, flush.
+		if wordCount+paragraphWords > dp.chunkSize && currentText.Len() > 0 {
+			flushChunk()
+			chunkStart = bytePos
+		}
+
+		if currentText.Len() > 0 {
+			currentText.WriteString("\n\n")
+		}
+		currentText.WriteString(paragraph)
+		wordCount += paragraphWords
+
+		// Advance byte position past the paragraph + separator.
+		bytePos += len(paragraph)
+		if i < len(paragraphs)-1 {
+			bytePos += 2 // the \n\n separator
+		}
+	}
+
+	flushChunk()
+	return chunks
+}
+
+// buildHeadingPath joins non-empty heading levels with " > ".
+func buildHeadingPath(headings []string) string {
+	var parts []string
+	for _, h := range headings {
+		if h != "" {
+			parts = append(parts, h)
+		}
+	}
+	return strings.Join(parts, " > ")
+}
+
+// textHash returns the SHA-256 hex string of s.
+func textHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
 }
 
 // extractFeatures simulates LLM-based feature extraction

--- a/pkg/indexer/documents/parser_test.go
+++ b/pkg/indexer/documents/parser_test.go
@@ -1,0 +1,144 @@
+package documents
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestChunkDocumentWithMeta_SingleChunk(t *testing.T) {
+	parser := &DocumentParser{chunkSize: 1000}
+	content := "Hello world.\n\nThis is a test document."
+
+	chunks := parser.ChunkDocumentWithMeta(content)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+	if c.ChunkIndex != 0 {
+		t.Errorf("expected ChunkIndex 0, got %d", c.ChunkIndex)
+	}
+	if c.TextHash == "" {
+		t.Error("TextHash should not be empty")
+	}
+	// Verify hash is correct.
+	h := sha256.Sum256([]byte(c.Content))
+	expectedHash := hex.EncodeToString(h[:])
+	if c.TextHash != expectedHash {
+		t.Errorf("TextHash mismatch: %s != %s", c.TextHash, expectedHash)
+	}
+}
+
+func TestChunkDocumentWithMeta_MultipleChunks(t *testing.T) {
+	parser := &DocumentParser{chunkSize: 5} // Very small chunk size to force splitting.
+
+	// Each paragraph has more than 5 words.
+	content := "This is the first paragraph with many words.\n\nThis is the second paragraph with enough words.\n\nThird paragraph here with some words."
+
+	chunks := parser.ChunkDocumentWithMeta(content)
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks with chunkSize=5, got %d", len(chunks))
+	}
+
+	// Verify chunk indices are sequential.
+	for i, c := range chunks {
+		if c.ChunkIndex != i {
+			t.Errorf("chunk %d has ChunkIndex %d", i, c.ChunkIndex)
+		}
+	}
+
+	// Verify all content is accounted for.
+	var allContent []string
+	for _, c := range chunks {
+		allContent = append(allContent, c.Content)
+	}
+	joined := strings.Join(allContent, "\n\n")
+	if !strings.Contains(joined, "first paragraph") {
+		t.Error("missing first paragraph in chunks")
+	}
+	if !strings.Contains(joined, "Third paragraph") {
+		t.Error("missing third paragraph in chunks")
+	}
+}
+
+func TestChunkDocumentWithMeta_HeadingTracking(t *testing.T) {
+	parser := &DocumentParser{chunkSize: 1000}
+	content := "# Main Title\n\nIntro text.\n\n## Section One\n\nSection one content.\n\n## Section Two\n\nSection two content."
+
+	chunks := parser.ChunkDocumentWithMeta(content)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk (large chunkSize), got %d", len(chunks))
+	}
+
+	// The heading path should contain the deepest heading encountered.
+	if !strings.Contains(chunks[0].HeadingPath, "Main Title") {
+		t.Errorf("expected heading path to contain 'Main Title', got %q", chunks[0].HeadingPath)
+	}
+}
+
+func TestChunkDocumentWithMeta_HeadingSplitAcrossChunks(t *testing.T) {
+	parser := &DocumentParser{chunkSize: 5}
+
+	content := "# Title\n\nFirst paragraph with many words enough.\n\n## Subsection\n\nSecond paragraph with many words enough."
+
+	chunks := parser.ChunkDocumentWithMeta(content)
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+
+	// First chunk should have "Title" in heading path.
+	if !strings.Contains(chunks[0].HeadingPath, "Title") {
+		t.Errorf("first chunk heading path should contain 'Title', got %q", chunks[0].HeadingPath)
+	}
+
+	// Later chunks should pick up deeper headings.
+	lastChunk := chunks[len(chunks)-1]
+	if !strings.Contains(lastChunk.HeadingPath, "Subsection") {
+		t.Errorf("last chunk heading path should contain 'Subsection', got %q", lastChunk.HeadingPath)
+	}
+}
+
+func TestChunkDocumentWithMeta_Determinism(t *testing.T) {
+	parser := &DocumentParser{chunkSize: 50}
+	content := "# Hello\n\nSome content here.\n\n## World\n\nMore content."
+
+	chunks1 := parser.ChunkDocumentWithMeta(content)
+	chunks2 := parser.ChunkDocumentWithMeta(content)
+
+	if len(chunks1) != len(chunks2) {
+		t.Fatalf("non-deterministic chunk count: %d vs %d", len(chunks1), len(chunks2))
+	}
+
+	for i := range chunks1 {
+		if chunks1[i].TextHash != chunks2[i].TextHash {
+			t.Errorf("chunk %d has different hash on re-run", i)
+		}
+		if chunks1[i].HeadingPath != chunks2[i].HeadingPath {
+			t.Errorf("chunk %d has different heading path on re-run", i)
+		}
+	}
+}
+
+func TestChunkDocumentWithMeta_EmptyDocument(t *testing.T) {
+	parser := &DocumentParser{chunkSize: 100}
+	chunks := parser.ChunkDocumentWithMeta("")
+	if len(chunks) != 0 {
+		t.Errorf("expected 0 chunks for empty document, got %d", len(chunks))
+	}
+}
+
+func TestBuildHeadingPath(t *testing.T) {
+	headings := []string{"Title", "Section", "", "", "", ""}
+	path := buildHeadingPath(headings)
+	if path != "Title > Section" {
+		t.Errorf("expected 'Title > Section', got %q", path)
+	}
+
+	headings = []string{"", "", "", "", "", ""}
+	path = buildHeadingPath(headings)
+	if path != "" {
+		t.Errorf("expected empty path, got %q", path)
+	}
+}

--- a/pkg/models/node.go
+++ b/pkg/models/node.go
@@ -20,8 +20,9 @@ const (
 	SymbolNode    NodeType = "Symbol"
 	APIRouteNode  NodeType = "APIRoute"
 	CommentNode   NodeType = "Comment"
-	DocumentNode  NodeType = "Document"
-	FeatureNode   NodeType = "Feature"
+	DocumentNode      NodeType = "Document"
+	DocumentChunkNode NodeType = "DocumentChunk"
+	FeatureNode       NodeType = "Feature"
 )
 
 // BaseNode represents common properties for all nodes
@@ -185,6 +186,18 @@ type Document struct {
 	Content   string `json:"content" neo4j:"content"`
 }
 
+// DocumentChunk represents a chunk of a document for granular linking and incremental updates
+type DocumentChunk struct {
+	BaseNode
+	DocumentKey string `json:"documentKey" neo4j:"documentKey"`
+	ChunkIndex  int    `json:"chunkIndex" neo4j:"chunkIndex"`
+	HeadingPath string `json:"headingPath" neo4j:"headingPath"`
+	Content     string `json:"content" neo4j:"content"`
+	TextHash    string `json:"textHash" neo4j:"textHash"`
+	StartOffset int    `json:"startOffset" neo4j:"startOffset"`
+	EndOffset   int    `json:"endOffset" neo4j:"endOffset"`
+}
+
 // Feature represents a specific feature or capability
 type Feature struct {
 	BaseNode
@@ -250,6 +263,10 @@ func NodeFactory(nodeType NodeType, props map[string]any) interface{} {
 		}
 	case DocumentNode:
 		return &Document{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case DocumentChunkNode:
+		return &DocumentChunk{
 			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
 		}
 	case FeatureNode:

--- a/pkg/models/nodekey.go
+++ b/pkg/models/nodekey.go
@@ -67,6 +67,11 @@ func DocumentNodeKey(sourceURL string) string {
 	return "doc:" + sourceURL
 }
 
+// DocumentChunkNodeKey returns "chunk:{documentKey}#{chunkIndex}".
+func DocumentChunkNodeKey(documentKey string, chunkIndex int) string {
+	return fmt.Sprintf("chunk:%s#%d", documentKey, chunkIndex)
+}
+
 // FeatureNodeKey returns "feat:{name}".
 func FeatureNodeKey(name string) string {
 	return "feat:" + name

--- a/pkg/models/nodekey_test.go
+++ b/pkg/models/nodekey_test.go
@@ -158,6 +158,23 @@ func TestNodeKeysAreUnique(t *testing.T) {
 	}
 }
 
+func TestDocumentChunkNodeKey(t *testing.T) {
+	key := DocumentChunkNodeKey("doc:docs/README.md", 0)
+	expected := "chunk:doc:docs/README.md#0"
+	if key != expected {
+		t.Errorf("expected %s, got %s", expected, key)
+	}
+	key2 := DocumentChunkNodeKey("doc:docs/README.md", 3)
+	expected2 := "chunk:doc:docs/README.md#3"
+	if key2 != expected2 {
+		t.Errorf("expected %s, got %s", expected2, key2)
+	}
+	// Different indices produce different keys.
+	if key == key2 {
+		t.Error("DocumentChunkNodeKey should differ for different chunk indices")
+	}
+}
+
 func TestNodeKeyDeterminism(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		a := FunctionNodeKey("pkg/foo.go", "Bar()")

--- a/pkg/neo4j/client.go
+++ b/pkg/neo4j/client.go
@@ -3,6 +3,7 @@ package neo4j
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
@@ -201,6 +202,50 @@ func (c *Client) CreateRelationship(ctx context.Context, fromID, toID, relType s
 
 	if len(result) == 0 {
 		return "", fmt.Errorf("no records returned from create relationship query")
+	}
+
+	id, ok := result[0].AsMap()["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to extract relationship ID from result")
+	}
+
+	return id, nil
+}
+
+// MergeRelationship creates or updates a relationship between two nodes using MERGE.
+// mergeProps are used to match an existing relationship; setProps are applied on match/create.
+func (c *Client) MergeRelationship(ctx context.Context, fromID, toID, relType string, mergeProps, setProps map[string]any) (string, error) {
+	mergeClause := ""
+	if len(mergeProps) > 0 {
+		parts := make([]string, 0, len(mergeProps))
+		for key := range mergeProps {
+			parts = append(parts, fmt.Sprintf("%s: $merge.%s", key, key))
+		}
+		mergeClause = " {" + strings.Join(parts, ", ") + "}"
+	}
+
+	cypher := fmt.Sprintf(`
+		MATCH (from), (to)
+		WHERE elementId(from) = $fromId AND elementId(to) = $toId
+		MERGE (from)-[r:%s%s]->(to)
+		SET r += $set
+		RETURN elementId(r) as id
+	`, relType, mergeClause)
+
+	params := map[string]any{
+		"fromId": fromID,
+		"toId":   toID,
+		"merge":  mergeProps,
+		"set":    setProps,
+	}
+
+	result, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to merge relationship: %w", err)
+	}
+
+	if len(result) == 0 {
+		return "", fmt.Errorf("no records returned from merge relationship query")
 	}
 
 	id, ok := result[0].AsMap()["id"].(string)

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -355,6 +355,31 @@ func GetIndexes() []Index {
 			Properties: []string{"scope", "scopeId"},
 			Type:       "BTREE",
 		},
+		// DocumentChunk indexes (Task 4)
+		{
+			Name:       "docchunk_nodekey_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "docchunk_nodekey_scope_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "docchunk_dockey_scope_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"documentKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "docchunk_texthash_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"textHash"},
+			Type:       "BTREE",
+		},
 		// Tombstone indexes (Phase 3)
 		{
 			Name:       "tombstone_nodekey_scope_idx",


### PR DESCRIPTION
## Summary
- Add `DocumentChunk` node type with `textHash`, `chunkIndex`, `headingPath`, `startOffset`, `endOffset`, `documentKey`
- Parser tracks heading hierarchy across chunks via `ChunkDocumentWithMeta()`
- SHA-256 hash-based incremental updates: re-indexing only writes changed chunks, skips unchanged ones
- `(Document)-[:HAS_CHUNK]->(DocumentChunk)` relationship via new `MergeRelationship()` client method
- DocumentChunk schema indexes for nodeKey, scope, documentKey, textHash
- Stale chunks (no longer in document) are automatically deleted on re-index

## Test plan
- [x] Unit tests: `go test ./pkg/models/... ./pkg/indexer/documents/...` — all pass
- [x] Full build: `go build ./...` — clean
- [x] Smoke test: `make smoke-test` — passes
- [x] Index docs/ twice: all 53 chunks show "0 created, N unchanged, 0 updated" on re-index
- [x] Verified in Neo4j: all 53 DocumentChunk nodes have textHash, nodeKey, headingPath; HAS_CHUNK relationships exist

Implements Task 4 from `docs/12-implementation-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)