### PR TITLE
feat: flow spine nodes and bounded expansion (Task 9)

### DIFF
--- a/cmd/codegraph/main.go
+++ b/cmd/codegraph/main.go
@@ -841,6 +841,63 @@ var queryDepsCmd = &cobra.Command{
 	},
 }
 
+// queryFlowsCmd lists or generates flow spines
+var queryFlowsCmd = &cobra.Command{
+	Use:   "flows",
+	Short: "List or generate flow spines",
+	Long:  "List existing flow spines or generate new ones from API endpoints",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		generate, _ := cmd.Flags().GetBool("generate")
+		maxDepth, _ := cmd.Flags().GetInt("max-depth")
+		flowType, _ := cmd.Flags().GetString("type")
+		scopeID, _ := cmd.Flags().GetString("scope-id")
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		gen := query.NewFlowSpineGenerator(client)
+		if scopeID != "" {
+			gen.SetScope(models.NewPRScope(scopeID))
+		}
+		ctx := context.Background()
+
+		if generate {
+			results, err := gen.GenerateFromAPIEndpoints(ctx, maxDepth)
+			if err != nil {
+				return fmt.Errorf("failed to generate flows: %w", err)
+			}
+			fmt.Printf("Generated %d flow spines\n", len(results))
+			for _, r := range results {
+				fmt.Printf("  %s (%s) — %d steps\n", r.FlowName, r.FlowType, len(r.Steps))
+				for _, s := range r.Steps {
+					fmt.Printf("    [%d] %s (%s)\n", s.Order, s.Name, s.Label)
+				}
+			}
+			return nil
+		}
+
+		// List existing flows.
+		flows, err := gen.ListFlows(ctx, flowType)
+		if err != nil {
+			return fmt.Errorf("failed to list flows: %w", err)
+		}
+
+		if len(flows) == 0 {
+			fmt.Println("No flow spines found. Use --generate to create them from API endpoints.")
+			return nil
+		}
+
+		fmt.Printf("Found %d flow spines:\n", len(flows))
+		for _, f := range flows {
+			fmt.Printf("  %s [%s] (%s)\n", f.FlowName, f.FlowType, f.FlowNodeKey)
+		}
+		return nil
+	},
+}
+
 // serverCmd starts the API server
 var serverCmd = &cobra.Command{
 	Use:   "server",
@@ -1733,11 +1790,18 @@ func init() {
 	queryCmd.AddCommand(querySearchCmd)
 	queryCmd.AddCommand(querySourceCmd)
 	queryCmd.AddCommand(queryDepsCmd)
+	queryCmd.AddCommand(queryFlowsCmd)
 
 	// Query flags
 	querySearchCmd.Flags().IntP("limit", "l", 0, "Limit search results (0 = no limit)")
 	queryDepsCmd.Flags().String("service", "", "Service name to query dependencies for")
 	queryDepsCmd.Flags().String("scope-id", "", "Optional scope ID for overlay-aware query")
+
+	// Flow flags
+	queryFlowsCmd.Flags().Bool("generate", false, "Generate flow spines from API endpoints")
+	queryFlowsCmd.Flags().Int("max-depth", 2, "Maximum call graph traversal depth")
+	queryFlowsCmd.Flags().String("type", "", "Filter by flow type (api, consumer, cron)")
+	queryFlowsCmd.Flags().String("scope-id", "", "Optional scope ID for overlay-aware flows")
 
 	// Benchmark subcommands
 	benchmarkCmd.AddCommand(benchmarkMemoryCmd)

--- a/pkg/models/node.go
+++ b/pkg/models/node.go
@@ -22,6 +22,7 @@ const (
 	CommentNode   NodeType = "Comment"
 	DocumentNode      NodeType = "Document"
 	DocumentChunkNode NodeType = "DocumentChunk"
+	FlowNode          NodeType = "Flow"
 	FeatureNode       NodeType = "Feature"
 )
 
@@ -198,6 +199,15 @@ type DocumentChunk struct {
 	EndOffset   int    `json:"endOffset" neo4j:"endOffset"`
 }
 
+// Flow represents a first-class execution flow (e.g., an API request path, consumer pipeline).
+type Flow struct {
+	BaseNode
+	Name           string `json:"name" neo4j:"name"`
+	EntrypointKey  string `json:"entrypointKey" neo4j:"entrypointKey"`
+	FlowType       string `json:"flowType" neo4j:"flowType"` // "api", "consumer", "cron"
+	MaxDepth       int    `json:"maxDepth" neo4j:"maxDepth"`
+}
+
 // Feature represents a specific feature or capability
 type Feature struct {
 	BaseNode
@@ -267,6 +277,10 @@ func NodeFactory(nodeType NodeType, props map[string]any) interface{} {
 		}
 	case DocumentChunkNode:
 		return &DocumentChunk{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case FlowNode:
+		return &Flow{
 			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
 		}
 	case FeatureNode:

--- a/pkg/models/nodekey.go
+++ b/pkg/models/nodekey.go
@@ -87,6 +87,11 @@ func CommentNodeKey(filePath string, startLine int) string {
 	return fmt.Sprintf("comment:%s:%d", filePath, startLine)
 }
 
+// FlowNodeKey returns "flow:{flowType}:{entrypointKey}".
+func FlowNodeKey(flowType, entrypointKey string) string {
+	return "flow:" + flowType + ":" + entrypointKey
+}
+
 // ReferenceNodeKey returns "ref:{filePath}:{startLine}:{startColumn}".
 func ReferenceNodeKey(filePath string, startLine, startColumn int) string {
 	return fmt.Sprintf("ref:%s:%d:%d", filePath, startLine, startColumn)

--- a/pkg/models/nodekey_test.go
+++ b/pkg/models/nodekey_test.go
@@ -128,6 +128,19 @@ func TestReferenceNodeKey(t *testing.T) {
 	}
 }
 
+func TestFlowNodeKey(t *testing.T) {
+	key := FlowNodeKey("api", "api:GET:/api/users")
+	expected := "flow:api:api:GET:/api/users"
+	if key != expected {
+		t.Errorf("expected %s, got %s", expected, key)
+	}
+	// Different flow types produce different keys
+	key2 := FlowNodeKey("consumer", "api:GET:/api/users")
+	if key == key2 {
+		t.Error("FlowNodeKey should differ for different flow types")
+	}
+}
+
 func TestNodeKeysAreUnique(t *testing.T) {
 	keys := map[string]string{
 		"service":   ServiceNodeKey("codegraph"),
@@ -144,6 +157,7 @@ func TestNodeKeysAreUnique(t *testing.T) {
 		"api":       APIRouteNodeKey("GET", "/api/users"),
 		"comment":   CommentNodeKey("pkg/models/node.go", 10),
 		"reference": ReferenceNodeKey("pkg/models/node.go", 42, 5),
+		"flow":      FlowNodeKey("api", "api:GET:/api/users"),
 	}
 
 	seen := make(map[string]string)

--- a/pkg/query/flow_spine.go
+++ b/pkg/query/flow_spine.go
@@ -1,0 +1,318 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+)
+
+// FlowStep represents a single step in a flow spine.
+type FlowStep struct {
+	NodeKey string `json:"nodeKey"`
+	Name    string `json:"name"`
+	Label   string `json:"label"` // Function, Method, Service, APIRoute
+	Order   int    `json:"order"`
+}
+
+// FlowSpineResult holds the generated flow and its steps.
+type FlowSpineResult struct {
+	FlowNodeKey string     `json:"flowNodeKey"`
+	FlowName    string     `json:"flowName"`
+	FlowType    string     `json:"flowType"`
+	Steps       []FlowStep `json:"steps"`
+}
+
+// FlowSpineGenerator creates Flow spine nodes from API endpoints and call graphs.
+type FlowSpineGenerator struct {
+	client   *neo4j.Client
+	scopeCtx models.ScopeContext
+}
+
+// NewFlowSpineGenerator creates a new generator.
+func NewFlowSpineGenerator(client *neo4j.Client) *FlowSpineGenerator {
+	return &FlowSpineGenerator{
+		client:   client,
+		scopeCtx: models.DefaultScope(),
+	}
+}
+
+// SetScope sets the scope context for flow generation.
+func (g *FlowSpineGenerator) SetScope(scope models.ScopeContext) {
+	g.scopeCtx = scope
+}
+
+// GenerateFromAPIEndpoints discovers API endpoints and builds flow spines by
+// traversing the call graph from each handler function up to maxDepth.
+func (g *FlowSpineGenerator) GenerateFromAPIEndpoints(ctx context.Context, maxDepth int) ([]FlowSpineResult, error) {
+	if maxDepth <= 0 {
+		maxDepth = 2
+	}
+
+	// Find API endpoints and their handler functions.
+	cypher := `
+		MATCH (route:APIRoute)
+		OPTIONAL MATCH (route)<-[:EXPOSES_API]-(handler)
+		WHERE handler:Function OR handler:Method
+		RETURN route.nodeKey AS routeKey, route.method AS method, route.path AS path,
+		       handler.nodeKey AS handlerKey, handler.name AS handlerName,
+		       labels(handler) AS handlerLabels`
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query API endpoints: %w", err)
+	}
+
+	var results []FlowSpineResult
+	for _, r := range records {
+		m := r.AsMap()
+		routeKey := strVal(m, "routeKey")
+		method := strVal(m, "method")
+		path := strVal(m, "path")
+		handlerKey := strVal(m, "handlerKey")
+		handlerName := strVal(m, "handlerName")
+
+		if routeKey == "" {
+			continue
+		}
+
+		flowName := fmt.Sprintf("%s %s", method, path)
+		flowNodeKey := models.FlowNodeKey("api", routeKey)
+
+		steps := []FlowStep{
+			{NodeKey: routeKey, Name: flowName, Label: "APIRoute", Order: 0},
+		}
+
+		// If there's a handler, traverse its call graph.
+		if handlerKey != "" {
+			handlerLabel := "Function"
+			if labels, ok := m["handlerLabels"].([]any); ok {
+				for _, l := range labels {
+					if s, ok := l.(string); ok && s == "Method" {
+						handlerLabel = "Method"
+						break
+					}
+				}
+			}
+			steps = append(steps, FlowStep{
+				NodeKey: handlerKey, Name: handlerName, Label: handlerLabel, Order: 1,
+			})
+
+			// Traverse CALLS edges from handler.
+			callees, err := g.traceCallees(ctx, handlerKey, maxDepth-1, 2)
+			if err != nil {
+				fmt.Printf("Warning: failed to trace callees for %s: %v\n", handlerKey, err)
+			} else {
+				steps = append(steps, callees...)
+			}
+		}
+
+		// Persist the Flow node and HAS_STEP edges.
+		if err := g.persistFlow(ctx, flowNodeKey, flowName, "api", routeKey, maxDepth, steps); err != nil {
+			fmt.Printf("Warning: failed to persist flow %s: %v\n", flowName, err)
+			continue
+		}
+
+		results = append(results, FlowSpineResult{
+			FlowNodeKey: flowNodeKey,
+			FlowName:    flowName,
+			FlowType:    "api",
+			Steps:       steps,
+		})
+	}
+
+	return results, nil
+}
+
+// traceCallees recursively follows CALLS edges from a given function nodeKey.
+func (g *FlowSpineGenerator) traceCallees(ctx context.Context, nodeKey string, remainingDepth, nextOrder int) ([]FlowStep, error) {
+	if remainingDepth <= 0 {
+		return nil, nil
+	}
+
+	cypher := `
+		MATCH (caller {nodeKey: $nodeKey})-[:CALLS]->(callee)
+		WHERE callee:Function OR callee:Method
+		RETURN callee.nodeKey AS calleeKey, callee.name AS calleeName, labels(callee) AS calleeLabels
+		LIMIT 20`
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, map[string]any{"nodeKey": nodeKey})
+	if err != nil {
+		return nil, err
+	}
+
+	var steps []FlowStep
+	order := nextOrder
+	for _, r := range records {
+		m := r.AsMap()
+		calleeKey := strVal(m, "calleeKey")
+		calleeName := strVal(m, "calleeName")
+		if calleeKey == "" {
+			continue
+		}
+
+		calleeLabel := "Function"
+		if labels, ok := m["calleeLabels"].([]any); ok {
+			for _, l := range labels {
+				if s, ok := l.(string); ok && s == "Method" {
+					calleeLabel = "Method"
+					break
+				}
+			}
+		}
+
+		steps = append(steps, FlowStep{
+			NodeKey: calleeKey, Name: calleeName, Label: calleeLabel, Order: order,
+		})
+		order++
+
+		// Recurse deeper.
+		deeper, err := g.traceCallees(ctx, calleeKey, remainingDepth-1, order)
+		if err != nil {
+			continue
+		}
+		steps = append(steps, deeper...)
+		order += len(deeper)
+	}
+
+	return steps, nil
+}
+
+// persistFlow creates/merges a Flow node and its HAS_STEP relationships.
+func (g *FlowSpineGenerator) persistFlow(ctx context.Context, flowNodeKey, name, flowType, entrypointKey string, maxDepth int, steps []FlowStep) error {
+	flowProps := map[string]any{
+		"name":          name,
+		"entrypointKey": entrypointKey,
+		"flowType":      flowType,
+		"maxDepth":      maxDepth,
+		"nodeKey":       flowNodeKey,
+		"scope":         g.scopeCtx.Scope,
+		"scopeId":       g.scopeCtx.ScopeID,
+	}
+
+	flowID, err := g.client.MergeNode(ctx, []string{"Flow"},
+		map[string]any{"nodeKey": flowNodeKey, "scopeId": g.scopeCtx.ScopeID}, flowProps)
+	if err != nil {
+		return fmt.Errorf("failed to create Flow node: %w", err)
+	}
+
+	// Create HAS_STEP edges to each step's node.
+	for _, step := range steps {
+		cypher := `
+			MATCH (target {nodeKey: $targetKey})
+			WHERE target:Function OR target:Method OR target:APIRoute OR target:Service
+			WITH target LIMIT 1
+			MATCH (flow:Flow {nodeKey: $flowKey, scopeId: $scopeId})
+			MERGE (flow)-[r:HAS_STEP {order: $order}]->(target)
+			SET r.stepName = $stepName`
+
+		_, err := g.client.ExecuteQuery(ctx, cypher, map[string]any{
+			"flowKey":   flowNodeKey,
+			"scopeId":   g.scopeCtx.ScopeID,
+			"targetKey": step.NodeKey,
+			"order":     step.Order,
+			"stepName":  step.Name,
+		})
+		if err != nil {
+			fmt.Printf("Warning: failed to create HAS_STEP for step %d (%s): %v\n", step.Order, step.Name, err)
+		}
+	}
+
+	_ = flowID // used by MergeNode
+	return nil
+}
+
+// GetFlow retrieves a flow spine by its nodeKey.
+func (g *FlowSpineGenerator) GetFlow(ctx context.Context, flowNodeKey string) (*FlowSpineResult, error) {
+	cypher := `
+		MATCH (f:Flow {nodeKey: $flowKey})
+		OPTIONAL MATCH (f)-[r:HAS_STEP]->(step)
+		RETURN f.name AS flowName, f.flowType AS flowType, f.nodeKey AS flowNodeKey,
+		       step.nodeKey AS stepKey, step.name AS stepName, labels(step) AS stepLabels,
+		       r.order AS stepOrder
+		ORDER BY r.order`
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, map[string]any{"flowKey": flowNodeKey})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get flow: %w", err)
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("flow not found: %s", flowNodeKey)
+	}
+
+	first := records[0].AsMap()
+	result := &FlowSpineResult{
+		FlowNodeKey: strVal(first, "flowNodeKey"),
+		FlowName:    strVal(first, "flowName"),
+		FlowType:    strVal(first, "flowType"),
+	}
+
+	for _, r := range records {
+		m := r.AsMap()
+		stepKey := strVal(m, "stepKey")
+		if stepKey == "" {
+			continue
+		}
+		order := 0
+		if o, ok := m["stepOrder"].(int64); ok {
+			order = int(o)
+		}
+
+		stepLabel := "Function"
+		if labels, ok := m["stepLabels"].([]any); ok {
+			for _, l := range labels {
+				if s, ok := l.(string); ok {
+					if s == "Method" || s == "APIRoute" || s == "Service" {
+						stepLabel = s
+						break
+					}
+				}
+			}
+		}
+
+		result.Steps = append(result.Steps, FlowStep{
+			NodeKey: stepKey,
+			Name:    strVal(m, "stepName"),
+			Label:   stepLabel,
+			Order:   order,
+		})
+	}
+
+	return result, nil
+}
+
+// ListFlows lists all flow spines, optionally filtered by type.
+func (g *FlowSpineGenerator) ListFlows(ctx context.Context, flowType string) ([]FlowSpineResult, error) {
+	var cypher string
+	params := map[string]any{}
+
+	if flowType != "" {
+		cypher = `MATCH (f:Flow {flowType: $flowType})
+			RETURN f.nodeKey AS flowNodeKey, f.name AS flowName, f.flowType AS flowType
+			ORDER BY f.name`
+		params["flowType"] = flowType
+	} else {
+		cypher = `MATCH (f:Flow)
+			RETURN f.nodeKey AS flowNodeKey, f.name AS flowName, f.flowType AS flowType
+			ORDER BY f.name`
+	}
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list flows: %w", err)
+	}
+
+	var results []FlowSpineResult
+	for _, r := range records {
+		m := r.AsMap()
+		results = append(results, FlowSpineResult{
+			FlowNodeKey: strVal(m, "flowNodeKey"),
+			FlowName:    strVal(m, "flowName"),
+			FlowType:    strVal(m, "flowType"),
+		})
+	}
+
+	return results, nil
+}

--- a/pkg/query/flow_spine_test.go
+++ b/pkg/query/flow_spine_test.go
@@ -1,0 +1,90 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+)
+
+func TestFlowStep_Fields(t *testing.T) {
+	step := FlowStep{
+		NodeKey: "func:pkg/handler.go#HandleUser(...)",
+		Name:    "HandleUser",
+		Label:   "Function",
+		Order:   1,
+	}
+
+	if step.NodeKey != "func:pkg/handler.go#HandleUser(...)" {
+		t.Errorf("unexpected NodeKey: %s", step.NodeKey)
+	}
+	if step.Order != 1 {
+		t.Errorf("expected Order 1, got %d", step.Order)
+	}
+}
+
+func TestFlowSpineResult_Fields(t *testing.T) {
+	result := FlowSpineResult{
+		FlowNodeKey: models.FlowNodeKey("api", "api:GET:/api/users"),
+		FlowName:    "GET /api/users",
+		FlowType:    "api",
+		Steps: []FlowStep{
+			{NodeKey: "api:GET:/api/users", Name: "GET /api/users", Label: "APIRoute", Order: 0},
+			{NodeKey: "func:pkg/handler.go#HandleUser(...)", Name: "HandleUser", Label: "Function", Order: 1},
+		},
+	}
+
+	if result.FlowType != "api" {
+		t.Errorf("expected FlowType 'api', got %s", result.FlowType)
+	}
+	if len(result.Steps) != 2 {
+		t.Errorf("expected 2 steps, got %d", len(result.Steps))
+	}
+	if result.Steps[0].Label != "APIRoute" {
+		t.Errorf("expected first step label 'APIRoute', got %s", result.Steps[0].Label)
+	}
+	if result.Steps[1].Order != 1 {
+		t.Errorf("expected second step order 1, got %d", result.Steps[1].Order)
+	}
+}
+
+func TestFlowNodeKeyIntegration(t *testing.T) {
+	// Verify FlowNodeKey produces expected format for flow spine usage.
+	key := models.FlowNodeKey("api", "api:GET:/api/users")
+	expected := "flow:api:api:GET:/api/users"
+	if key != expected {
+		t.Errorf("expected %s, got %s", expected, key)
+	}
+
+	key2 := models.FlowNodeKey("consumer", "queue:orders")
+	expected2 := "flow:consumer:queue:orders"
+	if key2 != expected2 {
+		t.Errorf("expected %s, got %s", expected2, key2)
+	}
+}
+
+func TestNewFlowSpineGenerator(t *testing.T) {
+	// Verify constructor sets defaults (nil client is fine for unit test).
+	gen := NewFlowSpineGenerator(nil)
+	if gen == nil {
+		t.Fatal("expected non-nil generator")
+	}
+	if gen.scopeCtx.Scope != "main" {
+		t.Errorf("expected default scope 'main', got %s", gen.scopeCtx.Scope)
+	}
+	if gen.scopeCtx.ScopeID != "main" {
+		t.Errorf("expected default scopeID 'main', got %s", gen.scopeCtx.ScopeID)
+	}
+}
+
+func TestFlowSpineGenerator_SetScope(t *testing.T) {
+	gen := NewFlowSpineGenerator(nil)
+	prScope := models.NewPRScope("42")
+	gen.SetScope(prScope)
+
+	if gen.scopeCtx.Scope != "pr" {
+		t.Errorf("expected scope 'pr', got %s", gen.scopeCtx.Scope)
+	}
+	if gen.scopeCtx.ScopeID != "pr-42" {
+		t.Errorf("expected scopeID 'pr-42', got %s", gen.scopeCtx.ScopeID)
+	}
+}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -380,6 +380,31 @@ func GetIndexes() []Index {
 			Properties: []string{"textHash"},
 			Type:       "BTREE",
 		},
+		// Flow indexes (Task 9)
+		{
+			Name:       "flow_nodekey_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "flow_nodekey_scope_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "flow_entrypoint_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"entrypointKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "flow_type_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"flowType"},
+			Type:       "BTREE",
+		},
 		// Tombstone indexes (Phase 3)
 		{
 			Name:       "tombstone_nodekey_scope_idx",


### PR DESCRIPTION
## Summary
- Adds `Flow` as a first-class node type representing execution paths (API request flows, consumer pipelines, etc.)
- `FlowSpineGenerator` discovers API endpoints, traverses CALLS edges to configurable depth, and creates Flow + HAS_STEP relationships
- New CLI command `query flows` with `--generate` flag to build spines and list existing flows
- Schema indexes for Flow nodes (nodeKey, scope, entrypoint, type)

## Test plan
- [x] Unit tests for FlowStep, FlowSpineResult, FlowNodeKey, constructor, SetScope
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [ ] Integration: `./bin/codegraph query flows --generate --max-depth 2` creates flow spines from indexed API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)