### PR TITLE
feat(monorepo phase2-libs): copy models/neo4j/vector packages to libs/

### DIFF
--- a/libs/core-models-go/import.go
+++ b/libs/core-models-go/import.go
@@ -1,0 +1,9 @@
+package models
+
+// PackageImport represents an import statement from one file/package to another
+type PackageImport struct {
+	SourceFile    string // File containing the import
+	TargetPackage string // Package being imported
+	ImportedNames []string // Specific symbols imported (if available)
+	IsExternal    bool   // Whether this is an external package
+}

--- a/libs/core-models-go/node.go
+++ b/libs/core-models-go/node.go
@@ -1,0 +1,326 @@
+package models
+
+import (
+	"time"
+)
+
+// NodeType represents the different types of nodes in the graph
+type NodeType string
+
+const (
+	ServiceNode   NodeType = "Service"
+	FileNode      NodeType = "File"
+	ModuleNode    NodeType = "Module"
+	ClassNode     NodeType = "Class"
+	InterfaceNode NodeType = "Interface"
+	FunctionNode  NodeType = "Function"
+	MethodNode    NodeType = "Method"
+	VariableNode  NodeType = "Variable"
+	ParameterNode NodeType = "Parameter"
+	SymbolNode    NodeType = "Symbol"
+	APIRouteNode  NodeType = "APIRoute"
+	CommentNode   NodeType = "Comment"
+	DocumentNode      NodeType = "Document"
+	DocumentChunkNode NodeType = "DocumentChunk"
+	FlowNode          NodeType = "Flow"
+	FeatureNode       NodeType = "Feature"
+	PullRequestNode   NodeType = "PullRequest"
+	GeneratedDocNode  NodeType = "GeneratedDoc"
+)
+
+// BaseNode represents common properties for all nodes
+type BaseNode struct {
+	ID        string            `json:"id,omitempty" neo4j:"id,omitempty"`
+	NodeKey   string            `json:"nodeKey,omitempty" neo4j:"nodeKey,omitempty"`
+	Labels    []string          `json:"labels,omitempty" neo4j:"labels,omitempty"`
+	Props     map[string]any    `json:"properties,omitempty" neo4j:"properties,omitempty"`
+	Scope     string            `json:"scope,omitempty" neo4j:"scope,omitempty"`
+	ScopeID   string            `json:"scopeId,omitempty" neo4j:"scopeId,omitempty"`
+	CreatedAt time.Time         `json:"createdAt" neo4j:"createdAt"`
+	UpdatedAt time.Time         `json:"updatedAt" neo4j:"updatedAt"`
+}
+
+// Service represents a microservice or application component
+type Service struct {
+	BaseNode
+	Name          string `json:"name" neo4j:"name"`
+	Language      string `json:"language" neo4j:"language"`
+	Version       string `json:"version" neo4j:"version"`
+	RepositoryURL string `json:"repositoryUrl" neo4j:"repositoryUrl"`
+}
+
+// File represents a source code file
+type File struct {
+	BaseNode
+	Path         string `json:"path" neo4j:"path"`
+	AbsolutePath string `json:"absolutePath" neo4j:"absolutePath"`
+	Language     string `json:"language" neo4j:"language"`
+	Size         int64  `json:"size" neo4j:"size"`
+	LineCount    int    `json:"lineCount" neo4j:"lineCount"`
+	Hash         string `json:"hash" neo4j:"hash"`
+}
+
+// Module represents a logical code grouping (package, namespace, module)
+type Module struct {
+	BaseNode
+	Name       string `json:"name" neo4j:"name"`
+	FQN        string `json:"fqn" neo4j:"fqn"`
+	Type       string `json:"type" neo4j:"type"`
+	IsExported bool   `json:"isExported" neo4j:"isExported"`
+}
+
+// Class represents an object-oriented class definition
+type Class struct {
+	BaseNode
+	Name           string `json:"name" neo4j:"name"`
+	FQN            string `json:"fqn" neo4j:"fqn"`
+	FilePath       string `json:"filePath" neo4j:"filePath"`
+	StartLine      int    `json:"startLine" neo4j:"startLine"`
+	EndLine        int    `json:"endLine" neo4j:"endLine"`
+	AccessModifier string `json:"accessModifier" neo4j:"accessModifier"`
+	IsAbstract     bool   `json:"isAbstract" neo4j:"isAbstract"`
+	IsInterface    bool   `json:"isInterface" neo4j:"isInterface"`
+	Docstring      string `json:"docstring" neo4j:"docstring"`
+}
+
+// Interface represents an interface definition
+type Interface struct {
+	BaseNode
+	Name      string `json:"name" neo4j:"name"`
+	FQN       string `json:"fqn" neo4j:"fqn"`
+	FilePath  string `json:"filePath" neo4j:"filePath"`
+	StartLine int    `json:"startLine" neo4j:"startLine"`
+	EndLine   int    `json:"endLine" neo4j:"endLine"`
+	Docstring string `json:"docstring" neo4j:"docstring"`
+}
+
+// Function represents a standalone function or static method
+type Function struct {
+	BaseNode
+	Name        string `json:"name" neo4j:"name"`
+	Signature   string `json:"signature" neo4j:"signature"`
+	ReturnType  string `json:"returnType" neo4j:"returnType"`
+	FilePath    string `json:"filePath" neo4j:"filePath"`
+	StartLine   int    `json:"startLine" neo4j:"startLine"`
+	EndLine     int    `json:"endLine" neo4j:"endLine"`
+	IsExported  bool   `json:"isExported" neo4j:"isExported"`
+	IsAsync     bool   `json:"isAsync" neo4j:"isAsync"`
+	Complexity  int    `json:"complexity" neo4j:"complexity"`
+	Docstring   string `json:"docstring" neo4j:"docstring"`
+}
+
+// Method represents an instance method belonging to a class
+type Method struct {
+	BaseNode
+	Name           string `json:"name" neo4j:"name"`
+	Signature      string `json:"signature" neo4j:"signature"`
+	ReturnType     string `json:"returnType" neo4j:"returnType"`
+	AccessModifier string `json:"accessModifier" neo4j:"accessModifier"`
+	FilePath       string `json:"filePath" neo4j:"filePath"`
+	StartLine      int    `json:"startLine" neo4j:"startLine"`
+	EndLine        int    `json:"endLine" neo4j:"endLine"`
+	IsStatic       bool   `json:"isStatic" neo4j:"isStatic"`
+	IsAbstract     bool   `json:"isAbstract" neo4j:"isAbstract"`
+	IsOverride     bool   `json:"isOverride" neo4j:"isOverride"`
+	Complexity     int    `json:"complexity" neo4j:"complexity"`
+	Docstring      string `json:"docstring" neo4j:"docstring"`
+}
+
+// Variable represents a variable declaration
+type Variable struct {
+	BaseNode
+	Name         string `json:"name" neo4j:"name"`
+	Type         string `json:"type" neo4j:"type"`
+	Scope        string `json:"scope" neo4j:"scope"`
+	FilePath     string `json:"filePath" neo4j:"filePath"`
+	StartLine    int    `json:"startLine" neo4j:"startLine"`
+	EndLine      int    `json:"endLine" neo4j:"endLine"`
+	IsConstant   bool   `json:"isConstant" neo4j:"isConstant"`
+	InitialValue string `json:"initialValue" neo4j:"initialValue"`
+}
+
+// Parameter represents a function/method parameter
+type Parameter struct {
+	BaseNode
+	Name         string `json:"name" neo4j:"name"`
+	Type         string `json:"type" neo4j:"type"`
+	Index        int    `json:"index" neo4j:"index"`
+	IsOptional   bool   `json:"isOptional" neo4j:"isOptional"`
+	DefaultValue string `json:"defaultValue" neo4j:"defaultValue"`
+}
+
+// Symbol represents a canonical code symbol using SCIP format
+type Symbol struct {
+	BaseNode
+	Symbol        string `json:"symbol" neo4j:"symbol"`
+	Kind          string `json:"kind" neo4j:"kind"`
+	DisplayName   string `json:"displayName" neo4j:"displayName"`
+	Documentation string `json:"documentation" neo4j:"documentation"`
+}
+
+// APIRoute represents an exposed API endpoint
+type APIRoute struct {
+	BaseNode
+	Path         string `json:"path" neo4j:"path"`
+	Method       string `json:"method" neo4j:"method"`
+	Protocol     string `json:"protocol" neo4j:"protocol"`
+	Description  string `json:"description" neo4j:"description"`
+	IsDeprecated bool   `json:"isDeprecated" neo4j:"isDeprecated"`
+	Version      string `json:"version" neo4j:"version"`
+}
+
+// Comment represents code comments and docstrings
+type Comment struct {
+	BaseNode
+	Text        string `json:"text" neo4j:"text"`
+	Type        string `json:"type" neo4j:"type"`
+	FilePath    string `json:"filePath" neo4j:"filePath"`
+	StartLine   int    `json:"startLine" neo4j:"startLine"`
+	EndLine     int    `json:"endLine" neo4j:"endLine"`
+	IsDocstring bool   `json:"isDocstring" neo4j:"isDocstring"`
+}
+
+// Document represents technical or business documents
+type Document struct {
+	BaseNode
+	Title     string `json:"title" neo4j:"title"`
+	Type      string `json:"type" neo4j:"type"`
+	SourceURL string `json:"sourceUrl" neo4j:"sourceUrl"`
+	Content   string `json:"content" neo4j:"content"`
+}
+
+// DocumentChunk represents a chunk of a document for granular linking and incremental updates
+type DocumentChunk struct {
+	BaseNode
+	DocumentKey string `json:"documentKey" neo4j:"documentKey"`
+	ChunkIndex  int    `json:"chunkIndex" neo4j:"chunkIndex"`
+	HeadingPath string `json:"headingPath" neo4j:"headingPath"`
+	Content     string `json:"content" neo4j:"content"`
+	TextHash    string `json:"textHash" neo4j:"textHash"`
+	StartOffset int    `json:"startOffset" neo4j:"startOffset"`
+	EndOffset   int    `json:"endOffset" neo4j:"endOffset"`
+}
+
+// Flow represents a first-class execution flow (e.g., an API request path, consumer pipeline).
+type Flow struct {
+	BaseNode
+	Name           string `json:"name" neo4j:"name"`
+	EntrypointKey  string `json:"entrypointKey" neo4j:"entrypointKey"`
+	FlowType       string `json:"flowType" neo4j:"flowType"` // "api", "consumer", "cron"
+	MaxDepth       int    `json:"maxDepth" neo4j:"maxDepth"`
+}
+
+// Feature represents a specific feature or capability
+type Feature struct {
+	BaseNode
+	Name        string   `json:"name" neo4j:"name"`
+	Description string   `json:"description" neo4j:"description"`
+	Status      string   `json:"status" neo4j:"status"`
+	Priority    string   `json:"priority" neo4j:"priority"`
+	Tags        []string `json:"tags" neo4j:"tags"`
+}
+
+// PullRequest represents a pull request overlay in the graph.
+type PullRequest struct {
+	BaseNode
+	PRID        string `json:"prId" neo4j:"prId"`
+	Title       string `json:"title" neo4j:"title"`
+	Author      string `json:"author" neo4j:"author"`
+	BaseBranch  string `json:"baseBranch" neo4j:"baseBranch"`
+	HeadBranch  string `json:"headBranch" neo4j:"headBranch"`
+	Status      string `json:"status" neo4j:"status"` // open, merged, closed
+	Description string `json:"description" neo4j:"description"`
+}
+
+// GeneratedDoc represents auto-generated documentation stored as a knowledge unit.
+type GeneratedDoc struct {
+	BaseNode
+	Type       string `json:"type" neo4j:"type"`       // pr_summary, flow_summary, docstring_suggestion
+	Title      string `json:"title" neo4j:"title"`
+	Content    string `json:"content" neo4j:"content"`
+	Model      string `json:"model" neo4j:"model"`           // LLM model used
+	SourceType string `json:"sourceType" neo4j:"sourceType"` // What triggered generation
+	SourceKey  string `json:"sourceKey" neo4j:"sourceKey"`   // nodeKey of the source
+}
+
+// NodeFactory creates nodes from maps (useful for Neo4j result parsing)
+func NodeFactory(nodeType NodeType, props map[string]any) interface{} {
+	now := time.Now()
+
+	switch nodeType {
+	case ServiceNode:
+		return &Service{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case FileNode:
+		return &File{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case ModuleNode:
+		return &Module{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case ClassNode:
+		return &Class{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case InterfaceNode:
+		return &Interface{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case FunctionNode:
+		return &Function{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case MethodNode:
+		return &Method{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case VariableNode:
+		return &Variable{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case ParameterNode:
+		return &Parameter{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case SymbolNode:
+		return &Symbol{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case APIRouteNode:
+		return &APIRoute{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case CommentNode:
+		return &Comment{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case DocumentNode:
+		return &Document{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case DocumentChunkNode:
+		return &DocumentChunk{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case FlowNode:
+		return &Flow{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case FeatureNode:
+		return &Feature{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case PullRequestNode:
+		return &PullRequest{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	case GeneratedDocNode:
+		return &GeneratedDoc{
+			BaseNode: BaseNode{Props: props, CreatedAt: now, UpdatedAt: now},
+		}
+	default:
+		return &BaseNode{Props: props, CreatedAt: now, UpdatedAt: now}
+	}
+}

--- a/libs/core-models-go/nodekey.go
+++ b/libs/core-models-go/nodekey.go
@@ -1,0 +1,113 @@
+package models
+
+import "fmt"
+
+// NodeKey derivation functions.
+// Each function returns a deterministic, human-readable key for a node type.
+// These keys are used as merge identifiers to ensure idempotent indexing.
+
+// ServiceNodeKey returns "svc:{name}".
+func ServiceNodeKey(name string) string {
+	return "svc:" + name
+}
+
+// FileNodeKey returns "file:{path}".
+func FileNodeKey(path string) string {
+	return "file:" + path
+}
+
+// SymbolNodeKey returns the SCIP symbol string directly (already globally unique).
+func SymbolNodeKey(scipSymbol string) string {
+	return scipSymbol
+}
+
+// FunctionNodeKey returns "func:{filePath}#{signature}".
+func FunctionNodeKey(filePath, signature string) string {
+	return "func:" + filePath + "#" + signature
+}
+
+// MethodNodeKey returns "method:{filePath}#{signature}".
+func MethodNodeKey(filePath, signature string) string {
+	return "method:" + filePath + "#" + signature
+}
+
+// ClassNodeKey returns "class:{fqn}" if fqn is non-empty, else "class:{filePath}#{name}".
+func ClassNodeKey(fqn, filePath, name string) string {
+	if fqn != "" {
+		return "class:" + fqn
+	}
+	return "class:" + filePath + "#" + name
+}
+
+// InterfaceNodeKey returns "iface:{fqn}" if fqn is non-empty, else "iface:{filePath}#{name}".
+func InterfaceNodeKey(fqn, filePath, name string) string {
+	if fqn != "" {
+		return "iface:" + fqn
+	}
+	return "iface:" + filePath + "#" + name
+}
+
+// ModuleNodeKey returns "mod:{fqn}".
+func ModuleNodeKey(fqn string) string {
+	return "mod:" + fqn
+}
+
+// VariableNodeKey returns "var:{filePath}#{name}:{startLine}".
+func VariableNodeKey(filePath, name string, startLine int) string {
+	return fmt.Sprintf("var:%s#%s:%d", filePath, name, startLine)
+}
+
+// ParameterNodeKey returns "param:{filePath}#{signature}:{name}:{index}".
+func ParameterNodeKey(filePath, signature, name string, index int) string {
+	return fmt.Sprintf("param:%s#%s:%s:%d", filePath, signature, name, index)
+}
+
+// DocumentNodeKey returns "doc:{sourceUrl}".
+func DocumentNodeKey(sourceURL string) string {
+	return "doc:" + sourceURL
+}
+
+// DocumentChunkNodeKey returns "chunk:{documentKey}#{chunkIndex}".
+func DocumentChunkNodeKey(documentKey string, chunkIndex int) string {
+	return fmt.Sprintf("chunk:%s#%d", documentKey, chunkIndex)
+}
+
+// FeatureNodeKey returns "feat:{name}".
+func FeatureNodeKey(name string) string {
+	return "feat:" + name
+}
+
+// APIRouteNodeKey returns "api:{method}:{path}".
+func APIRouteNodeKey(method, path string) string {
+	return "api:" + method + ":" + path
+}
+
+// CommentNodeKey returns "comment:{filePath}:{startLine}".
+func CommentNodeKey(filePath string, startLine int) string {
+	return fmt.Sprintf("comment:%s:%d", filePath, startLine)
+}
+
+// FlowNodeKey returns "flow:{flowType}:{entrypointKey}".
+func FlowNodeKey(flowType, entrypointKey string) string {
+	return "flow:" + flowType + ":" + entrypointKey
+}
+
+// PullRequestNodeKey returns "pr:{prID}".
+func PullRequestNodeKey(prID string) string {
+	return "pr:" + prID
+}
+
+// GeneratedDocNodeKey returns "gendoc:{type}:{sourceKey}".
+func GeneratedDocNodeKey(docType, sourceKey string) string {
+	return "gendoc:" + docType + ":" + sourceKey
+}
+
+// SDKCallNodeKey returns "sdkcall:{target}".
+func SDKCallNodeKey(target string) string {
+	return "sdkcall:" + target
+}
+
+// ReferenceNodeKey returns "ref:{filePath}:{startLine}:{startColumn}".
+func ReferenceNodeKey(filePath string, startLine, startColumn int) string {
+	return fmt.Sprintf("ref:%s:%d:%d", filePath, startLine, startColumn)
+}

--- a/libs/core-models-go/project.json
+++ b/libs/core-models-go/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "core-models-go",
+  "root": "libs/core-models-go",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go build ./libs/core-models-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go test ./libs/core-models-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    }
+  }
+}

--- a/libs/core-models-go/relationship.go
+++ b/libs/core-models-go/relationship.go
@@ -1,0 +1,173 @@
+package models
+
+// RelationshipType represents the different types of relationships in the graph
+type RelationshipType string
+
+const (
+	// Structural Relationships
+	ContainsRel   RelationshipType = "CONTAINS"
+	DefinesRel    RelationshipType = "DEFINES"
+	ReferencesRel RelationshipType = "REFERENCES"
+
+	// Behavioral Relationships
+	CallsRel      RelationshipType = "CALLS"
+	FlowsToRel    RelationshipType = "FLOWS_TO"
+	NextExecRel   RelationshipType = "NEXT_EXECUTION"
+
+	// Object-Oriented Relationships
+	InheritsFromRel RelationshipType = "INHERITS_FROM"
+	ImplementsRel   RelationshipType = "IMPLEMENTS"
+
+	// API Relationships
+	ExposesAPIRel RelationshipType = "EXPOSES_API"
+	CallsAPIRel   RelationshipType = "CALLS_API"
+
+	// Service Relationships
+	DependsOnRel     RelationshipType = "DEPENDS_ON"
+	CallsServiceRel  RelationshipType = "CALLS_SERVICE"
+
+	// Documentation Relationships
+	DescribesRel RelationshipType = "DESCRIBES"
+	MentionsRel  RelationshipType = "MENTIONS"
+)
+
+// BaseRelationship represents common properties for all relationships
+type BaseRelationship struct {
+	ID         string            `json:"id,omitempty" neo4j:"id,omitempty"`
+	Type       RelationshipType  `json:"type" neo4j:"type"`
+	Properties map[string]any    `json:"properties,omitempty" neo4j:"properties,omitempty"`
+	StartID    string            `json:"startId" neo4j:"startId"`
+	EndID      string            `json:"endId" neo4j:"endId"`
+}
+
+// ContainsRelationship represents hierarchical containment
+type ContainsRelationship struct {
+	BaseRelationship
+	Order int `json:"order" neo4j:"order"` // Order within container
+}
+
+// DefinesRelationship represents symbol definitions
+type DefinesRelationship struct {
+	BaseRelationship
+	IsExported bool `json:"isExported" neo4j:"isExported"`
+}
+
+// ReferencesRelationship represents symbol usage sites
+type ReferencesRelationship struct {
+	BaseRelationship
+	IsDefinition bool `json:"isDefinition" neo4j:"isDefinition"`
+	Line         int  `json:"line" neo4j:"line"`
+	Column       int  `json:"column" neo4j:"column"`
+}
+
+// CallsRelationship represents function/method invocations
+type CallsRelationship struct {
+	BaseRelationship
+	IsDynamic   bool `json:"isDynamic" neo4j:"isDynamic"`
+	Line        int  `json:"line" neo4j:"line"`
+	IsRecursive bool `json:"isRecursive" neo4j:"isRecursive"`
+}
+
+// FlowsToRelationship represents data flow dependencies
+type FlowsToRelationship struct {
+	BaseRelationship
+	Path     []string `json:"path" neo4j:"path"`
+	FlowType string   `json:"flowType" neo4j:"flowType"` // direct, indirect, conditional
+}
+
+// NextExecutionRelationship represents control flow between statements
+type NextExecutionRelationship struct {
+	BaseRelationship
+	IsConditional bool   `json:"isConditional" neo4j:"isConditional"`
+	Condition     string `json:"condition" neo4j:"condition"`
+}
+
+// InheritsFromRelationship represents class inheritance
+type InheritsFromRelationship struct {
+	BaseRelationship
+}
+
+// ImplementsRelationship represents interface implementation or feature realization
+type ImplementsRelationship struct {
+	BaseRelationship
+	Confidence       float64 `json:"confidence" neo4j:"confidence"`             // LLM validation confidence (0.0-1.0)
+	ValidationMethod string  `json:"validationMethod" neo4j:"validationMethod"` // "llm", "heuristic", "hybrid"
+	CodeSummary      string  `json:"codeSummary" neo4j:"codeSummary"`           // LLM-generated summary of implementing code
+	SubgraphSize     int     `json:"subgraphSize" neo4j:"subgraphSize"`         // Number of functions in implementing subgraph
+}
+
+// ExposesAPIRelationship connects code handlers to API endpoints
+type ExposesAPIRelationship struct {
+	BaseRelationship
+}
+
+// CallsAPIRelationship represents API calls between services
+type CallsAPIRelationship struct {
+	BaseRelationship
+	Timeout    int `json:"timeout" neo4j:"timeout"`       // Call timeout in milliseconds
+	RetryCount int `json:"retryCount" neo4j:"retryCount"` // Number of retries
+}
+
+// DependsOnRelationship represents dependencies between services or modules
+type DependsOnRelationship struct {
+	BaseRelationship
+	Version  string `json:"version" neo4j:"version"`
+	IsDirect bool   `json:"isDirect" neo4j:"isDirect"`
+}
+
+// DescribesRelationship connects documents to features or code elements
+type DescribesRelationship struct {
+	BaseRelationship
+}
+
+// MentionsRelationship represents references in documentation
+type MentionsRelationship struct {
+	BaseRelationship
+	Context string `json:"context" neo4j:"context"`
+}
+
+// RelationshipFactory creates relationships from type and properties
+func RelationshipFactory(relType RelationshipType, startID, endID string, props map[string]any) interface{} {
+	base := BaseRelationship{
+		Type:       relType,
+		Properties: props,
+		StartID:    startID,
+		EndID:      endID,
+	}
+
+	switch relType {
+	case ContainsRel:
+		return &ContainsRelationship{BaseRelationship: base}
+	case DefinesRel:
+		return &DefinesRelationship{BaseRelationship: base}
+	case ReferencesRel:
+		return &ReferencesRelationship{BaseRelationship: base}
+	case CallsRel:
+		return &CallsRelationship{BaseRelationship: base}
+	case FlowsToRel:
+		return &FlowsToRelationship{BaseRelationship: base}
+	case NextExecRel:
+		return &NextExecutionRelationship{BaseRelationship: base}
+	case InheritsFromRel:
+		return &InheritsFromRelationship{BaseRelationship: base}
+	case ImplementsRel:
+		return &ImplementsRelationship{BaseRelationship: base}
+	case ExposesAPIRel:
+		return &ExposesAPIRelationship{BaseRelationship: base}
+	case CallsAPIRel:
+		return &CallsAPIRelationship{BaseRelationship: base}
+	case DependsOnRel:
+		return &DependsOnRelationship{BaseRelationship: base}
+	case DescribesRel:
+		return &DescribesRelationship{BaseRelationship: base}
+	case MentionsRel:
+		return &MentionsRelationship{BaseRelationship: base}
+	default:
+		return &BaseRelationship{
+			Type:       relType,
+			Properties: props,
+			StartID:    startID,
+			EndID:      endID,
+		}
+	}
+}

--- a/libs/core-models-go/scope.go
+++ b/libs/core-models-go/scope.go
@@ -1,0 +1,38 @@
+package models
+
+// ScopeContext represents the scope context for indexing operations.
+// Scope is either "main" (default branch) or "pr" (pull request overlay).
+// ScopeID uniquely identifies the scope instance (e.g., "main", "pr-42").
+type ScopeContext struct {
+	Scope   string // "main" or "pr"
+	ScopeID string // "main" or "pr-{id}"
+}
+
+const (
+	ScopeMain = "main"
+	ScopePR   = "pr"
+)
+
+// DefaultScope returns the default scope context (main branch).
+func DefaultScope() ScopeContext {
+	return ScopeContext{
+		Scope:   ScopeMain,
+		ScopeID: ScopeMain,
+	}
+}
+
+// NewPRScope creates a scope context for a pull request overlay.
+func NewPRScope(prID string) ScopeContext {
+	return ScopeContext{
+		Scope:   ScopePR,
+		ScopeID: "pr-" + prID,
+	}
+}
+
+// Props returns the scope fields as a map for injection into Neo4j properties.
+func (sc ScopeContext) Props() map[string]any {
+	return map[string]any{
+		"scope":   sc.Scope,
+		"scopeId": sc.ScopeID,
+	}
+}

--- a/libs/core-models-go/symbol.go
+++ b/libs/core-models-go/symbol.go
@@ -1,0 +1,193 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SCIPSymbol represents a SCIP (Source Code Intelligence Protocol) symbol
+// Format: <scheme> <manager> <name> <version> <descriptor>
+// Example: scip-go go github.com/context-maximiser/code-graph v1.0.0 pkg/models/Symbol#
+type SCIPSymbol struct {
+	Scheme     string `json:"scheme"`     // scip-go, scip-java, scip-python, etc.
+	Manager    string `json:"manager"`    // go, maven, npm, pip, etc.
+	Name       string `json:"name"`       // package/repository name
+	Version    string `json:"version"`    // version string
+	Descriptor string `json:"descriptor"` // path to symbol within package
+}
+
+// String returns the SCIP symbol as a formatted string
+func (s *SCIPSymbol) String() string {
+	return fmt.Sprintf("%s %s %s %s %s", s.Scheme, s.Manager, s.Name, s.Version, s.Descriptor)
+}
+
+// ParseSCIPSymbol parses a SCIP symbol string into components
+func ParseSCIPSymbol(symbol string) (*SCIPSymbol, error) {
+	parts := strings.SplitN(symbol, " ", 5)
+	if len(parts) != 5 {
+		return nil, fmt.Errorf("invalid SCIP symbol format: %s", symbol)
+	}
+
+	return &SCIPSymbol{
+		Scheme:     parts[0],
+		Manager:    parts[1],
+		Name:       parts[2],
+		Version:    parts[3],
+		Descriptor: parts[4],
+	}, nil
+}
+
+// NewGoSCIPSymbol creates a SCIP symbol for Go code
+func NewGoSCIPSymbol(packageName, version, descriptor string) *SCIPSymbol {
+	return &SCIPSymbol{
+		Scheme:     "scip-go",
+		Manager:    "go",
+		Name:       packageName,
+		Version:    version,
+		Descriptor: descriptor,
+	}
+}
+
+// GoDescriptor represents different Go symbol descriptors
+type GoDescriptor struct {
+	Package   string
+	Type      string
+	Method    string
+	Field     string
+	Local     string
+	Parameter string
+}
+
+// String formats the Go descriptor according to SCIP conventions
+func (d *GoDescriptor) String() string {
+	var parts []string
+
+	if d.Package != "" {
+		parts = append(parts, d.Package)
+	}
+
+	if d.Type != "" {
+		parts = append(parts, d.Type+"#")
+	}
+
+	if d.Method != "" {
+		parts = append(parts, d.Method+"().")
+	}
+
+	if d.Field != "" {
+		parts = append(parts, d.Field+".")
+	}
+
+	if d.Local != "" {
+		parts = append(parts, "local "+d.Local)
+	}
+
+	if d.Parameter != "" {
+		parts = append(parts, "param "+d.Parameter)
+	}
+
+	return strings.Join(parts, "")
+}
+
+// SymbolKind represents different kinds of symbols
+type SymbolKind string
+
+const (
+	PackageSymbol   SymbolKind = "Package"
+	TypeSymbol      SymbolKind = "Type"
+	MethodSymbol    SymbolKind = "Method"
+	FunctionSymbol  SymbolKind = "Function"
+	FieldSymbol     SymbolKind = "Field"
+	VariableSymbol  SymbolKind = "Variable"
+	ConstantSymbol  SymbolKind = "Constant"
+	InterfaceSymbol SymbolKind = "Interface"
+	ParameterSymbol SymbolKind = "Parameter"
+	LocalSymbol     SymbolKind = "Local"
+)
+
+// SymbolScope represents the scope/visibility of a symbol
+type SymbolScope string
+
+const (
+	PublicScope    SymbolScope = "public"
+	PrivateScope   SymbolScope = "private"
+	ProtectedScope SymbolScope = "protected"
+	PackageScope   SymbolScope = "package"
+	LocalScope     SymbolScope = "local"
+)
+
+// SymbolInfo represents metadata about a code symbol
+type SymbolInfo struct {
+	Symbol         *SCIPSymbol `json:"symbol"`
+	Kind           SymbolKind  `json:"kind"`
+	Scope          SymbolScope `json:"scope"`
+	DisplayName    string      `json:"displayName"`
+	Documentation  string      `json:"documentation"`
+	Signature      string      `json:"signature"`
+	ReturnType     string      `json:"returnType,omitempty"`
+	Parameters     []Parameter `json:"parameters,omitempty"`
+	FilePath       string      `json:"filePath"`
+	StartLine      int         `json:"startLine"`
+	EndLine        int         `json:"endLine"`
+	StartColumn    int         `json:"startColumn"`
+	EndColumn      int         `json:"endColumn"`
+}
+
+// IsExported returns true if the symbol is exported (public)
+func (si *SymbolInfo) IsExported() bool {
+	return si.Scope == PublicScope
+}
+
+// GenerateSymbolID generates a unique ID for the symbol (for use as Neo4j node ID)
+func (si *SymbolInfo) GenerateSymbolID() string {
+	if si.Symbol != nil {
+		return si.Symbol.String()
+	}
+	// Fallback: use file path and position
+	return fmt.Sprintf("%s:%d:%d", si.FilePath, si.StartLine, si.StartColumn)
+}
+
+// SymbolReference represents a reference to a symbol in code
+type SymbolReference struct {
+	Symbol      *SCIPSymbol `json:"symbol"`
+	FilePath    string      `json:"filePath"`
+	StartLine   int         `json:"startLine"`
+	EndLine     int         `json:"endLine"`
+	StartColumn int         `json:"startColumn"`
+	EndColumn   int         `json:"endColumn"`
+	IsDefinition bool       `json:"isDefinition"`
+	Context     string      `json:"context"` // surrounding code context
+}
+
+// SymbolDefinition represents a symbol definition
+type SymbolDefinition struct {
+	Symbol *SCIPSymbol  `json:"symbol"`
+	Info   *SymbolInfo  `json:"info"`
+	Refs   []*SymbolReference `json:"references"`
+}
+
+// AddReference adds a reference to this symbol definition
+func (sd *SymbolDefinition) AddReference(ref *SymbolReference) {
+	sd.Refs = append(sd.Refs, ref)
+}
+
+// GetDefinitionReference returns the definition reference (where IsDefinition is true)
+func (sd *SymbolDefinition) GetDefinitionReference() *SymbolReference {
+	for _, ref := range sd.Refs {
+		if ref.IsDefinition {
+			return ref
+		}
+	}
+	return nil
+}
+
+// GetUsageReferences returns all usage references (where IsDefinition is false)
+func (sd *SymbolDefinition) GetUsageReferences() []*SymbolReference {
+	var usages []*SymbolReference
+	for _, ref := range sd.Refs {
+		if !ref.IsDefinition {
+			usages = append(usages, ref)
+		}
+	}
+	return usages
+}

--- a/libs/core-models-go/tombstone.go
+++ b/libs/core-models-go/tombstone.go
@@ -1,0 +1,25 @@
+package models
+
+import "fmt"
+
+// TombstoneReason describes why a tombstone was created.
+type TombstoneReason string
+
+const (
+	TombstoneFileDeleted   TombstoneReason = "file_deleted"
+	TombstoneSymbolRemoved TombstoneReason = "symbol_removed"
+)
+
+// Tombstone represents a marker that hides a main-scope node in a PR overlay.
+// When querying a PR scope, tombstoned nodes from the main scope should be excluded.
+type Tombstone struct {
+	BaseNode
+	TargetNodeKey string          `json:"targetNodeKey" neo4j:"targetNodeKey"`
+	TargetLabel   string          `json:"targetLabel" neo4j:"targetLabel"`
+	Reason        TombstoneReason `json:"reason" neo4j:"reason"`
+}
+
+// TombstoneNodeKey returns "tombstone:{scopeId}:{targetNodeKey}".
+func TombstoneNodeKey(scopeID, targetNodeKey string) string {
+	return fmt.Sprintf("tombstone:%s:%s", scopeID, targetNodeKey)
+}

--- a/libs/neo4j-client-go/client.go
+++ b/libs/neo4j-client-go/client.go
@@ -1,0 +1,493 @@
+package neo4j
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// Config holds the configuration for Neo4j connection
+type Config struct {
+	URI      string
+	Username string
+	Password string
+	Database string
+}
+
+// Client wraps the Neo4j driver and provides higher-level operations
+type Client struct {
+	driver   neo4j.DriverWithContext
+	database string
+}
+
+// NewClient creates a new Neo4j client with the given configuration
+func NewClient(config Config) (*Client, error) {
+	driver, err := neo4j.NewDriverWithContext(
+		config.URI,
+		neo4j.BasicAuth(config.Username, config.Password, ""),
+		func(c *neo4j.Config) {
+			c.MaxConnectionPoolSize = 10  // Reduced for stability
+			c.MaxConnectionLifetime = 5 * time.Minute
+			c.ConnectionAcquisitionTimeout = 30 * time.Second
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Neo4j driver: %w", err)
+	}
+
+	// Test the connection
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = driver.VerifyConnectivity(ctx)
+	if err != nil {
+		driver.Close(ctx)
+		return nil, fmt.Errorf("failed to verify Neo4j connectivity: %w", err)
+	}
+
+	return &Client{
+		driver:   driver,
+		database: config.Database,
+	}, nil
+}
+
+// Close closes the Neo4j driver connection
+func (c *Client) Close(ctx context.Context) error {
+	return c.driver.Close(ctx)
+}
+
+// ExecuteQuery executes a Cypher query and returns the result
+func (c *Client) ExecuteQuery(ctx context.Context, cypher string, params map[string]any) ([]*neo4j.Record, error) {
+	session := c.driver.NewSession(ctx, neo4j.SessionConfig{
+		DatabaseName: c.database,
+	})
+	defer session.Close(ctx)
+
+	result, err := session.Run(ctx, cypher, params)
+	if err != nil {
+		return nil, err
+	}
+
+	records, err := result.Collect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+// ExecuteWrite executes a write transaction
+func (c *Client) ExecuteWrite(ctx context.Context, work func(tx neo4j.ManagedTransaction) (any, error)) (any, error) {
+	session := c.driver.NewSession(ctx, neo4j.SessionConfig{
+		DatabaseName: c.database,
+		AccessMode:   neo4j.AccessModeWrite,
+	})
+	defer session.Close(ctx)
+
+	return session.ExecuteWrite(ctx, work)
+}
+
+// ExecuteRead executes a read transaction
+func (c *Client) ExecuteRead(ctx context.Context, work func(tx neo4j.ManagedTransaction) (any, error)) (any, error) {
+	session := c.driver.NewSession(ctx, neo4j.SessionConfig{
+		DatabaseName: c.database,
+		AccessMode:   neo4j.AccessModeRead,
+	})
+	defer session.Close(ctx)
+
+	return session.ExecuteRead(ctx, work)
+}
+
+// CreateNode creates a single node in the graph
+func (c *Client) CreateNode(ctx context.Context, labels []string, properties map[string]any) (string, error) {
+	labelStr := ""
+	for i, label := range labels {
+		if i > 0 {
+			labelStr += ":"
+		}
+		labelStr += label
+	}
+
+	cypher := fmt.Sprintf("CREATE (n:%s) SET n = $props RETURN elementId(n) as id", labelStr)
+
+	result, err := c.ExecuteQuery(ctx, cypher, map[string]any{
+		"props": properties,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create node: %w", err)
+	}
+
+	if len(result) == 0 {
+		return "", fmt.Errorf("no records returned from create node query")
+	}
+
+	id, ok := result[0].AsMap()["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to extract node ID from result")
+	}
+
+	return id, nil
+}
+
+// MergeNode creates or updates a node using MERGE
+func (c *Client) MergeNode(ctx context.Context, labels []string, mergeProps, setProps map[string]any) (string, error) {
+	labelStr := ""
+	for i, label := range labels {
+		if i > 0 {
+			labelStr += ":"
+		}
+		labelStr += label
+	}
+
+	// Build the merge properties clause
+	mergeClause := ""
+	for key := range mergeProps {
+		if mergeClause != "" {
+			mergeClause += ", "
+		}
+		mergeClause += fmt.Sprintf("%s: $merge.%s", key, key)
+	}
+
+	cypher := fmt.Sprintf(`
+		MERGE (n:%s {%s})
+		SET n += $set
+		RETURN elementId(n) as id
+	`, labelStr, mergeClause)
+
+	params := map[string]any{
+		"merge": mergeProps,
+		"set":   setProps,
+	}
+
+	result, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to merge node: %w", err)
+	}
+
+	if len(result) == 0 {
+		return "", fmt.Errorf("no records returned from merge node query")
+	}
+
+	id, ok := result[0].AsMap()["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to extract node ID from result")
+	}
+
+	return id, nil
+}
+
+// CreateRelationship creates a relationship between two nodes
+func (c *Client) CreateRelationship(ctx context.Context, fromID, toID, relType string, properties map[string]any) (string, error) {
+	cypher := fmt.Sprintf(`
+		MATCH (from), (to)
+		WHERE elementId(from) = $fromId AND elementId(to) = $toId
+		CREATE (from)-[r:%s]->(to)
+		SET r = $props
+		RETURN elementId(r) as id
+	`, relType)
+
+	params := map[string]any{
+		"fromId": fromID,
+		"toId":   toID,
+		"props":  properties,
+	}
+
+	result, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to create relationship: %w", err)
+	}
+
+	if len(result) == 0 {
+		return "", fmt.Errorf("no records returned from create relationship query")
+	}
+
+	id, ok := result[0].AsMap()["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to extract relationship ID from result")
+	}
+
+	return id, nil
+}
+
+// MergeRelationship creates or updates a relationship between two nodes using MERGE.
+// mergeProps are used to match an existing relationship; setProps are applied on match/create.
+func (c *Client) MergeRelationship(ctx context.Context, fromID, toID, relType string, mergeProps, setProps map[string]any) (string, error) {
+	mergeClause := ""
+	if len(mergeProps) > 0 {
+		parts := make([]string, 0, len(mergeProps))
+		for key := range mergeProps {
+			parts = append(parts, fmt.Sprintf("%s: $merge.%s", key, key))
+		}
+		mergeClause = " {" + strings.Join(parts, ", ") + "}"
+	}
+
+	cypher := fmt.Sprintf(`
+		MATCH (from), (to)
+		WHERE elementId(from) = $fromId AND elementId(to) = $toId
+		MERGE (from)-[r:%s%s]->(to)
+		SET r += $set
+		RETURN elementId(r) as id
+	`, relType, mergeClause)
+
+	params := map[string]any{
+		"fromId": fromID,
+		"toId":   toID,
+		"merge":  mergeProps,
+		"set":    setProps,
+	}
+
+	result, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to merge relationship: %w", err)
+	}
+
+	if len(result) == 0 {
+		return "", fmt.Errorf("no records returned from merge relationship query")
+	}
+
+	id, ok := result[0].AsMap()["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to extract relationship ID from result")
+	}
+
+	return id, nil
+}
+
+// MergeNodesBatch merges nodes in UNWIND batches of batchSize, using pure Cypher (no APOC).
+// label is the single Neo4j label for all items.
+// Each item must have "nodeKey", "scopeId", and "props" keys.
+// Returns a map of nodeKey → elementId for every merged node.
+func (c *Client) MergeNodesBatch(ctx context.Context, label string, items []map[string]any, batchSize int) (map[string]string, error) {
+	if len(items) == 0 {
+		return make(map[string]string), nil
+	}
+	if batchSize <= 0 {
+		batchSize = 500
+	}
+
+	cypher := fmt.Sprintf(`
+		UNWIND $batch AS item
+		MERGE (n:%s {nodeKey: item.nodeKey, scopeId: item.scopeId})
+		SET n += item.props
+		RETURN item.nodeKey AS nodeKey, elementId(n) AS id
+	`, label)
+
+	result := make(map[string]string, len(items))
+
+	for start := 0; start < len(items); start += batchSize {
+		end := start + batchSize
+		if end > len(items) {
+			end = len(items)
+		}
+		chunk := items[start:end]
+
+		records, err := c.ExecuteQuery(ctx, cypher, map[string]any{"batch": chunk})
+		if err != nil {
+			return nil, fmt.Errorf("MergeNodesBatch(%s) chunk %d-%d failed: %w", label, start, end, err)
+		}
+
+		for _, rec := range records {
+			m := rec.AsMap()
+			nk, _ := m["nodeKey"].(string)
+			id, _ := m["id"].(string)
+			if nk != "" && id != "" {
+				result[nk] = id
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// CreateRelsBatch creates relationships in UNWIND batches of batchSize, using pure Cypher (no APOC).
+// relType is the single relationship type for all items.
+// Each item must have "fromId" and "toId" (elementId strings) and "props" (map).
+func (c *Client) CreateRelsBatch(ctx context.Context, relType string, items []map[string]any, batchSize int) error {
+	if len(items) == 0 {
+		return nil
+	}
+	if batchSize <= 0 {
+		batchSize = 500
+	}
+
+	cypher := fmt.Sprintf(`
+		UNWIND $batch AS item
+		MATCH (a), (b)
+		WHERE elementId(a) = item.fromId AND elementId(b) = item.toId
+		CREATE (a)-[r:%s]->(b)
+		SET r = item.props
+	`, relType)
+
+	for start := 0; start < len(items); start += batchSize {
+		end := start + batchSize
+		if end > len(items) {
+			end = len(items)
+		}
+		chunk := items[start:end]
+
+		_, err := c.ExecuteQuery(ctx, cypher, map[string]any{"batch": chunk})
+		if err != nil {
+			return fmt.Errorf("CreateRelsBatch(%s) chunk %d-%d failed: %w", relType, start, end, err)
+		}
+	}
+
+	return nil
+}
+
+// BatchCreateNodes creates multiple nodes in a single transaction
+func (c *Client) BatchCreateNodes(ctx context.Context, nodes []BatchNode) error {
+	cypher := `
+		UNWIND $nodes AS nodeData
+		CALL apoc.create.node(nodeData.labels, nodeData.properties) YIELD node
+		RETURN count(node) as created
+	`
+
+	params := map[string]any{
+		"nodes": nodes,
+	}
+
+	_, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return fmt.Errorf("failed to batch create nodes: %w", err)
+	}
+
+	return nil
+}
+
+// BatchMergeNodes creates or updates multiple nodes in a single transaction
+func (c *Client) BatchMergeNodes(ctx context.Context, nodes []BatchMergeNode) error {
+	cypher := `
+		UNWIND $nodes AS nodeData
+		CALL apoc.merge.node(nodeData.labels, nodeData.mergeProps, nodeData.setProps) YIELD node
+		RETURN count(node) as processed
+	`
+
+	params := map[string]any{
+		"nodes": nodes,
+	}
+
+	_, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return fmt.Errorf("failed to batch merge nodes: %w", err)
+	}
+
+	return nil
+}
+
+// BatchCreateRelationships creates multiple relationships in a single transaction
+func (c *Client) BatchCreateRelationships(ctx context.Context, relationships []BatchRelationship) error {
+	cypher := `
+		UNWIND $rels AS relData
+		MATCH (from), (to)
+		WHERE elementId(from) = relData.fromId AND elementId(to) = relData.toId
+		CALL apoc.create.relationship(from, relData.type, relData.properties, to) YIELD rel
+		RETURN count(rel) as created
+	`
+
+	params := map[string]any{
+		"rels": relationships,
+	}
+
+	_, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return fmt.Errorf("failed to batch create relationships: %w", err)
+	}
+
+	return nil
+}
+
+// SetNodeProperty sets a property on a node identified by its ID
+func (c *Client) SetNodeProperty(ctx context.Context, nodeID string, propertyName string, propertyValue any) error {
+	cypher := `
+		MATCH (n)
+		WHERE elementId(n) = $nodeId
+		SET n.` + propertyName + ` = $value
+		RETURN n
+	`
+
+	params := map[string]any{
+		"nodeId": nodeID,
+		"value":  propertyValue,
+	}
+
+	result, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return fmt.Errorf("failed to set node property: %w", err)
+	}
+
+	if len(result) == 0 {
+		return fmt.Errorf("node not found: %s", nodeID)
+	}
+
+	return nil
+}
+
+// SetNodeProperties sets multiple properties on a node identified by its ID
+func (c *Client) SetNodeProperties(ctx context.Context, nodeID string, properties map[string]any) error {
+	cypher := `
+		MATCH (n)
+		WHERE elementId(n) = $nodeId
+		SET n += $props
+		RETURN n
+	`
+
+	params := map[string]any{
+		"nodeId": nodeID,
+		"props":  properties,
+	}
+
+	result, err := c.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return fmt.Errorf("failed to set node properties: %w", err)
+	}
+
+	if len(result) == 0 {
+		return fmt.Errorf("node not found: %s", nodeID)
+	}
+
+	return nil
+}
+
+// GetDatabaseInfo returns information about the database
+func (c *Client) GetDatabaseInfo(ctx context.Context) (map[string]any, error) {
+	cypher := "CALL dbms.components() YIELD name, versions, edition"
+
+	result, err := c.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database info: %w", err)
+	}
+
+	info := make(map[string]any)
+	for _, record := range result {
+		recordMap := record.AsMap()
+		info["name"] = recordMap["name"]
+		info["versions"] = recordMap["versions"]
+		info["edition"] = recordMap["edition"]
+	}
+
+	return info, nil
+}
+
+// BatchNode represents a node for batch operations
+type BatchNode struct {
+	Labels     []string       `json:"labels"`
+	Properties map[string]any `json:"properties"`
+}
+
+// BatchMergeNode represents a node for batch merge operations
+type BatchMergeNode struct {
+	Labels     []string       `json:"labels"`
+	MergeProps map[string]any `json:"mergeProps"`
+	SetProps   map[string]any `json:"setProps"`
+}
+
+// BatchRelationship represents a relationship for batch operations
+type BatchRelationship struct {
+	FromID     string         `json:"fromId"`
+	ToID       string         `json:"toId"`
+	Type       string         `json:"type"`
+	Properties map[string]any `json:"properties"`
+}

--- a/libs/neo4j-client-go/project.json
+++ b/libs/neo4j-client-go/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "neo4j-client-go",
+  "root": "libs/neo4j-client-go",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go build ./libs/neo4j-client-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go test ./libs/neo4j-client-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    }
+  }
+}

--- a/libs/neo4j-client-go/query.go
+++ b/libs/neo4j-client-go/query.go
@@ -1,0 +1,750 @@
+package neo4j
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// QueryBuilder helps build Cypher queries programmatically
+type QueryBuilder struct {
+	client *Client
+}
+
+// NewQueryBuilder creates a new query builder
+func NewQueryBuilder(client *Client) *QueryBuilder {
+	return &QueryBuilder{client: client}
+}
+
+// FindNodesByLabel finds all nodes with a specific label
+func (qb *QueryBuilder) FindNodesByLabel(ctx context.Context, label string, limit int) ([]*neo4j.Record, error) {
+	cypher := fmt.Sprintf("MATCH (n:%s) RETURN n", label)
+	if limit > 0 {
+		cypher += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	result, err := qb.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find nodes by label %s: %w", label, err)
+	}
+
+	return result, nil
+}
+
+// FindNodeByProperty finds nodes by a specific property value
+func (qb *QueryBuilder) FindNodeByProperty(ctx context.Context, label, property string, value any) ([]*neo4j.Record, error) {
+	cypher := fmt.Sprintf("MATCH (n:%s {%s: $value}) RETURN n", label, property)
+	params := map[string]any{"value": value}
+
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find node by property %s=%v: %w", property, value, err)
+	}
+
+	return result, nil
+}
+
+// FindSymbolDefinition finds the definition of a symbol by its SCIP identifier
+func (qb *QueryBuilder) FindSymbolDefinition(ctx context.Context, symbol string) (*models.SymbolInfo, error) {
+	cypher := `
+		MATCH (s:Symbol {symbol: $symbol})<-[:DEFINES]-(definition)
+		RETURN
+			labels(definition) AS nodeType,
+			definition.name AS name,
+			definition.signature AS signature,
+			definition.filePath AS filePath,
+			definition.startLine AS startLine,
+			definition.endLine AS endLine,
+			properties(definition) AS allProperties
+	`
+
+	params := map[string]any{"symbol": symbol}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find symbol definition: %w", err)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("symbol definition not found: %s", symbol)
+	}
+
+	record := result[0]
+	recordMap := record.AsMap()
+
+	// Parse the SCIP symbol
+	scipSymbol, err := models.ParseSCIPSymbol(symbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SCIP symbol: %w", err)
+	}
+
+	// Extract symbol info
+	symbolInfo := &models.SymbolInfo{
+		Symbol:      scipSymbol,
+		DisplayName: getString(recordMap, "name"),
+		Signature:   getString(recordMap, "signature"),
+		FilePath:    getString(recordMap, "filePath"),
+		StartLine:   getInt(recordMap, "startLine"),
+		EndLine:     getInt(recordMap, "endLine"),
+	}
+
+	// Determine symbol kind from node labels
+	if labels, ok := recordMap["nodeType"].([]interface{}); ok {
+		for _, label := range labels {
+			if labelStr, ok := label.(string); ok {
+				switch labelStr {
+				case "Function":
+					symbolInfo.Kind = models.FunctionSymbol
+				case "Method":
+					symbolInfo.Kind = models.MethodSymbol
+				case "Class":
+					symbolInfo.Kind = models.TypeSymbol
+				case "Interface":
+					symbolInfo.Kind = models.InterfaceSymbol
+				case "Variable":
+					symbolInfo.Kind = models.VariableSymbol
+				case "Parameter":
+					symbolInfo.Kind = models.ParameterSymbol
+				}
+			}
+		}
+	}
+
+	return symbolInfo, nil
+}
+
+// FindAllReferences finds all references to a symbol
+func (qb *QueryBuilder) FindAllReferences(ctx context.Context, symbol string) ([]*models.SymbolReference, error) {
+	cypher := `
+		MATCH (s:Symbol {symbol: $symbol})<-[:REFERENCES]-(usage)
+		MATCH (usage)<-[:CONTAINS*]-(file:File)
+		RETURN
+			usage.name AS usageName,
+			usage.startLine AS startLine,
+			usage.endLine AS endLine,
+			usage.startColumn AS startColumn,
+			usage.endColumn AS endColumn,
+			file.path AS filePath
+		ORDER BY file.path, startLine
+	`
+
+	params := map[string]any{"symbol": symbol}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find symbol references: %w", err)
+	}
+
+	scipSymbol, err := models.ParseSCIPSymbol(symbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SCIP symbol: %w", err)
+	}
+
+	var references []*models.SymbolReference
+	for _, record := range result {
+		recordMap := record.AsMap()
+
+		ref := &models.SymbolReference{
+			Symbol:      scipSymbol,
+			FilePath:    getString(recordMap, "filePath"),
+			StartLine:   getInt(recordMap, "startLine"),
+			EndLine:     getInt(recordMap, "endLine"),
+			StartColumn: getInt(recordMap, "startColumn"),
+			EndColumn:   getInt(recordMap, "endColumn"),
+			IsDefinition: false, // These are usage references
+		}
+		references = append(references, ref)
+	}
+
+	return references, nil
+}
+
+// FindImplementations finds all classes that implement an interface
+func (qb *QueryBuilder) FindImplementations(ctx context.Context, interfaceSymbol string) ([]*models.Class, error) {
+	cypher := `
+		MATCH (interfaceSymbol:Symbol {symbol: $interfaceSymbol})
+		MATCH (interfaceSymbol)<-[:DEFINES]-(interfaceNode:Interface)
+		MATCH (interfaceNode)<-[:IMPLEMENTS]-(classNode:Class)
+		RETURN
+			classNode.name AS className,
+			classNode.fqn AS fullyQualifiedName,
+			classNode.filePath AS filePath,
+			classNode.startLine AS startLine,
+			classNode.endLine AS endLine
+	`
+
+	params := map[string]any{"interfaceSymbol": interfaceSymbol}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find implementations: %w", err)
+	}
+
+	var classes []*models.Class
+	for _, record := range result {
+		recordMap := record.AsMap()
+
+		class := &models.Class{
+			Name:      getString(recordMap, "className"),
+			FQN:       getString(recordMap, "fullyQualifiedName"),
+			FilePath:  getString(recordMap, "filePath"),
+			StartLine: getInt(recordMap, "startLine"),
+			EndLine:   getInt(recordMap, "endLine"),
+		}
+		classes = append(classes, class)
+	}
+
+	return classes, nil
+}
+
+// FindAPIEndpointsAffectedByFunction performs impact analysis
+func (qb *QueryBuilder) FindAPIEndpointsAffectedByFunction(ctx context.Context, functionSymbol string) ([]*models.APIRoute, error) {
+	cypher := `
+		MATCH (startFunc)-[:DEFINES]->(:Symbol {symbol: $functionSymbol})
+		WHERE startFunc:Function OR startFunc:Method
+
+		// Find all functions and methods called by startFunc, up to 10 levels deep
+		MATCH (startFunc)-[:CALLS*1..10]->(downstream)
+		WHERE downstream:Function OR downstream:Method
+
+		// From the set of downstream functions, find any that directly handle an API route
+		MATCH (downstream)-[:EXPOSES_API]->(route:APIRoute)
+
+		RETURN DISTINCT
+			route.protocol AS protocol,
+			route.method AS httpMethod,
+			route.path AS apiPath,
+			route.description AS description
+	`
+
+	params := map[string]any{"functionSymbol": functionSymbol}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find affected API endpoints: %w", err)
+	}
+
+	var routes []*models.APIRoute
+	for _, record := range result {
+		recordMap := record.AsMap()
+
+		route := &models.APIRoute{
+			Protocol:    getString(recordMap, "protocol"),
+			Method:      getString(recordMap, "httpMethod"),
+			Path:        getString(recordMap, "apiPath"),
+			Description: getString(recordMap, "description"),
+		}
+		routes = append(routes, route)
+	}
+
+	return routes, nil
+}
+
+// TraceDataFlow traces the flow of data from a parameter to function calls
+func (qb *QueryBuilder) TraceDataFlow(ctx context.Context, paramSymbol string) ([]*models.SymbolReference, error) {
+	cypher := `
+		MATCH (param:Parameter)-[:DEFINES]->(:Symbol {symbol: $paramSymbol})
+
+		// Follow the data flow path through intermediate variables
+		MATCH path = (param)-[:FLOWS_TO*1..15]->(usage)
+
+		// Identify if the final usage is a parameter in another function call
+		MATCH (usage:Parameter)<-[:CONTAINS]-(call:Method)
+		WHERE usage:Parameter
+
+		RETURN
+			call.name AS receivingMethod,
+			call.signature AS receivingMethodSignature,
+			nodes(path) AS dataFlowPath
+	`
+
+	params := map[string]any{"paramSymbol": paramSymbol}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to trace data flow: %w", err)
+	}
+
+	scipSymbol, err := models.ParseSCIPSymbol(paramSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SCIP symbol: %w", err)
+	}
+
+	var references []*models.SymbolReference
+	for _, record := range result {
+		recordMap := record.AsMap()
+
+		ref := &models.SymbolReference{
+			Symbol:  scipSymbol,
+			Context: getString(recordMap, "receivingMethod"),
+		}
+		references = append(references, ref)
+	}
+
+	return references, nil
+}
+
+// DiscoverServiceDependencies finds all external service dependencies
+func (qb *QueryBuilder) DiscoverServiceDependencies(ctx context.Context, serviceName string) ([]map[string]any, error) {
+	cypher := `
+		MATCH (s:Service {name: $serviceName})
+
+		// Find all functions/methods defined within this service
+		MATCH (s)-[:CONTAINS*]->(caller)
+		WHERE caller:Function OR caller:Method
+
+		// Find all calls originating from these functions to symbols in other services
+		MATCH (caller)-[:CALLS]->()-[:DEFINES]->(symbol:Symbol)
+		// SCIP symbols for external packages contain the package name
+		// We filter out internal calls by checking that the symbol does not contain the current service's name
+		WHERE symbol.symbol CONTAINS " " AND NOT symbol.symbol CONTAINS $serviceName
+
+		// Extract the foreign service name from the SCIP symbol string
+		WITH caller, split(symbol.symbol, ' ') AS symbolParts, symbol
+		RETURN DISTINCT
+			symbolParts[2] AS foreignServiceName,
+			caller.name AS callingFunction,
+			symbol.symbol AS targetSymbol
+		ORDER BY foreignServiceName, callingFunction
+	`
+
+	params := map[string]any{"serviceName": serviceName}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover service dependencies: %w", err)
+	}
+
+	var dependencies []map[string]any
+	for _, record := range result {
+		dependencies = append(dependencies, record.AsMap())
+	}
+
+	return dependencies, nil
+}
+
+// TombstoneFilter returns a Cypher WHERE clause fragment that excludes nodes
+// which have been tombstoned in the given scopeID. If scopeID is empty or "main",
+// no filtering is applied.
+func TombstoneFilter(nodeVar, scopeID string) string {
+	if scopeID == "" || scopeID == "main" {
+		return ""
+	}
+	return fmt.Sprintf(` AND NOT EXISTS {
+		MATCH (t:Tombstone {scopeId: "%s"})
+		WHERE t.targetNodeKey = %s.nodeKey
+	}`, scopeID, nodeVar)
+}
+
+// SearchNodesScoped performs a search with tombstone filtering for PR overlays.
+// It returns nodes visible in the given scopeID by:
+// 1. Including nodes from the PR scope
+// 2. Including main-scope nodes NOT tombstoned in this PR scope
+func (qb *QueryBuilder) SearchNodesScoped(ctx context.Context, searchTerm string, nodeTypes []string, limit int, scopeID string) ([]*neo4j.Record, error) {
+	if scopeID == "" || scopeID == "main" {
+		// No overlay — just search main scope
+		return qb.SearchNodes(ctx, searchTerm, nodeTypes, limit)
+	}
+
+	var labelFilters []string
+	for _, nodeType := range nodeTypes {
+		labelFilters = append(labelFilters, fmt.Sprintf("n:%s", nodeType))
+	}
+	labelFilter := ""
+	if len(labelFilters) > 0 {
+		labelFilter = "AND (" + strings.Join(labelFilters, " OR ") + ")"
+	}
+
+	tombstoneClause := TombstoneFilter("n", scopeID)
+
+	cypher := fmt.Sprintf(`
+		MATCH (n)
+		WHERE (n.scopeId = $scopeId OR n.scopeId = 'main')
+		%s
+		%s
+		AND (
+			toLower(n.name) CONTAINS toLower($searchTerm) OR
+			toLower(n.displayName) CONTAINS toLower($searchTerm) OR
+			toLower(n.signature) CONTAINS toLower($searchTerm) OR
+			toLower(n.symbol) CONTAINS toLower($searchTerm) OR
+			toLower(n.path) CONTAINS toLower($searchTerm) OR
+			toLower(n.description) CONTAINS toLower($searchTerm) OR
+			toLower(n.content) CONTAINS toLower($searchTerm) OR
+			toLower(n.title) CONTAINS toLower($searchTerm)
+		)
+		WITH n
+		ORDER BY CASE WHEN n.scopeId = $scopeId THEN 0 ELSE 1 END
+		WITH n.nodeKey AS nk, collect(n)[0] AS n
+		WITH n, labels(n) AS nodeLabels
+		ORDER BY
+			CASE
+				WHEN n:Function OR n:Method THEN 1
+				WHEN n:Class OR n:Interface THEN 2
+				WHEN n:Variable OR n:Parameter THEN 3
+				WHEN n:File OR n:Feature OR n:Document THEN 4
+				WHEN n:Symbol THEN 5
+				ELSE 6
+			END,
+			n.name
+		RETURN n, nodeLabels
+	`, labelFilter, tombstoneClause)
+
+	if limit > 0 {
+		cypher += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	params := map[string]any{
+		"searchTerm": searchTerm,
+		"scopeId":    scopeID,
+	}
+
+	return qb.client.ExecuteQuery(ctx, cypher, params)
+}
+
+// Helper functions to safely extract values from record maps
+func getString(m map[string]any, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func getInt(m map[string]any, key string) int {
+	if v, ok := m[key]; ok {
+		if i, ok := v.(int64); ok {
+			return int(i)
+		}
+		if i, ok := v.(int); ok {
+			return i
+		}
+	}
+	return 0
+}
+
+// SearchNodes performs a full-text search across nodes
+func (qb *QueryBuilder) SearchNodes(ctx context.Context, searchTerm string, nodeTypes []string, limit int) ([]*neo4j.Record, error) {
+	// Build the label filter
+	var labelFilters []string
+	for _, nodeType := range nodeTypes {
+		labelFilters = append(labelFilters, fmt.Sprintf("n:%s", nodeType))
+	}
+
+	var cypher string
+	if len(labelFilters) > 0 {
+		labelFilter := strings.Join(labelFilters, " OR ")
+		cypher = fmt.Sprintf(`
+			MATCH (n)
+			WHERE (%s) AND (
+				toLower(n.name) CONTAINS toLower($searchTerm) OR
+				toLower(n.displayName) CONTAINS toLower($searchTerm) OR
+				toLower(n.signature) CONTAINS toLower($searchTerm) OR
+				toLower(n.symbol) CONTAINS toLower($searchTerm) OR
+				toLower(n.path) CONTAINS toLower($searchTerm) OR
+				toLower(n.description) CONTAINS toLower($searchTerm) OR
+				toLower(n.content) CONTAINS toLower($searchTerm) OR
+				toLower(n.title) CONTAINS toLower($searchTerm)
+			)
+			RETURN n, labels(n) AS nodeLabels
+			ORDER BY
+				CASE
+					WHEN n:Function OR n:Method THEN 1
+					WHEN n:Class OR n:Interface THEN 2
+					WHEN n:Variable OR n:Parameter THEN 3
+					WHEN n:File OR n:Feature OR n:Document THEN 4
+					WHEN n:Symbol THEN 5
+					ELSE 6
+				END,
+				n.name
+		`, labelFilter)
+	} else {
+		cypher = `
+			MATCH (n)
+			WHERE
+				toLower(n.name) CONTAINS toLower($searchTerm) OR
+				toLower(n.displayName) CONTAINS toLower($searchTerm) OR
+				toLower(n.signature) CONTAINS toLower($searchTerm) OR
+				toLower(n.symbol) CONTAINS toLower($searchTerm) OR
+				toLower(n.path) CONTAINS toLower($searchTerm) OR
+				toLower(n.description) CONTAINS toLower($searchTerm) OR
+				toLower(n.content) CONTAINS toLower($searchTerm) OR
+				toLower(n.title) CONTAINS toLower($searchTerm)
+			RETURN n, labels(n) AS nodeLabels
+			ORDER BY
+				CASE
+					WHEN n:Function OR n:Method THEN 1
+					WHEN n:Class OR n:Interface THEN 2
+					WHEN n:Variable OR n:Parameter THEN 3
+					WHEN n:File OR n:Feature OR n:Document THEN 4
+					WHEN n:Symbol THEN 5
+					ELSE 6
+				END,
+				n.name
+		`
+	}
+
+	// Only apply limit if it's greater than 0
+	if limit > 0 {
+		cypher += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	params := map[string]any{"searchTerm": searchTerm}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search nodes: %w", err)
+	}
+
+	return result, nil
+}
+
+// SemanticSearch performs advanced search including multi-word phrases and related concepts
+func (qb *QueryBuilder) SemanticSearch(ctx context.Context, searchTerm string, nodeTypes []string, limit int) ([]*neo4j.Record, error) {
+	// Split search term into individual words for better matching
+	words := strings.Fields(searchTerm)
+
+	// Build the label filter
+	var labelFilters []string
+	for _, nodeType := range nodeTypes {
+		labelFilters = append(labelFilters, fmt.Sprintf("n:%s", nodeType))
+	}
+
+	// Build word-based search conditions
+	var wordConditions []string
+	for i := range words {
+		wordParam := fmt.Sprintf("word%d", i)
+		wordConditions = append(wordConditions, fmt.Sprintf(`(
+			toLower(n.name) CONTAINS toLower($%s) OR
+			toLower(n.displayName) CONTAINS toLower($%s) OR
+			toLower(n.signature) CONTAINS toLower($%s) OR
+			toLower(n.symbol) CONTAINS toLower($%s) OR
+			toLower(n.path) CONTAINS toLower($%s) OR
+			toLower(n.description) CONTAINS toLower($%s) OR
+			toLower(n.content) CONTAINS toLower($%s) OR
+			toLower(n.title) CONTAINS toLower($%s)
+		)`, wordParam, wordParam, wordParam, wordParam, wordParam, wordParam, wordParam, wordParam))
+	}
+
+	var cypher string
+	wordSearchCondition := strings.Join(wordConditions, " AND ")
+
+	if len(labelFilters) > 0 {
+		labelFilter := strings.Join(labelFilters, " OR ")
+		cypher = fmt.Sprintf(`
+			MATCH (n)
+			WHERE (%s) AND (%s)
+			// Also search for related nodes through relationships
+			OPTIONAL MATCH (n)-[:MENTIONS|IMPLEMENTS|DOCUMENTS|BELONGS_TO]-(related)
+			WHERE %s
+			RETURN n, labels(n) AS nodeLabels, COUNT(related) as relationshipScore
+			ORDER BY
+				relationshipScore DESC,
+				CASE
+					WHEN n:Function OR n:Method THEN 1
+					WHEN n:Class OR n:Interface THEN 2
+					WHEN n:Variable OR n:Parameter THEN 3
+					WHEN n:Document OR n:Feature THEN 4
+					WHEN n:File THEN 5
+					WHEN n:Symbol THEN 6
+					ELSE 7
+				END,
+				n.name
+		`, labelFilter, wordSearchCondition, wordSearchCondition)
+	} else {
+		cypher = fmt.Sprintf(`
+			MATCH (n)
+			WHERE %s
+			// Also search for related nodes through relationships
+			OPTIONAL MATCH (n)-[:MENTIONS|IMPLEMENTS|DOCUMENTS|BELONGS_TO]-(related)
+			WHERE %s
+			RETURN n, labels(n) AS nodeLabels, COUNT(related) as relationshipScore
+			ORDER BY
+				relationshipScore DESC,
+				CASE
+					WHEN n:Function OR n:Method THEN 1
+					WHEN n:Class OR n:Interface THEN 2
+					WHEN n:Variable OR n:Parameter THEN 3
+					WHEN n:Document OR n:Feature THEN 4
+					WHEN n:File THEN 5
+					WHEN n:Symbol THEN 6
+					ELSE 7
+				END,
+				n.name
+		`, wordSearchCondition, wordSearchCondition)
+	}
+
+	// Only apply limit if it's greater than 0
+	if limit > 0 {
+		cypher += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	// Build parameters for all words
+	params := make(map[string]any)
+	for i, word := range words {
+		params[fmt.Sprintf("word%d", i)] = word
+	}
+
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform semantic search: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetFunctionSourceCode retrieves the exact source code for a function or method
+func (qb *QueryBuilder) GetFunctionSourceCode(ctx context.Context, functionName string) (string, error) {
+	// Find the function/method node with location metadata
+	cypher := `
+		MATCH (f)
+		WHERE (f:Function OR f:Method) AND f.name = $functionName
+		RETURN f.filePath AS filePath, f.startByte AS startByte, f.endByte AS endByte,
+			   f.startLine AS startLine, f.endLine AS endLine,
+			   f.name AS name, f.signature AS signature
+		LIMIT 1
+	`
+
+	params := map[string]any{"functionName": functionName}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to find function: %w", err)
+	}
+
+	if len(result) == 0 {
+		return "", fmt.Errorf("function not found: %s", functionName)
+	}
+
+	record := result[0].AsMap()
+	filePath := getString(record, "filePath")
+	startByte := getInt(record, "startByte")
+	endByte := getInt(record, "endByte")
+	startLine := getInt(record, "startLine")
+	endLine := getInt(record, "endLine")
+
+	if filePath == "" {
+		return "", fmt.Errorf("no file path found for function: %s", functionName)
+	}
+
+	// Read the file content - handle both absolute and relative paths
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		// If relative path fails, try from project root
+		// This handles the case where tests run from different directories
+		if !filepath.IsAbs(filePath) {
+			// Try from current working directory
+			if pwd, pwdErr := os.Getwd(); pwdErr == nil {
+				// Go up to project root if we're in test directory
+				projectRoot := pwd
+				if strings.HasSuffix(pwd, "/test/integration") {
+					projectRoot = filepath.Dir(filepath.Dir(pwd))
+				}
+				absolutePath := filepath.Join(projectRoot, filePath)
+				if content, err = os.ReadFile(absolutePath); err == nil {
+					// Success with absolute path
+				} else {
+					return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+				}
+			} else {
+				return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+			}
+		} else {
+			return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+	}
+
+	// If we have byte offsets, use them for precise extraction
+	if startByte >= 0 && endByte >= 0 && startByte < len(content) && endByte <= len(content) {
+		sourceCode := string(content[startByte:endByte])
+		return sourceCode, nil
+	}
+
+	// Fallback to line-based extraction
+	if startLine > 0 && endLine > 0 {
+		lines := strings.Split(string(content), "\n")
+		if startLine <= len(lines) && endLine <= len(lines) {
+			functionLines := lines[startLine-1 : endLine]
+			sourceCode := strings.Join(functionLines, "\n")
+			return sourceCode, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to extract source code for function: %s", functionName)
+}
+
+// GetFunctionSourceCodeBySignature retrieves source code using the function signature for disambiguation
+func (qb *QueryBuilder) GetFunctionSourceCodeBySignature(ctx context.Context, signature string) (string, error) {
+	// Find the function/method node with location metadata using signature
+	cypher := `
+		MATCH (f)
+		WHERE (f:Function OR f:Method) AND f.signature = $signature
+		RETURN f.filePath AS filePath, f.startByte AS startByte, f.endByte AS endByte,
+			   f.startLine AS startLine, f.endLine AS endLine,
+			   f.name AS name, f.signature AS signature
+		LIMIT 1
+	`
+
+	params := map[string]any{"signature": signature}
+	result, err := qb.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to find function: %w", err)
+	}
+
+	if len(result) == 0 {
+		return "", fmt.Errorf("function not found with signature: %s", signature)
+	}
+
+	record := result[0].AsMap()
+	filePath := getString(record, "filePath")
+	startByte := getInt(record, "startByte")
+	endByte := getInt(record, "endByte")
+	startLine := getInt(record, "startLine")
+	endLine := getInt(record, "endLine")
+
+	if filePath == "" {
+		return "", fmt.Errorf("no file path found for function with signature: %s", signature)
+	}
+
+	// Read the file content - handle both absolute and relative paths
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		// If relative path fails, try from project root
+		// This handles the case where tests run from different directories
+		if !filepath.IsAbs(filePath) {
+			// Try from current working directory
+			if pwd, pwdErr := os.Getwd(); pwdErr == nil {
+				// Go up to project root if we're in test directory
+				projectRoot := pwd
+				if strings.HasSuffix(pwd, "/test/integration") {
+					projectRoot = filepath.Dir(filepath.Dir(pwd))
+				}
+				absolutePath := filepath.Join(projectRoot, filePath)
+				if content, err = os.ReadFile(absolutePath); err == nil {
+					// Success with absolute path
+				} else {
+					return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+				}
+			} else {
+				return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+			}
+		} else {
+			return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+	}
+
+	// If we have byte offsets, use them for precise extraction
+	if startByte >= 0 && endByte >= 0 && startByte < len(content) && endByte <= len(content) {
+		sourceCode := string(content[startByte:endByte])
+		return sourceCode, nil
+	}
+
+	// Fallback to line-based extraction
+	if startLine > 0 && endLine > 0 {
+		lines := strings.Split(string(content), "\n")
+		if startLine <= len(lines) && endLine <= len(lines) {
+			functionLines := lines[startLine-1 : endLine]
+			sourceCode := strings.Join(functionLines, "\n")
+			return sourceCode, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to extract source code for function with signature: %s", signature)
+}

--- a/libs/vector-client-go/project.json
+++ b/libs/vector-client-go/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "vector-client-go",
+  "root": "libs/vector-client-go",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go build ./libs/vector-client-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go test ./libs/vector-client-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    }
+  }
+}

--- a/libs/vector-client-go/qdrant_vector_store.go
+++ b/libs/vector-client-go/qdrant_vector_store.go
@@ -1,0 +1,397 @@
+package search
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log"
+
+	pb "github.com/qdrant/go-client/qdrant"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// QdrantVectorStore implements VectorStore using Qdrant's gRPC API.
+type QdrantVectorStore struct {
+	conn           *grpc.ClientConn
+	pointsClient   pb.PointsClient
+	collectClient  pb.CollectionsClient
+}
+
+// NewQdrantVectorStore creates a new Qdrant-backed vector store.
+// host is the gRPC endpoint (e.g. "localhost:6334").
+func NewQdrantVectorStore(host string) (*QdrantVectorStore, error) {
+	conn, err := grpc.NewClient(host, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Qdrant at %s: %w", host, err)
+	}
+	return &QdrantVectorStore{
+		conn:          conn,
+		pointsClient:  pb.NewPointsClient(conn),
+		collectClient: pb.NewCollectionsClient(conn),
+	}, nil
+}
+
+// Close closes the gRPC connection.
+func (q *QdrantVectorStore) Close() error {
+	if q.conn != nil {
+		return q.conn.Close()
+	}
+	return nil
+}
+
+func (q *QdrantVectorStore) CreateIndex(ctx context.Context, name string, dimensions int, similarity string) error {
+	dist := pb.Distance_Cosine
+	switch similarity {
+	case "euclidean":
+		dist = pb.Distance_Euclid
+	case "dot":
+		dist = pb.Distance_Dot
+	}
+
+	_, err := q.collectClient.Create(ctx, &pb.CreateCollection{
+		CollectionName: name,
+		VectorsConfig: &pb.VectorsConfig{
+			Config: &pb.VectorsConfig_Params{
+				Params: &pb.VectorParams{
+					Size:     uint64(dimensions),
+					Distance: dist,
+				},
+			},
+		},
+	})
+	if err != nil {
+		// Collection may already exist – treat as success.
+		log.Printf("Qdrant CreateIndex %s: %v (may already exist)", name, err)
+		return nil
+	}
+
+	// Create payload indexes for efficient filtering.
+	for _, field := range []string{"nodeLabel", "nodeKey"} {
+		_, _ = q.pointsClient.CreateFieldIndex(ctx, &pb.CreateFieldIndexCollection{
+			CollectionName: name,
+			FieldName:      field,
+			FieldType:      pb.FieldType_FieldTypeKeyword.Enum(),
+		})
+	}
+
+	return nil
+}
+
+func (q *QdrantVectorStore) UpsertVectors(ctx context.Context, vectors []VectorUpsert) error {
+	// Group by collection (derived from NodeLabel).
+	byCollection := make(map[string][]*pb.PointStruct)
+
+	for _, v := range vectors {
+		collection := collectionForLabel(v.NodeLabel, len(v.Vector))
+
+		payload := make(map[string]*pb.Value)
+		payload["nodeKey"] = qdrantStrVal(v.ID)
+		payload["nodeLabel"] = qdrantStrVal(v.NodeLabel)
+
+		for k, val := range v.Metadata {
+			if s, ok := val.(string); ok {
+				payload[k] = qdrantStrVal(s)
+			}
+		}
+
+		vec32 := toFloat32(v.Vector)
+
+		point := &pb.PointStruct{
+			Id: &pb.PointId{
+				PointIdOptions: &pb.PointId_Uuid{Uuid: deterministicUUID(v.ID)},
+			},
+			Vectors: &pb.Vectors{
+				VectorsOptions: &pb.Vectors_Vector{
+					Vector: &pb.Vector{Data: vec32},
+				},
+			},
+			Payload: payload,
+		}
+
+		byCollection[collection] = append(byCollection[collection], point)
+	}
+
+	for collection, points := range byCollection {
+		_, err := q.pointsClient.Upsert(ctx, &pb.UpsertPoints{
+			CollectionName: collection,
+			Points:         points,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to upsert %d points into %s: %w", len(points), collection, err)
+		}
+	}
+
+	return nil
+}
+
+func (q *QdrantVectorStore) Query(ctx context.Context, query VectorQuery) ([]VectorResult, error) {
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+
+	// Determine which collections to search.
+	collections := collectionsForQuery(query)
+
+	var allResults []VectorResult
+	for _, collection := range collections {
+		var filter *pb.Filter
+		if len(query.NodeLabels) > 0 {
+			conditions := make([]*pb.Condition, 0, len(query.NodeLabels))
+			for _, label := range query.NodeLabels {
+				conditions = append(conditions, &pb.Condition{
+					ConditionOneOf: &pb.Condition_Field{
+						Field: &pb.FieldCondition{
+							Key: "nodeLabel",
+							Match: &pb.Match{
+								MatchValue: &pb.Match_Keyword{Keyword: label},
+							},
+						},
+					},
+				})
+			}
+			filter = &pb.Filter{Should: conditions}
+		}
+
+		resp, err := q.pointsClient.Query(ctx, &pb.QueryPoints{
+			CollectionName: collection,
+			Query: &pb.Query{
+				Variant: &pb.Query_Nearest{
+					Nearest: &pb.VectorInput{
+						Variant: &pb.VectorInput_Dense{
+							Dense: &pb.DenseVector{Data: toFloat32(query.Vector)},
+						},
+					},
+				},
+			},
+			Filter:      filter,
+			Limit:       pb.PtrOf(uint64(limit)),
+			WithPayload: &pb.WithPayloadSelector{SelectorOptions: &pb.WithPayloadSelector_Enable{Enable: true}},
+		})
+		if err != nil {
+			log.Printf("Warning: Qdrant query failed for collection %s: %v", collection, err)
+			continue
+		}
+
+		for _, pt := range resp.GetResult() {
+			metadata := make(map[string]any)
+			for k, v := range pt.GetPayload() {
+				if sv := v.GetStringValue(); sv != "" {
+					metadata[k] = sv
+				}
+			}
+
+			id := ""
+			if nk, ok := metadata["nodeKey"].(string); ok {
+				id = nk
+			}
+
+			allResults = append(allResults, VectorResult{
+				ID:       id,
+				Score:    float64(pt.GetScore()),
+				Metadata: metadata,
+			})
+		}
+	}
+
+	if len(allResults) > limit {
+		allResults = allResults[:limit]
+	}
+	return allResults, nil
+}
+
+func (q *QdrantVectorStore) DeleteVectors(ctx context.Context, ids []string) error {
+	// We don't know which collection(s) the IDs belong to, so we derive UUIDs
+	// and attempt deletion across common collections.
+	uuids := make([]*pb.PointId, len(ids))
+	for i, id := range ids {
+		uuids[i] = &pb.PointId{
+			PointIdOptions: &pb.PointId_Uuid{Uuid: deterministicUUID(id)},
+		}
+	}
+
+	// Try to delete from common collections.
+	for _, suffix := range []string{"function", "method", "class", "document", "feature"} {
+		// We don't know the dimension; attempt both common sizes.
+		for _, dim := range []int{768, 384} {
+			collection := fmt.Sprintf("%s_embeddings_%d", suffix, dim)
+			_, _ = q.pointsClient.Delete(ctx, &pb.DeletePoints{
+				CollectionName: collection,
+				Points: &pb.PointsSelector{
+					PointsSelectorOneOf: &pb.PointsSelector_Points{
+						Points: &pb.PointsIdsList{Ids: uuids},
+					},
+				},
+			})
+		}
+	}
+
+	return nil
+}
+
+// labelToIndexPrefix converts a Neo4j label to the index naming convention prefix.
+func labelToIndexPrefix(label string) string {
+	switch label {
+	case "Function":
+		return "function"
+	case "Class":
+		return "class"
+	case "Method":
+		return "method"
+	case "Document":
+		return "document"
+	case "Feature":
+		return "feature"
+	case "DocumentChunk":
+		return "docchunk"
+	default:
+		return "function"
+	}
+}
+
+// collectionForLabel maps a node label to a Qdrant collection name.
+func collectionForLabel(label string, dimensions int) string {
+	prefix := labelToIndexPrefix(label)
+	return fmt.Sprintf("%s_embeddings_%d", prefix, dimensions)
+}
+
+// collectionsForQuery determines which Qdrant collections to search.
+func collectionsForQuery(q VectorQuery) []string {
+	dim := len(q.Vector)
+
+	if q.IndexName != "" {
+		return []string{q.IndexName}
+	}
+
+	if len(q.NodeLabels) > 0 {
+		cols := make([]string, 0, len(q.NodeLabels))
+		for _, label := range q.NodeLabels {
+			cols = append(cols, collectionForLabel(label, dim))
+		}
+		return cols
+	}
+
+	// Default: search common collections.
+	return []string{
+		fmt.Sprintf("function_embeddings_%d", dim),
+		fmt.Sprintf("class_embeddings_%d", dim),
+		fmt.Sprintf("document_embeddings_%d", dim),
+	}
+}
+
+// deterministicUUID generates a deterministic UUID from a string key using SHA-256.
+func deterministicUUID(key string) string {
+	h := sha256.Sum256([]byte(key))
+	// Format as UUID v4 (variant bits set).
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		h[0:4],
+		h[4:6],
+		(h[6]&0x0f)|0x40, // Version 4.
+		(h[8]&0x3f)|0x80, // Variant.
+		h[10:16],
+	)
+}
+
+func qdrantStrVal(s string) *pb.Value {
+	return &pb.Value{Kind: &pb.Value_StringValue{StringValue: s}}
+}
+
+func toFloat32(v []float64) []float32 {
+	out := make([]float32, len(v))
+	for i, f := range v {
+		out[i] = float32(f)
+	}
+	return out
+}
+
+// ScrolledPoint is a lightweight point representation returned by ScrollPoints.
+type ScrolledPoint struct {
+	UUID    string            // Qdrant point UUID
+	Payload map[string]string // String payload fields (nodeKey, nodeLabel, name, etc.)
+}
+
+// ScrollPoints returns all points in a collection without their vectors.
+// It pages through results using Qdrant's scroll API.
+func (q *QdrantVectorStore) ScrollPoints(ctx context.Context, collection string) ([]ScrolledPoint, error) {
+	var all []ScrolledPoint
+	var offset *pb.PointId // nil means start from beginning
+
+	for {
+		resp, err := q.pointsClient.Scroll(ctx, &pb.ScrollPoints{
+			CollectionName: collection,
+			Limit:          pb.PtrOf(uint32(250)),
+			Offset:         offset,
+			WithPayload:    &pb.WithPayloadSelector{SelectorOptions: &pb.WithPayloadSelector_Enable{Enable: true}},
+			WithVectors:    &pb.WithVectorsSelector{SelectorOptions: &pb.WithVectorsSelector_Enable{Enable: false}},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scroll failed for %s: %w", collection, err)
+		}
+
+		for _, pt := range resp.GetResult() {
+			sp := ScrolledPoint{Payload: make(map[string]string)}
+			if u, ok := pt.Id.GetPointIdOptions().(*pb.PointId_Uuid); ok {
+				sp.UUID = u.Uuid
+			}
+			for k, v := range pt.GetPayload() {
+				if sv := v.GetStringValue(); sv != "" {
+					sp.Payload[k] = sv
+				}
+			}
+			all = append(all, sp)
+		}
+
+		if resp.GetNextPageOffset() == nil {
+			break
+		}
+		offset = resp.GetNextPageOffset()
+	}
+
+	return all, nil
+}
+
+// SetPayloadFields merges extra payload fields onto existing Qdrant points.
+// pointUUIDs and payloads must be the same length.
+func (q *QdrantVectorStore) SetPayloadFields(ctx context.Context, collection string, pointUUIDs []string, payloads []map[string]string) error {
+	if len(pointUUIDs) == 0 {
+		return nil
+	}
+
+	// Qdrant's SetPayload operates on one point at a time or with a filter.
+	// Batch by sending up to 100 per RPC using OverwritePayload with point IDs.
+	const batchSize = 100
+	for i := 0; i < len(pointUUIDs); i += batchSize {
+		end := i + batchSize
+		if end > len(pointUUIDs) {
+			end = len(pointUUIDs)
+		}
+
+		for j := i; j < end; j++ {
+			payload := make(map[string]*pb.Value, len(payloads[j]))
+			for k, v := range payloads[j] {
+				payload[k] = qdrantStrVal(v)
+			}
+			_, err := q.pointsClient.SetPayload(ctx, &pb.SetPayloadPoints{
+				CollectionName: collection,
+				Payload:        payload,
+				PointsSelector: &pb.PointsSelector{
+					PointsSelectorOneOf: &pb.PointsSelector_Points{
+						Points: &pb.PointsIdsList{
+							Ids: []*pb.PointId{{
+								PointIdOptions: &pb.PointId_Uuid{Uuid: pointUUIDs[j]},
+							}},
+						},
+					},
+				},
+			})
+			if err != nil {
+				log.Printf("Warning: SetPayload failed for %s point %s: %v", collection, pointUUIDs[j], err)
+			}
+		}
+	}
+	return nil
+}
+
+// Compile-time interface check.
+var _ VectorStore = (*QdrantVectorStore)(nil)

--- a/libs/vector-client-go/vector_store.go
+++ b/libs/vector-client-go/vector_store.go
@@ -1,0 +1,43 @@
+package search
+
+import "context"
+
+// VectorUpsert represents a single vector to upsert into the store.
+type VectorUpsert struct {
+	ID         string            // Unique identifier (e.g., nodeKey or elementId).
+	Vector     []float64         // The embedding vector.
+	Metadata   map[string]any    // Optional metadata to store alongside the vector.
+	NodeLabel  string            // The Neo4j label (for stores that support label filtering).
+}
+
+// VectorQuery represents a vector similarity query.
+type VectorQuery struct {
+	Vector     []float64         // The query vector.
+	Limit      int               // Maximum number of results.
+	Filters    map[string]any    // Optional metadata filters.
+	NodeLabels []string          // Optional label filter (for stores that support it).
+	IndexName  string            // Optional: specific index to query (store-specific).
+}
+
+// VectorResult represents a single result from a vector search.
+type VectorResult struct {
+	ID       string         // The matched vector's ID.
+	Score    float64        // Similarity score (higher = more similar for cosine).
+	Metadata map[string]any // Metadata associated with the vector.
+}
+
+// VectorStore defines the interface for storing and querying vectors.
+// Implementations may use Neo4j vector indexes, Qdrant, Pinecone, etc.
+type VectorStore interface {
+	// UpsertVectors stores or updates vectors in the store.
+	UpsertVectors(ctx context.Context, vectors []VectorUpsert) error
+
+	// Query finds the k most similar vectors to the given query.
+	Query(ctx context.Context, query VectorQuery) ([]VectorResult, error)
+
+	// DeleteVectors removes vectors by their IDs.
+	DeleteVectors(ctx context.Context, ids []string) error
+
+	// CreateIndex creates a vector index (if the store supports explicit index creation).
+	CreateIndex(ctx context.Context, name string, dimensions int, similarity string) error
+}


### PR DESCRIPTION
## Summary

Stacked on: #18 (phase0+1)

Copies three shared library packages to their target locations under `libs/` using the **copy-forward strategy** — originals in `pkg/` are kept in place so all existing importers continue working with zero changes.

## Packages migrated

| Source | Destination | Notes |
|--------|-------------|-------|
| `pkg/models/` | `libs/core-models-go/` | All 7 files: node, nodekey, relationship, scope, symbol, tombstone, import |
| `pkg/neo4j/` | `libs/neo4j-client-go/` | client.go + query.go; internal import updated to `libs/core-models-go` |
| `pkg/search/vector_store.go` + `qdrant_vector_store.go` | `libs/vector-client-go/` | Interface + Qdrant implementation |

## Nx projects added

Each new lib directory now has a `project.json` with `build` and `test` targets wired to `go build`/`go test`.

## Shim strategy

Old `pkg/` files are **not deleted** in this phase. Future phase (cleanup) will remove them once all importers have been updated to use `libs/` paths.

## Validation

```
go build ./libs/core-models-go/...    ✓
go build ./libs/neo4j-client-go/...   ✓
go build ./libs/vector-client-go/...  ✓
go build ./...                         ✓  (all existing pkg/ importers still work)
go test ./pkg/... ./libs/...           ✓  (all unit tests pass)
```

## Test plan

- [ ] `go build ./libs/...` passes
- [ ] `go build ./...` (full module) passes
- [ ] `go test ./pkg/... ./libs/...` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)