### PR TITLE
feat: external doc connector + sync CLI

### DIFF
--- a/cmd/codegraph/main.go
+++ b/cmd/codegraph/main.go
@@ -516,6 +516,95 @@ var indexDocsCmd = &cobra.Command{
 	},
 }
 
+// docsSyncCmd syncs documents from an external source (Confluence, etc.)
+var docsSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync documents from an external source",
+	Long:  "Fetch documents from Confluence or other external sources and index them into the graph",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		source, _ := cmd.Flags().GetString("source")
+		space, _ := cmd.Flags().GetString("space")
+		docURL, _ := cmd.Flags().GetString("url")
+		docID, _ := cmd.Flags().GetString("doc-id")
+		baseURL, _ := cmd.Flags().GetString("base-url")
+		username, _ := cmd.Flags().GetString("username")
+		apiToken, _ := cmd.Flags().GetString("api-token")
+
+		if source == "" {
+			return fmt.Errorf("--source is required (e.g., 'confluence')")
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		indexer := documents.NewDocumentIndexer(client)
+
+		// Set scope if provided.
+		syncScopeFlag, _ := cmd.Flags().GetString("scope")
+		syncScopeIDFlag, _ := cmd.Flags().GetString("scope-id")
+		if syncScopeFlag == "pr" {
+			prID := syncScopeIDFlag
+			if prID == "" {
+				return fmt.Errorf("--scope-id is required when --scope=pr")
+			}
+			if strings.HasPrefix(prID, "pr-") {
+				prID = prID[3:]
+			}
+			indexer.SetScope(models.NewPRScope(prID))
+		}
+
+		ctx := context.Background()
+
+		var connector documents.DocConnector
+		switch strings.ToLower(source) {
+		case "confluence":
+			if baseURL == "" {
+				return fmt.Errorf("--base-url is required for Confluence (e.g., 'https://your-domain.atlassian.net/wiki')")
+			}
+			if username == "" || apiToken == "" {
+				return fmt.Errorf("--username and --api-token are required for Confluence")
+			}
+			connector = documents.NewConfluenceConnector(documents.ConfluenceConfig{
+				BaseURL:  baseURL,
+				Username: username,
+				APIToken: apiToken,
+			})
+		default:
+			return fmt.Errorf("unsupported source: %s (supported: confluence)", source)
+		}
+
+		// Single document sync (by URL or doc ID).
+		if docURL != "" || docID != "" {
+			id := docID
+			if id == "" {
+				id = docURL
+			}
+			fmt.Printf("Syncing single document: %s\n", id)
+			if err := indexer.SyncExternalDocument(ctx, connector, id); err != nil {
+				return fmt.Errorf("failed to sync document: %w", err)
+			}
+			fmt.Println("✓ Document synced successfully")
+			return nil
+		}
+
+		// Space sync.
+		if space != "" {
+			fmt.Printf("Syncing space: %s from %s\n", space, source)
+			synced, err := indexer.SyncExternalSpace(ctx, connector, space)
+			if err != nil {
+				return fmt.Errorf("failed to sync space: %w", err)
+			}
+			fmt.Printf("✓ Synced %d documents from space %s\n", synced, space)
+			return nil
+		}
+
+		return fmt.Errorf("provide either --space (to sync all docs) or --url/--doc-id (to sync one doc)")
+	},
+}
+
 // indexTombstoneCmd creates tombstones for deleted files/symbols in a PR overlay
 var indexTombstoneCmd = &cobra.Command{
 	Use:   "tombstone [file_paths...]",
@@ -1542,6 +1631,7 @@ func init() {
 	indexCmd.AddCommand(indexSCIPCmd)
 	indexCmd.AddCommand(indexIncrementalCmd)
 	indexCmd.AddCommand(indexDocsCmd)
+	indexDocsCmd.AddCommand(docsSyncCmd)
 	indexCmd.AddCommand(indexTombstoneCmd)
 
 	// Flags for project command
@@ -1566,6 +1656,17 @@ func init() {
 	// Flags for docs command
 	indexDocsCmd.Flags().String("scope", "main", "Scope for indexing: 'main' (default) or 'pr'")
 	indexDocsCmd.Flags().String("scope-id", "", "Scope ID (e.g., 'pr-42'). Defaults to scope value if not set.")
+
+	// Flags for docs sync command
+	docsSyncCmd.Flags().String("source", "", "Document source (e.g., 'confluence')")
+	docsSyncCmd.Flags().String("space", "", "Space/collection to sync (e.g., Confluence space key)")
+	docsSyncCmd.Flags().String("url", "", "Single document URL to sync")
+	docsSyncCmd.Flags().String("doc-id", "", "Single document ID to sync")
+	docsSyncCmd.Flags().String("base-url", "", "Base URL of the document source API")
+	docsSyncCmd.Flags().String("username", "", "Username for authentication")
+	docsSyncCmd.Flags().String("api-token", "", "API token for authentication")
+	docsSyncCmd.Flags().String("scope", "main", "Scope for indexing: 'main' (default) or 'pr'")
+	docsSyncCmd.Flags().String("scope-id", "", "Scope ID (e.g., 'pr-42')")
 
 	// Flags for tombstone command
 	indexTombstoneCmd.Flags().String("scope", "pr", "Scope for tombstone creation (must be 'pr')")

--- a/pkg/indexer/documents/confluence.go
+++ b/pkg/indexer/documents/confluence.go
@@ -1,0 +1,255 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ConfluenceConnector fetches documents from Atlassian Confluence via REST API v2.
+type ConfluenceConnector struct {
+	baseURL    string // e.g., "https://your-domain.atlassian.net/wiki"
+	username   string // Atlassian account email
+	apiToken   string // API token (not password)
+	httpClient *http.Client
+}
+
+// ConfluenceConfig holds configuration for connecting to Confluence.
+type ConfluenceConfig struct {
+	BaseURL  string
+	Username string
+	APIToken string
+}
+
+// NewConfluenceConnector creates a new Confluence connector.
+func NewConfluenceConnector(cfg ConfluenceConfig) *ConfluenceConnector {
+	return &ConfluenceConnector{
+		baseURL:  strings.TrimRight(cfg.BaseURL, "/"),
+		username: cfg.Username,
+		apiToken: cfg.APIToken,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (c *ConfluenceConnector) Name() string { return "confluence" }
+
+// ListDocuments lists pages in a Confluence space using the v2 REST API.
+func (c *ConfluenceConnector) ListDocuments(ctx context.Context, space string) ([]ExternalDocument, error) {
+	endpoint := fmt.Sprintf("%s/api/v2/spaces?keys=%s", c.baseURL, url.QueryEscape(space))
+
+	// First, get the space ID.
+	spaceResp, err := c.doRequest(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get space %s: %w", space, err)
+	}
+
+	var spacesResult struct {
+		Results []struct {
+			ID   string `json:"id"`
+			Key  string `json:"key"`
+			Name string `json:"name"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(spaceResp, &spacesResult); err != nil {
+		return nil, fmt.Errorf("failed to parse space response: %w", err)
+	}
+	if len(spacesResult.Results) == 0 {
+		return nil, fmt.Errorf("space %s not found", space)
+	}
+
+	spaceID := spacesResult.Results[0].ID
+
+	// List pages in the space.
+	pagesEndpoint := fmt.Sprintf("%s/api/v2/spaces/%s/pages?limit=100&body-format=storage", c.baseURL, spaceID)
+	pagesResp, err := c.doRequest(ctx, pagesEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pages: %w", err)
+	}
+
+	var pagesResult struct {
+		Results []confluencePageV2 `json:"results"`
+	}
+	if err := json.Unmarshal(pagesResp, &pagesResult); err != nil {
+		return nil, fmt.Errorf("failed to parse pages response: %w", err)
+	}
+
+	var docs []ExternalDocument
+	for _, page := range pagesResult.Results {
+		docs = append(docs, ExternalDocument{
+			ID:        page.ID,
+			Title:     page.Title,
+			SourceURL: fmt.Sprintf("%s/pages/%s", c.baseURL, page.ID),
+			Source:    "confluence",
+			Metadata: map[string]string{
+				"space":  space,
+				"status": page.Status,
+			},
+		})
+	}
+
+	return docs, nil
+}
+
+// FetchDocument retrieves a single Confluence page by ID and converts its content to markdown.
+func (c *ConfluenceConnector) FetchDocument(ctx context.Context, docID string) (*ExternalDocument, error) {
+	endpoint := fmt.Sprintf("%s/api/v2/pages/%s?body-format=storage", c.baseURL, url.PathEscape(docID))
+	body, err := c.doRequest(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch page %s: %w", docID, err)
+	}
+
+	var page confluencePageV2
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("failed to parse page response: %w", err)
+	}
+
+	content := ""
+	if page.Body.Storage.Value != "" {
+		content = confluenceStorageToMarkdown(page.Body.Storage.Value)
+	}
+
+	updatedAt := time.Time{}
+	if page.Version.CreatedAt != "" {
+		updatedAt, _ = time.Parse(time.RFC3339, page.Version.CreatedAt)
+	}
+
+	return &ExternalDocument{
+		ID:        page.ID,
+		Title:     page.Title,
+		Content:   content,
+		SourceURL: fmt.Sprintf("%s/pages/%s", c.baseURL, page.ID),
+		Source:    "confluence",
+		UpdatedAt: updatedAt,
+		Metadata: map[string]string{
+			"status":  page.Status,
+			"version": fmt.Sprintf("%d", page.Version.Number),
+		},
+	}, nil
+}
+
+// doRequest performs an authenticated GET request and returns the response body.
+func (c *ConfluenceConnector) doRequest(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.username, c.apiToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("confluence API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// confluencePageV2 represents a Confluence page from the v2 API.
+type confluencePageV2 struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
+	Body   struct {
+		Storage struct {
+			Value string `json:"value"`
+		} `json:"storage"`
+	} `json:"body"`
+	Version struct {
+		Number    int    `json:"number"`
+		CreatedAt string `json:"createdAt"`
+	} `json:"version"`
+}
+
+// confluenceStorageToMarkdown converts Confluence storage format (XHTML) to markdown.
+// This is a simplified converter that handles common elements.
+func confluenceStorageToMarkdown(storage string) string {
+	s := storage
+
+	// Headers: <h1> through <h6>
+	for i := 6; i >= 1; i-- {
+		prefix := strings.Repeat("#", i)
+		openTag := fmt.Sprintf("<h%d[^>]*>", i)
+		closeTag := fmt.Sprintf("</h%d>", i)
+		s = regexp.MustCompile(openTag).ReplaceAllString(s, prefix+" ")
+		s = strings.ReplaceAll(s, closeTag, "\n\n")
+	}
+
+	// Paragraphs
+	s = regexp.MustCompile(`<p[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</p>", "\n\n")
+
+	// Bold and italic
+	s = regexp.MustCompile(`<strong[^>]*>`).ReplaceAllString(s, "**")
+	s = strings.ReplaceAll(s, "</strong>", "**")
+	s = regexp.MustCompile(`<em[^>]*>`).ReplaceAllString(s, "*")
+	s = strings.ReplaceAll(s, "</em>", "*")
+
+	// Code blocks
+	s = regexp.MustCompile(`<ac:structured-macro[^>]*ac:name="code"[^>]*>.*?<ac:plain-text-body><!\[CDATA\[(.*?)\]\]></ac:plain-text-body></ac:structured-macro>`).
+		ReplaceAllString(s, "```\n$1\n```\n")
+
+	// Inline code
+	s = regexp.MustCompile(`<code[^>]*>`).ReplaceAllString(s, "`")
+	s = strings.ReplaceAll(s, "</code>", "`")
+
+	// Lists
+	s = regexp.MustCompile(`<ul[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</ul>", "\n")
+	s = regexp.MustCompile(`<ol[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</ol>", "\n")
+	s = regexp.MustCompile(`<li[^>]*>`).ReplaceAllString(s, "- ")
+	s = strings.ReplaceAll(s, "</li>", "\n")
+
+	// Links
+	s = regexp.MustCompile(`<a[^>]*href="([^"]*)"[^>]*>(.*?)</a>`).
+		ReplaceAllString(s, "[$2]($1)")
+
+	// Images
+	s = regexp.MustCompile(`<ac:image[^>]*><ri:url ri:value="([^"]*)"[^/]*/></ac:image>`).
+		ReplaceAllString(s, "![]($1)")
+
+	// Tables (simplified)
+	s = regexp.MustCompile(`<table[^>]*>`).ReplaceAllString(s, "\n")
+	s = strings.ReplaceAll(s, "</table>", "\n")
+	s = regexp.MustCompile(`<tr[^>]*>`).ReplaceAllString(s, "| ")
+	s = strings.ReplaceAll(s, "</tr>", " |\n")
+	s = regexp.MustCompile(`<t[hd][^>]*>`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`</t[hd]>`).ReplaceAllString(s, " | ")
+	s = regexp.MustCompile(`<tbody[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</tbody>", "")
+
+	// Strip remaining HTML tags
+	s = regexp.MustCompile(`<[^>]+>`).ReplaceAllString(s, "")
+
+	// Clean up HTML entities
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&quot;", "\"")
+	s = strings.ReplaceAll(s, "&#39;", "'")
+	s = strings.ReplaceAll(s, "&nbsp;", " ")
+
+	// Normalize whitespace
+	s = regexp.MustCompile(`\n{3,}`).ReplaceAllString(s, "\n\n")
+	s = strings.TrimSpace(s)
+
+	return s
+}

--- a/pkg/indexer/documents/connector.go
+++ b/pkg/indexer/documents/connector.go
@@ -1,0 +1,29 @@
+package documents
+
+import (
+	"context"
+	"time"
+)
+
+// ExternalDocument represents a document fetched from an external source.
+type ExternalDocument struct {
+	ID        string            // Unique identifier in the source system.
+	Title     string            // Human-readable title.
+	Content   string            // Markdown or plain-text content.
+	SourceURL string            // Canonical URL to the document.
+	Source    string            // Source system name (e.g., "confluence", "gdocs").
+	UpdatedAt time.Time         // Last modification time in the source.
+	Metadata  map[string]string // Arbitrary key-value metadata from the source.
+}
+
+// DocConnector defines the interface for fetching documents from external systems.
+type DocConnector interface {
+	// Name returns the connector name (e.g., "confluence", "gdocs").
+	Name() string
+
+	// ListDocuments returns a list of document IDs/URLs available in the given space/collection.
+	ListDocuments(ctx context.Context, space string) ([]ExternalDocument, error)
+
+	// FetchDocument retrieves a single document by its ID or URL and returns normalized content.
+	FetchDocument(ctx context.Context, docID string) (*ExternalDocument, error)
+}

--- a/pkg/indexer/documents/connector_test.go
+++ b/pkg/indexer/documents/connector_test.go
@@ -1,0 +1,210 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestConfluenceStorageToMarkdown_Headers(t *testing.T) {
+	input := `<h1>Title</h1><h2>Section</h2><h3>Sub</h3>`
+	result := confluenceStorageToMarkdown(input)
+
+	if !strings.Contains(result, "# Title") {
+		t.Errorf("expected '# Title', got %q", result)
+	}
+	if !strings.Contains(result, "## Section") {
+		t.Errorf("expected '## Section', got %q", result)
+	}
+	if !strings.Contains(result, "### Sub") {
+		t.Errorf("expected '### Sub', got %q", result)
+	}
+}
+
+func TestConfluenceStorageToMarkdown_BoldAndItalic(t *testing.T) {
+	input := `<p><strong>bold</strong> and <em>italic</em></p>`
+	result := confluenceStorageToMarkdown(input)
+
+	if !strings.Contains(result, "**bold**") {
+		t.Errorf("expected **bold**, got %q", result)
+	}
+	if !strings.Contains(result, "*italic*") {
+		t.Errorf("expected *italic*, got %q", result)
+	}
+}
+
+func TestConfluenceStorageToMarkdown_Lists(t *testing.T) {
+	input := `<ul><li>item one</li><li>item two</li></ul>`
+	result := confluenceStorageToMarkdown(input)
+
+	if !strings.Contains(result, "- item one") {
+		t.Errorf("expected '- item one', got %q", result)
+	}
+	if !strings.Contains(result, "- item two") {
+		t.Errorf("expected '- item two', got %q", result)
+	}
+}
+
+func TestConfluenceStorageToMarkdown_Links(t *testing.T) {
+	input := `<a href="https://example.com">Example</a>`
+	result := confluenceStorageToMarkdown(input)
+
+	if !strings.Contains(result, "[Example](https://example.com)") {
+		t.Errorf("expected markdown link, got %q", result)
+	}
+}
+
+func TestConfluenceStorageToMarkdown_InlineCode(t *testing.T) {
+	input := `<p>Use <code>foo()</code> here</p>`
+	result := confluenceStorageToMarkdown(input)
+
+	if !strings.Contains(result, "`foo()`") {
+		t.Errorf("expected inline code, got %q", result)
+	}
+}
+
+func TestConfluenceStorageToMarkdown_HTMLEntities(t *testing.T) {
+	input := `<p>A &amp; B &lt; C &gt; D</p>`
+	result := confluenceStorageToMarkdown(input)
+
+	if !strings.Contains(result, "A & B < C > D") {
+		t.Errorf("expected decoded entities, got %q", result)
+	}
+}
+
+func TestConfluenceStorageToMarkdown_StripsTags(t *testing.T) {
+	input := `<div class="panel"><span style="color:red">text</span></div>`
+	result := confluenceStorageToMarkdown(input)
+
+	if strings.Contains(result, "<") {
+		t.Errorf("expected no HTML tags, got %q", result)
+	}
+	if !strings.Contains(result, "text") {
+		t.Errorf("expected 'text' in output, got %q", result)
+	}
+}
+
+func TestConfluenceStorageToMarkdown_Empty(t *testing.T) {
+	result := confluenceStorageToMarkdown("")
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestConfluenceConnector_Name(t *testing.T) {
+	c := NewConfluenceConnector(ConfluenceConfig{})
+	if c.Name() != "confluence" {
+		t.Errorf("expected 'confluence', got %s", c.Name())
+	}
+}
+
+func TestConfluenceConnector_FetchDocument(t *testing.T) {
+	// Mock Confluence API server.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/api/v2/pages/12345") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		page := confluencePageV2{
+			ID:     "12345",
+			Title:  "Test Page",
+			Status: "current",
+		}
+		page.Body.Storage.Value = "<h1>Hello</h1><p>World</p>"
+		page.Version.Number = 3
+		page.Version.CreatedAt = "2025-01-15T10:00:00Z"
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(page)
+	}))
+	defer server.Close()
+
+	c := NewConfluenceConnector(ConfluenceConfig{
+		BaseURL:  server.URL,
+		Username: "user",
+		APIToken: "token",
+	})
+
+	doc, err := c.FetchDocument(context.Background(), "12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if doc.ID != "12345" {
+		t.Errorf("expected ID '12345', got %s", doc.ID)
+	}
+	if doc.Title != "Test Page" {
+		t.Errorf("expected title 'Test Page', got %s", doc.Title)
+	}
+	if !strings.Contains(doc.Content, "# Hello") {
+		t.Errorf("expected markdown content with '# Hello', got %q", doc.Content)
+	}
+	if !strings.Contains(doc.Content, "World") {
+		t.Errorf("expected 'World' in content, got %q", doc.Content)
+	}
+	if doc.Source != "confluence" {
+		t.Errorf("expected source 'confluence', got %s", doc.Source)
+	}
+	if doc.Metadata["version"] != "3" {
+		t.Errorf("expected version '3', got %s", doc.Metadata["version"])
+	}
+}
+
+func TestConfluenceConnector_ListDocuments(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, "/api/v2/spaces") && !strings.Contains(r.URL.Path, "/pages") {
+			// Space lookup.
+			json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{
+					{"id": "space-1", "key": "DEV", "name": "Development"},
+				},
+			})
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/pages") {
+			// Pages listing.
+			json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{
+					{"id": "101", "title": "Page One", "status": "current"},
+					{"id": "102", "title": "Page Two", "status": "current"},
+				},
+			})
+			return
+		}
+
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := NewConfluenceConnector(ConfluenceConfig{
+		BaseURL:  server.URL,
+		Username: "user",
+		APIToken: "token",
+	})
+
+	docs, err := c.ListDocuments(context.Background(), "DEV")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(docs))
+	}
+
+	if docs[0].Title != "Page One" {
+		t.Errorf("expected first doc 'Page One', got %s", docs[0].Title)
+	}
+	if docs[1].ID != "102" {
+		t.Errorf("expected second doc ID '102', got %s", docs[1].ID)
+	}
+}
+
+// Verify the interface is satisfied at compile time.
+var _ DocConnector = (*ConfluenceConnector)(nil)

--- a/pkg/indexer/documents/indexer.go
+++ b/pkg/indexer/documents/indexer.go
@@ -362,3 +362,70 @@ func (di *DocumentIndexer) GetDocumentStats(ctx context.Context) (map[string]any
 	
 	return map[string]any{}, nil
 }
+
+// SyncExternalDocument fetches a document from an external connector and indexes it.
+func (di *DocumentIndexer) SyncExternalDocument(ctx context.Context, connector DocConnector, docID string) error {
+	extDoc, err := connector.FetchDocument(ctx, docID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch document %s: %w", docID, err)
+	}
+
+	return di.indexExternalDocument(ctx, extDoc)
+}
+
+// SyncExternalSpace fetches all documents from a space and indexes them.
+func (di *DocumentIndexer) SyncExternalSpace(ctx context.Context, connector DocConnector, space string) (int, error) {
+	docs, err := connector.ListDocuments(ctx, space)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list documents in space %s: %w", space, err)
+	}
+
+	synced := 0
+	for _, doc := range docs {
+		fmt.Printf("Syncing: %s (%s)\n", doc.Title, doc.ID)
+		extDoc, err := connector.FetchDocument(ctx, doc.ID)
+		if err != nil {
+			fmt.Printf("Warning: failed to fetch %s: %v\n", doc.ID, err)
+			continue
+		}
+		if err := di.indexExternalDocument(ctx, extDoc); err != nil {
+			fmt.Printf("Warning: failed to index %s: %v\n", doc.ID, err)
+			continue
+		}
+		synced++
+	}
+
+	return synced, nil
+}
+
+// indexExternalDocument indexes a single external document with chunks.
+func (di *DocumentIndexer) indexExternalDocument(ctx context.Context, extDoc *ExternalDocument) error {
+	doc := &models.Document{
+		Title:     extDoc.Title,
+		Type:      fmt.Sprintf("External/%s", extDoc.Source),
+		SourceURL: extDoc.SourceURL,
+		Content:   extDoc.Content,
+	}
+
+	docID, err := di.createDocumentNode(ctx, doc)
+	if err != nil {
+		return fmt.Errorf("failed to create document node: %w", err)
+	}
+
+	// Create chunks.
+	docNodeKey := models.DocumentNodeKey(extDoc.SourceURL)
+	chunkStats, err := di.createDocumentChunks(ctx, docID, docNodeKey, extDoc.Content)
+	if err != nil {
+		return fmt.Errorf("failed to create chunks: %w", err)
+	}
+
+	fmt.Printf("  Chunks: %d total, %d created, %d unchanged, %d updated\n",
+		chunkStats.Total, chunkStats.Created, chunkStats.Unchanged, chunkStats.Updated)
+
+	// Link to code symbols.
+	if err := di.linkToCodeSymbols(ctx, docID, extDoc.Content); err != nil {
+		fmt.Printf("  Warning: failed to link to code symbols: %v\n", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `DocConnector` interface with `ListDocuments()` and `FetchDocument()` methods
- Implement `ConfluenceConnector` using Atlassian Confluence v2 REST API
- Add Confluence storage format to Markdown converter (headers, formatting, code, lists, links, tables)
- Add `SyncExternalDocument()` and `SyncExternalSpace()` to `DocumentIndexer`
- Add CLI command: `codegraph index docs sync --source confluence --space DEV`
- Single doc sync: `codegraph index docs sync --source confluence --doc-id 12345`

Stacked on: #8 (document chunk nodes)

## Test plan
- [x] Unit tests for Confluence storage-to-markdown conversion (8 test cases)
- [x] Unit tests for FetchDocument and ListDocuments with httptest mock server
- [x] Interface satisfaction verified at compile time
- [x] Full build: `go build ./...` — clean
- [x] CLI `--help` output verified

Implements Task 5 from `docs/12-implementation-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)