### PR TITLE
feat: generated context in PR overlay (Task 10)

### DIFF
--- a/pkg/indexer/generated/context.go
+++ b/pkg/indexer/generated/context.go
@@ -1,0 +1,240 @@
+package generated
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+)
+
+// GeneratedDocType constants for the different types of generated docs.
+const (
+	DocTypePRSummary          = "pr_summary"
+	DocTypeFlowSummary        = "flow_summary"
+	DocTypeDocstringSuggestion = "docstring_suggestion"
+)
+
+// ContextGenerator creates and manages generated context nodes in the graph.
+type ContextGenerator struct {
+	client   *neo4j.Client
+	scopeCtx models.ScopeContext
+}
+
+// NewContextGenerator creates a new context generator.
+func NewContextGenerator(client *neo4j.Client) *ContextGenerator {
+	return &ContextGenerator{
+		client:   client,
+		scopeCtx: models.DefaultScope(),
+	}
+}
+
+// SetScope sets the scope context.
+func (g *ContextGenerator) SetScope(scope models.ScopeContext) {
+	g.scopeCtx = scope
+}
+
+// CreatePullRequestNode creates a PullRequest node in the graph.
+func (g *ContextGenerator) CreatePullRequestNode(ctx context.Context, prID, title, author, baseBranch, headBranch, description string) (string, error) {
+	nodeKey := models.PullRequestNodeKey(prID)
+	props := map[string]any{
+		"prId":        prID,
+		"title":       title,
+		"author":      author,
+		"baseBranch":  baseBranch,
+		"headBranch":  headBranch,
+		"status":      "open",
+		"description": description,
+		"nodeKey":     nodeKey,
+		"scope":       g.scopeCtx.Scope,
+		"scopeId":     g.scopeCtx.ScopeID,
+	}
+
+	id, err := g.client.MergeNode(ctx, []string{"PullRequest"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": g.scopeCtx.ScopeID}, props)
+	if err != nil {
+		return "", fmt.Errorf("failed to create PullRequest node: %w", err)
+	}
+	return id, nil
+}
+
+// StorePRSummary creates a GeneratedDoc node with type "pr_summary" and links it
+// to the PullRequest via DOCUMENTS, and to changed files via DERIVED_FROM.
+func (g *ContextGenerator) StorePRSummary(ctx context.Context, prID, title, content, model string, changedFileKeys []string) (string, error) {
+	prNodeKey := models.PullRequestNodeKey(prID)
+	genDocKey := models.GeneratedDocNodeKey(DocTypePRSummary, prNodeKey)
+
+	docProps := map[string]any{
+		"type":       DocTypePRSummary,
+		"title":      title,
+		"content":    content,
+		"model":      model,
+		"sourceType": "pull_request",
+		"sourceKey":  prNodeKey,
+		"nodeKey":    genDocKey,
+		"scope":      g.scopeCtx.Scope,
+		"scopeId":    g.scopeCtx.ScopeID,
+	}
+
+	docID, err := g.client.MergeNode(ctx, []string{"GeneratedDoc"},
+		map[string]any{"nodeKey": genDocKey, "scopeId": g.scopeCtx.ScopeID}, docProps)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GeneratedDoc node: %w", err)
+	}
+
+	// Link GeneratedDoc -[DOCUMENTS]-> PullRequest
+	cypher := `
+		MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+		MATCH (pr:PullRequest {nodeKey: $prNodeKey, scopeId: $scopeId})
+		MERGE (gd)-[:DOCUMENTS]->(pr)`
+	_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"genDocKey": genDocKey,
+		"prNodeKey": prNodeKey,
+		"scopeId":   g.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to create DOCUMENTS edge: %v\n", err)
+	}
+
+	// Link GeneratedDoc -[DERIVED_FROM]-> changed Files
+	for _, fileKey := range changedFileKeys {
+		cypher := `
+			MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+			MATCH (f:File {nodeKey: $fileKey})
+			MERGE (gd)-[:DERIVED_FROM]->(f)`
+		_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+			"genDocKey": genDocKey,
+			"fileKey":   fileKey,
+			"scopeId":   g.scopeCtx.ScopeID,
+		})
+		if err != nil {
+			fmt.Printf("Warning: failed to create DERIVED_FROM edge to %s: %v\n", fileKey, err)
+		}
+	}
+
+	return docID, nil
+}
+
+// StoreFlowSummary creates a GeneratedDoc node with type "flow_summary" and links it
+// to the Flow via DOCUMENTS and DERIVED_FROM.
+func (g *ContextGenerator) StoreFlowSummary(ctx context.Context, flowNodeKey, title, content, model string) (string, error) {
+	genDocKey := models.GeneratedDocNodeKey(DocTypeFlowSummary, flowNodeKey)
+
+	docProps := map[string]any{
+		"type":       DocTypeFlowSummary,
+		"title":      title,
+		"content":    content,
+		"model":      model,
+		"sourceType": "flow",
+		"sourceKey":  flowNodeKey,
+		"nodeKey":    genDocKey,
+		"scope":      g.scopeCtx.Scope,
+		"scopeId":    g.scopeCtx.ScopeID,
+	}
+
+	docID, err := g.client.MergeNode(ctx, []string{"GeneratedDoc"},
+		map[string]any{"nodeKey": genDocKey, "scopeId": g.scopeCtx.ScopeID}, docProps)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GeneratedDoc node: %w", err)
+	}
+
+	// Link GeneratedDoc -[DOCUMENTS]-> Flow
+	cypher := `
+		MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+		MATCH (f:Flow {nodeKey: $flowKey})
+		MERGE (gd)-[:DOCUMENTS]->(f)
+		MERGE (gd)-[:DERIVED_FROM]->(f)`
+	_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"genDocKey": genDocKey,
+		"flowKey":   flowNodeKey,
+		"scopeId":   g.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to create edges to Flow: %v\n", err)
+	}
+
+	return docID, nil
+}
+
+// StoreDocstringSuggestion creates a GeneratedDoc node with type "docstring_suggestion"
+// and links it to the target function/method via DOCUMENTS and DERIVED_FROM.
+func (g *ContextGenerator) StoreDocstringSuggestion(ctx context.Context, targetNodeKey, title, content, model string) (string, error) {
+	genDocKey := models.GeneratedDocNodeKey(DocTypeDocstringSuggestion, targetNodeKey)
+
+	docProps := map[string]any{
+		"type":       DocTypeDocstringSuggestion,
+		"title":      title,
+		"content":    content,
+		"model":      model,
+		"sourceType": "code_symbol",
+		"sourceKey":  targetNodeKey,
+		"nodeKey":    genDocKey,
+		"scope":      g.scopeCtx.Scope,
+		"scopeId":    g.scopeCtx.ScopeID,
+	}
+
+	docID, err := g.client.MergeNode(ctx, []string{"GeneratedDoc"},
+		map[string]any{"nodeKey": genDocKey, "scopeId": g.scopeCtx.ScopeID}, docProps)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GeneratedDoc node: %w", err)
+	}
+
+	// Link to target node (Function or Method)
+	cypher := `
+		MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+		MATCH (target {nodeKey: $targetKey})
+		WHERE target:Function OR target:Method
+		WITH gd, target LIMIT 1
+		MERGE (gd)-[:DOCUMENTS]->(target)
+		MERGE (gd)-[:DERIVED_FROM]->(target)`
+	_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"genDocKey": genDocKey,
+		"targetKey": targetNodeKey,
+		"scopeId":   g.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to create edges to target: %v\n", err)
+	}
+
+	return docID, nil
+}
+
+// ListGeneratedDocs lists generated docs, optionally filtered by type and/or source.
+func (g *ContextGenerator) ListGeneratedDocs(ctx context.Context, docType, sourceKey string) ([]map[string]any, error) {
+	conditions := []string{"gd.scopeId = $scopeId"}
+	params := map[string]any{"scopeId": g.scopeCtx.ScopeID}
+
+	if docType != "" {
+		conditions = append(conditions, "gd.type = $type")
+		params["type"] = docType
+	}
+	if sourceKey != "" {
+		conditions = append(conditions, "gd.sourceKey = $sourceKey")
+		params["sourceKey"] = sourceKey
+	}
+
+	where := ""
+	for i, c := range conditions {
+		if i == 0 {
+			where = "WHERE " + c
+		} else {
+			where += " AND " + c
+		}
+	}
+
+	cypher := fmt.Sprintf(`MATCH (gd:GeneratedDoc) %s
+		RETURN gd.nodeKey AS nodeKey, gd.type AS type, gd.title AS title,
+		       gd.sourceKey AS sourceKey, gd.model AS model
+		ORDER BY gd.title`, where)
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list generated docs: %w", err)
+	}
+
+	var results []map[string]any
+	for _, r := range records {
+		results = append(results, r.AsMap())
+	}
+	return results, nil
+}

--- a/pkg/indexer/generated/context_test.go
+++ b/pkg/indexer/generated/context_test.go
@@ -1,0 +1,113 @@
+package generated
+
+import (
+	"testing"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+)
+
+func TestDocTypeConstants(t *testing.T) {
+	if DocTypePRSummary != "pr_summary" {
+		t.Errorf("expected pr_summary, got %s", DocTypePRSummary)
+	}
+	if DocTypeFlowSummary != "flow_summary" {
+		t.Errorf("expected flow_summary, got %s", DocTypeFlowSummary)
+	}
+	if DocTypeDocstringSuggestion != "docstring_suggestion" {
+		t.Errorf("expected docstring_suggestion, got %s", DocTypeDocstringSuggestion)
+	}
+}
+
+func TestNewContextGenerator(t *testing.T) {
+	gen := NewContextGenerator(nil)
+	if gen == nil {
+		t.Fatal("expected non-nil generator")
+	}
+	if gen.scopeCtx.Scope != "main" {
+		t.Errorf("expected default scope 'main', got %s", gen.scopeCtx.Scope)
+	}
+}
+
+func TestContextGenerator_SetScope(t *testing.T) {
+	gen := NewContextGenerator(nil)
+	prScope := models.NewPRScope("42")
+	gen.SetScope(prScope)
+
+	if gen.scopeCtx.Scope != "pr" {
+		t.Errorf("expected scope 'pr', got %s", gen.scopeCtx.Scope)
+	}
+	if gen.scopeCtx.ScopeID != "pr-42" {
+		t.Errorf("expected scopeID 'pr-42', got %s", gen.scopeCtx.ScopeID)
+	}
+}
+
+func TestPullRequestNodeKey(t *testing.T) {
+	key := models.PullRequestNodeKey("123")
+	if key != "pr:123" {
+		t.Errorf("expected pr:123, got %s", key)
+	}
+}
+
+func TestGeneratedDocNodeKeys(t *testing.T) {
+	// PR summary
+	prKey := models.GeneratedDocNodeKey(DocTypePRSummary, "pr:123")
+	expected := "gendoc:pr_summary:pr:123"
+	if prKey != expected {
+		t.Errorf("expected %s, got %s", expected, prKey)
+	}
+
+	// Flow summary
+	flowKey := models.GeneratedDocNodeKey(DocTypeFlowSummary, "flow:api:api:GET:/users")
+	expected2 := "gendoc:flow_summary:flow:api:api:GET:/users"
+	if flowKey != expected2 {
+		t.Errorf("expected %s, got %s", expected2, flowKey)
+	}
+
+	// Docstring suggestion
+	dsKey := models.GeneratedDocNodeKey(DocTypeDocstringSuggestion, "func:pkg/foo.go#Bar()")
+	expected3 := "gendoc:docstring_suggestion:func:pkg/foo.go#Bar()"
+	if dsKey != expected3 {
+		t.Errorf("expected %s, got %s", expected3, dsKey)
+	}
+
+	// All three must be unique
+	if prKey == flowKey || prKey == dsKey || flowKey == dsKey {
+		t.Error("generated doc node keys should be unique across types")
+	}
+}
+
+func TestPullRequestModel(t *testing.T) {
+	pr := models.PullRequest{
+		PRID:       "123",
+		Title:      "Add feature X",
+		Author:     "dev",
+		BaseBranch: "main",
+		HeadBranch: "feat/x",
+		Status:     "open",
+	}
+
+	if pr.PRID != "123" {
+		t.Errorf("unexpected PRID: %s", pr.PRID)
+	}
+	if pr.Status != "open" {
+		t.Errorf("unexpected Status: %s", pr.Status)
+	}
+}
+
+func TestGeneratedDocModel(t *testing.T) {
+	doc := models.GeneratedDoc{
+		Type:       DocTypePRSummary,
+		Title:      "PR #123 Summary",
+		Content:    "This PR adds...",
+		Model:      "claude-sonnet-4-20250514",
+		SourceType: "pull_request",
+		SourceKey:  "pr:123",
+	}
+
+	if doc.Type != DocTypePRSummary {
+		t.Errorf("unexpected Type: %s", doc.Type)
+	}
+	if doc.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("unexpected Model: %s", doc.Model)
+	}
+}

--- a/pkg/models/node.go
+++ b/pkg/models/node.go
@@ -24,6 +24,8 @@ const (
 	DocumentChunkNode NodeType = "DocumentChunk"
 	FlowNode          NodeType = "Flow"
 	FeatureNode       NodeType = "Feature"
+	PullRequestNode   NodeType = "PullRequest"
+	GeneratedDocNode  NodeType = "GeneratedDoc"
 )
 
 // BaseNode represents common properties for all nodes
@@ -218,6 +220,29 @@ type Feature struct {
 	Tags        []string `json:"tags" neo4j:"tags"`
 }
 
+// PullRequest represents a pull request overlay in the graph.
+type PullRequest struct {
+	BaseNode
+	PRID        string `json:"prId" neo4j:"prId"`
+	Title       string `json:"title" neo4j:"title"`
+	Author      string `json:"author" neo4j:"author"`
+	BaseBranch  string `json:"baseBranch" neo4j:"baseBranch"`
+	HeadBranch  string `json:"headBranch" neo4j:"headBranch"`
+	Status      string `json:"status" neo4j:"status"` // open, merged, closed
+	Description string `json:"description" neo4j:"description"`
+}
+
+// GeneratedDoc represents auto-generated documentation stored as a knowledge unit.
+type GeneratedDoc struct {
+	BaseNode
+	Type       string `json:"type" neo4j:"type"`       // pr_summary, flow_summary, docstring_suggestion
+	Title      string `json:"title" neo4j:"title"`
+	Content    string `json:"content" neo4j:"content"`
+	Model      string `json:"model" neo4j:"model"`           // LLM model used
+	SourceType string `json:"sourceType" neo4j:"sourceType"` // What triggered generation
+	SourceKey  string `json:"sourceKey" neo4j:"sourceKey"`   // nodeKey of the source
+}
+
 // NodeFactory creates nodes from maps (useful for Neo4j result parsing)
 func NodeFactory(nodeType NodeType, props map[string]any) interface{} {
 	now := time.Now()
@@ -285,6 +310,14 @@ func NodeFactory(nodeType NodeType, props map[string]any) interface{} {
 		}
 	case FeatureNode:
 		return &Feature{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case PullRequestNode:
+		return &PullRequest{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case GeneratedDocNode:
+		return &GeneratedDoc{
 			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
 		}
 	default:

--- a/pkg/models/nodekey.go
+++ b/pkg/models/nodekey.go
@@ -92,6 +92,16 @@ func FlowNodeKey(flowType, entrypointKey string) string {
 	return "flow:" + flowType + ":" + entrypointKey
 }
 
+// PullRequestNodeKey returns "pr:{prID}".
+func PullRequestNodeKey(prID string) string {
+	return "pr:" + prID
+}
+
+// GeneratedDocNodeKey returns "gendoc:{type}:{sourceKey}".
+func GeneratedDocNodeKey(docType, sourceKey string) string {
+	return "gendoc:" + docType + ":" + sourceKey
+}
+
 // ReferenceNodeKey returns "ref:{filePath}:{startLine}:{startColumn}".
 func ReferenceNodeKey(filePath string, startLine, startColumn int) string {
 	return fmt.Sprintf("ref:%s:%d:%d", filePath, startLine, startColumn)

--- a/pkg/models/nodekey_test.go
+++ b/pkg/models/nodekey_test.go
@@ -141,6 +141,25 @@ func TestFlowNodeKey(t *testing.T) {
 	}
 }
 
+func TestPullRequestNodeKey(t *testing.T) {
+	key := PullRequestNodeKey("123")
+	if key != "pr:123" {
+		t.Errorf("expected pr:123, got %s", key)
+	}
+}
+
+func TestGeneratedDocNodeKey(t *testing.T) {
+	key := GeneratedDocNodeKey("pr_summary", "pr:123")
+	expected := "gendoc:pr_summary:pr:123"
+	if key != expected {
+		t.Errorf("expected %s, got %s", expected, key)
+	}
+	key2 := GeneratedDocNodeKey("flow_summary", "flow:api:api:GET:/users")
+	if key == key2 {
+		t.Error("GeneratedDocNodeKey should differ for different types/sources")
+	}
+}
+
 func TestNodeKeysAreUnique(t *testing.T) {
 	keys := map[string]string{
 		"service":   ServiceNodeKey("codegraph"),
@@ -157,7 +176,9 @@ func TestNodeKeysAreUnique(t *testing.T) {
 		"api":       APIRouteNodeKey("GET", "/api/users"),
 		"comment":   CommentNodeKey("pkg/models/node.go", 10),
 		"reference": ReferenceNodeKey("pkg/models/node.go", 42, 5),
-		"flow":      FlowNodeKey("api", "api:GET:/api/users"),
+		"flow":         FlowNodeKey("api", "api:GET:/api/users"),
+		"pullrequest":  PullRequestNodeKey("123"),
+		"generateddoc": GeneratedDocNodeKey("pr_summary", "pr:123"),
 	}
 
 	seen := make(map[string]string)

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -405,6 +405,50 @@ func GetIndexes() []Index {
 			Properties: []string{"flowType"},
 			Type:       "BTREE",
 		},
+		// PullRequest indexes (Task 10)
+		{
+			Name:       "pr_nodekey_idx",
+			NodeLabel:  "PullRequest",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "pr_nodekey_scope_idx",
+			NodeLabel:  "PullRequest",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "pr_prid_idx",
+			NodeLabel:  "PullRequest",
+			Properties: []string{"prId"},
+			Type:       "BTREE",
+		},
+		// GeneratedDoc indexes (Task 10)
+		{
+			Name:       "gendoc_nodekey_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "gendoc_nodekey_scope_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "gendoc_type_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"type"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "gendoc_sourcekey_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"sourceKey"},
+			Type:       "BTREE",
+		},
 		// Tombstone indexes (Phase 3)
 		{
 			Name:       "tombstone_nodekey_scope_idx",


### PR DESCRIPTION
## Summary
- Adds `PullRequest` and `GeneratedDoc` as first-class node types
- `ContextGenerator` stores PR summaries, flow summaries, and docstring suggestions as knowledge units
- Links generated docs to sources via `DOCUMENTS` and `DERIVED_FROM` edges
- Schema indexes for efficient lookup by nodeKey, type, sourceKey

## Test plan
- [x] Unit tests for all models, nodeKeys, and ContextGenerator
- [x] `go build ./...` and `go vet ./...` pass
- [ ] Integration: create PR node + summary, verify DOCUMENTS/DERIVED_FROM edges exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)