### PR TITLE
feat(monorepo phase2-services): copy indexing/retrieval service packages to services/

### DIFF
--- a/services/indexing-go/documents/confluence.go
+++ b/services/indexing-go/documents/confluence.go
@@ -1,0 +1,255 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ConfluenceConnector fetches documents from Atlassian Confluence via REST API v2.
+type ConfluenceConnector struct {
+	baseURL    string // e.g., "https://your-domain.atlassian.net/wiki"
+	username   string // Atlassian account email
+	apiToken   string // API token (not password)
+	httpClient *http.Client
+}
+
+// ConfluenceConfig holds configuration for connecting to Confluence.
+type ConfluenceConfig struct {
+	BaseURL  string
+	Username string
+	APIToken string
+}
+
+// NewConfluenceConnector creates a new Confluence connector.
+func NewConfluenceConnector(cfg ConfluenceConfig) *ConfluenceConnector {
+	return &ConfluenceConnector{
+		baseURL:  strings.TrimRight(cfg.BaseURL, "/"),
+		username: cfg.Username,
+		apiToken: cfg.APIToken,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (c *ConfluenceConnector) Name() string { return "confluence" }
+
+// ListDocuments lists pages in a Confluence space using the v2 REST API.
+func (c *ConfluenceConnector) ListDocuments(ctx context.Context, space string) ([]ExternalDocument, error) {
+	endpoint := fmt.Sprintf("%s/api/v2/spaces?keys=%s", c.baseURL, url.QueryEscape(space))
+
+	// First, get the space ID.
+	spaceResp, err := c.doRequest(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get space %s: %w", space, err)
+	}
+
+	var spacesResult struct {
+		Results []struct {
+			ID   string `json:"id"`
+			Key  string `json:"key"`
+			Name string `json:"name"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(spaceResp, &spacesResult); err != nil {
+		return nil, fmt.Errorf("failed to parse space response: %w", err)
+	}
+	if len(spacesResult.Results) == 0 {
+		return nil, fmt.Errorf("space %s not found", space)
+	}
+
+	spaceID := spacesResult.Results[0].ID
+
+	// List pages in the space.
+	pagesEndpoint := fmt.Sprintf("%s/api/v2/spaces/%s/pages?limit=100&body-format=storage", c.baseURL, spaceID)
+	pagesResp, err := c.doRequest(ctx, pagesEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pages: %w", err)
+	}
+
+	var pagesResult struct {
+		Results []confluencePageV2 `json:"results"`
+	}
+	if err := json.Unmarshal(pagesResp, &pagesResult); err != nil {
+		return nil, fmt.Errorf("failed to parse pages response: %w", err)
+	}
+
+	var docs []ExternalDocument
+	for _, page := range pagesResult.Results {
+		docs = append(docs, ExternalDocument{
+			ID:        page.ID,
+			Title:     page.Title,
+			SourceURL: fmt.Sprintf("%s/pages/%s", c.baseURL, page.ID),
+			Source:    "confluence",
+			Metadata: map[string]string{
+				"space":  space,
+				"status": page.Status,
+			},
+		})
+	}
+
+	return docs, nil
+}
+
+// FetchDocument retrieves a single Confluence page by ID and converts its content to markdown.
+func (c *ConfluenceConnector) FetchDocument(ctx context.Context, docID string) (*ExternalDocument, error) {
+	endpoint := fmt.Sprintf("%s/api/v2/pages/%s?body-format=storage", c.baseURL, url.PathEscape(docID))
+	body, err := c.doRequest(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch page %s: %w", docID, err)
+	}
+
+	var page confluencePageV2
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("failed to parse page response: %w", err)
+	}
+
+	content := ""
+	if page.Body.Storage.Value != "" {
+		content = confluenceStorageToMarkdown(page.Body.Storage.Value)
+	}
+
+	updatedAt := time.Time{}
+	if page.Version.CreatedAt != "" {
+		updatedAt, _ = time.Parse(time.RFC3339, page.Version.CreatedAt)
+	}
+
+	return &ExternalDocument{
+		ID:        page.ID,
+		Title:     page.Title,
+		Content:   content,
+		SourceURL: fmt.Sprintf("%s/pages/%s", c.baseURL, page.ID),
+		Source:    "confluence",
+		UpdatedAt: updatedAt,
+		Metadata: map[string]string{
+			"status":  page.Status,
+			"version": fmt.Sprintf("%d", page.Version.Number),
+		},
+	}, nil
+}
+
+// doRequest performs an authenticated GET request and returns the response body.
+func (c *ConfluenceConnector) doRequest(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.username, c.apiToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("confluence API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// confluencePageV2 represents a Confluence page from the v2 API.
+type confluencePageV2 struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
+	Body   struct {
+		Storage struct {
+			Value string `json:"value"`
+		} `json:"storage"`
+	} `json:"body"`
+	Version struct {
+		Number    int    `json:"number"`
+		CreatedAt string `json:"createdAt"`
+	} `json:"version"`
+}
+
+// confluenceStorageToMarkdown converts Confluence storage format (XHTML) to markdown.
+// This is a simplified converter that handles common elements.
+func confluenceStorageToMarkdown(storage string) string {
+	s := storage
+
+	// Headers: <h1> through <h6>
+	for i := 6; i >= 1; i-- {
+		prefix := strings.Repeat("#", i)
+		openTag := fmt.Sprintf("<h%d[^>]*>", i)
+		closeTag := fmt.Sprintf("</h%d>", i)
+		s = regexp.MustCompile(openTag).ReplaceAllString(s, prefix+" ")
+		s = strings.ReplaceAll(s, closeTag, "\n\n")
+	}
+
+	// Paragraphs
+	s = regexp.MustCompile(`<p[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</p>", "\n\n")
+
+	// Bold and italic
+	s = regexp.MustCompile(`<strong[^>]*>`).ReplaceAllString(s, "**")
+	s = strings.ReplaceAll(s, "</strong>", "**")
+	s = regexp.MustCompile(`<em[^>]*>`).ReplaceAllString(s, "*")
+	s = strings.ReplaceAll(s, "</em>", "*")
+
+	// Code blocks
+	s = regexp.MustCompile(`<ac:structured-macro[^>]*ac:name="code"[^>]*>.*?<ac:plain-text-body><!\[CDATA\[(.*?)\]\]></ac:plain-text-body></ac:structured-macro>`).
+		ReplaceAllString(s, "```\n$1\n```\n")
+
+	// Inline code
+	s = regexp.MustCompile(`<code[^>]*>`).ReplaceAllString(s, "`")
+	s = strings.ReplaceAll(s, "</code>", "`")
+
+	// Lists
+	s = regexp.MustCompile(`<ul[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</ul>", "\n")
+	s = regexp.MustCompile(`<ol[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</ol>", "\n")
+	s = regexp.MustCompile(`<li[^>]*>`).ReplaceAllString(s, "- ")
+	s = strings.ReplaceAll(s, "</li>", "\n")
+
+	// Links
+	s = regexp.MustCompile(`<a[^>]*href="([^"]*)"[^>]*>(.*?)</a>`).
+		ReplaceAllString(s, "[$2]($1)")
+
+	// Images
+	s = regexp.MustCompile(`<ac:image[^>]*><ri:url ri:value="([^"]*)"[^/]*/></ac:image>`).
+		ReplaceAllString(s, "![]($1)")
+
+	// Tables (simplified)
+	s = regexp.MustCompile(`<table[^>]*>`).ReplaceAllString(s, "\n")
+	s = strings.ReplaceAll(s, "</table>", "\n")
+	s = regexp.MustCompile(`<tr[^>]*>`).ReplaceAllString(s, "| ")
+	s = strings.ReplaceAll(s, "</tr>", " |\n")
+	s = regexp.MustCompile(`<t[hd][^>]*>`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`</t[hd]>`).ReplaceAllString(s, " | ")
+	s = regexp.MustCompile(`<tbody[^>]*>`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "</tbody>", "")
+
+	// Strip remaining HTML tags
+	s = regexp.MustCompile(`<[^>]+>`).ReplaceAllString(s, "")
+
+	// Clean up HTML entities
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&quot;", "\"")
+	s = strings.ReplaceAll(s, "&#39;", "'")
+	s = strings.ReplaceAll(s, "&nbsp;", " ")
+
+	// Normalize whitespace
+	s = regexp.MustCompile(`\n{3,}`).ReplaceAllString(s, "\n\n")
+	s = strings.TrimSpace(s)
+
+	return s
+}

--- a/services/indexing-go/documents/connector.go
+++ b/services/indexing-go/documents/connector.go
@@ -1,0 +1,29 @@
+package documents
+
+import (
+	"context"
+	"time"
+)
+
+// ExternalDocument represents a document fetched from an external source.
+type ExternalDocument struct {
+	ID        string            // Unique identifier in the source system.
+	Title     string            // Human-readable title.
+	Content   string            // Markdown or plain-text content.
+	SourceURL string            // Canonical URL to the document.
+	Source    string            // Source system name (e.g., "confluence", "gdocs").
+	UpdatedAt time.Time         // Last modification time in the source.
+	Metadata  map[string]string // Arbitrary key-value metadata from the source.
+}
+
+// DocConnector defines the interface for fetching documents from external systems.
+type DocConnector interface {
+	// Name returns the connector name (e.g., "confluence", "gdocs").
+	Name() string
+
+	// ListDocuments returns a list of document IDs/URLs available in the given space/collection.
+	ListDocuments(ctx context.Context, space string) ([]ExternalDocument, error)
+
+	// FetchDocument retrieves a single document by its ID or URL and returns normalized content.
+	FetchDocument(ctx context.Context, docID string) (*ExternalDocument, error)
+}

--- a/services/indexing-go/documents/indexer.go
+++ b/services/indexing-go/documents/indexer.go
@@ -1,0 +1,445 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+	"github.com/context-maximiser/code-graph/pkg/search"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+)
+
+// DocumentIndexer handles indexing documents into Neo4j
+type DocumentIndexer struct {
+	client                *neo4j.Client
+	parser                *DocumentParser
+	intelligentLinker     *search.IntelligentDocumentLinker
+	chunkLinker           *search.ChunkLinker
+	useIntelligentLinking bool
+	scopeCtx              models.ScopeContext
+}
+
+// NewDocumentIndexer creates a new document indexer
+func NewDocumentIndexer(client *neo4j.Client) *DocumentIndexer {
+	return &DocumentIndexer{
+		client:                client,
+		parser:                NewDocumentParser(),
+		chunkLinker:           search.NewChunkLinker(client),
+		useIntelligentLinking: false,
+		scopeCtx:              models.DefaultScope(),
+	}
+}
+
+// SetScope sets the scope context for the document indexer.
+func (di *DocumentIndexer) SetScope(scope models.ScopeContext) {
+	di.scopeCtx = scope
+}
+
+// EnableIntelligentLinking enables semantic analysis and intelligent linking
+func (di *DocumentIndexer) EnableIntelligentLinking(embeddingService search.EmbeddingService, vectorStore search.VectorStore) {
+	di.intelligentLinker = search.NewIntelligentDocumentLinker(di.client, embeddingService, vectorStore)
+	di.useIntelligentLinking = true
+}
+
+// IndexDocument indexes a single document file
+func (di *DocumentIndexer) IndexDocument(ctx context.Context, filePath string) error {
+	fmt.Printf("Indexing document: %s\n", filePath)
+
+	// Parse the document
+	doc, features, err := di.parser.ParseDocument(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse document %s: %w", filePath, err)
+	}
+
+	fmt.Printf("Extracted %d features from document\n", len(features))
+
+	// Create document node
+	docID, err := di.createDocumentNode(ctx, doc)
+	if err != nil {
+		return fmt.Errorf("failed to create document node: %w", err)
+	}
+
+	// Create feature nodes and relationships
+	for _, feature := range features {
+		featureID, err := di.createFeatureNode(ctx, feature)
+		if err != nil {
+			fmt.Printf("Warning: failed to create feature node for %s: %v\n", feature.Name, err)
+			continue
+		}
+
+		// Create DESCRIBES relationship from document to feature
+		_, err = di.client.CreateRelationship(ctx, docID, featureID, "DESCRIBES",
+			map[string]any{"scope": di.scopeCtx.Scope, "scopeId": di.scopeCtx.ScopeID})
+		if err != nil {
+			fmt.Printf("Warning: failed to create DESCRIBES relationship: %v\n", err)
+		}
+	}
+
+	// Create document chunks
+	docNodeKey := models.DocumentNodeKey(doc.SourceURL)
+	chunkStats, err := di.createDocumentChunks(ctx, docID, docNodeKey, doc.Content)
+	if err != nil {
+		fmt.Printf("Warning: failed to create document chunks: %v\n", err)
+	} else {
+		fmt.Printf("Chunks: %d total, %d created, %d unchanged, %d updated\n",
+			chunkStats.Total, chunkStats.Created, chunkStats.Unchanged, chunkStats.Updated)
+	}
+
+	// Create chunk-level MENTIONS links with provenance.
+	if di.chunkLinker != nil {
+		docNodeKey2 := models.DocumentNodeKey(doc.SourceURL)
+		linkCount, err := di.chunkLinker.LinkChunksForDocument(ctx, docNodeKey2, di.scopeCtx.ScopeID)
+		if err != nil {
+			fmt.Printf("Warning: chunk-level linking failed: %v\n", err)
+		} else if linkCount > 0 {
+			fmt.Printf("Chunk MENTIONS links: %d\n", linkCount)
+		}
+	}
+
+	// Create relationships to code symbols using intelligent or simple linking
+	if err := di.linkToCodeSymbols(ctx, docID, doc.Content); err != nil {
+		fmt.Printf("Warning: failed to link to code symbols: %v\n", err)
+	}
+
+	fmt.Printf("Successfully indexed document: %s\n", doc.Title)
+	return nil
+}
+
+// chunkStats tracks incremental chunk update statistics.
+type chunkStats struct {
+	Total     int
+	Created   int
+	Updated   int
+	Unchanged int
+}
+
+// createDocumentChunks creates DocumentChunk nodes linked to the parent Document via HAS_CHUNK.
+// Uses textHash for incremental updates — only changed chunks are written.
+func (di *DocumentIndexer) createDocumentChunks(ctx context.Context, docID, docNodeKey, content string) (chunkStats, error) {
+	chunks := di.parser.ChunkDocumentWithMeta(content)
+	var stats chunkStats
+	stats.Total = len(chunks)
+
+	// Load existing chunk hashes for this document to detect changes.
+	existingHashes, err := di.loadExistingChunkHashes(ctx, docNodeKey)
+	if err != nil {
+		// Non-fatal: just index all chunks.
+		fmt.Printf("Warning: could not load existing chunk hashes: %v\n", err)
+		existingHashes = map[string]string{}
+	}
+
+	for _, chunk := range chunks {
+		chunkNodeKey := models.DocumentChunkNodeKey(docNodeKey, chunk.ChunkIndex)
+
+		// Check if chunk already exists with the same hash.
+		if existingHash, exists := existingHashes[chunkNodeKey]; exists && existingHash == chunk.TextHash {
+			stats.Unchanged++
+			delete(existingHashes, chunkNodeKey) // Mark as still present.
+			continue
+		}
+
+		if _, exists := existingHashes[chunkNodeKey]; exists {
+			stats.Updated++
+		} else {
+			stats.Created++
+		}
+		delete(existingHashes, chunkNodeKey)
+
+		chunkProps := map[string]any{
+			"documentKey": docNodeKey,
+			"chunkIndex":  chunk.ChunkIndex,
+			"headingPath": chunk.HeadingPath,
+			"content":     chunk.Content,
+			"textHash":    chunk.TextHash,
+			"startOffset": chunk.StartOffset,
+			"endOffset":   chunk.EndOffset,
+			"nodeKey":     chunkNodeKey,
+			"scope":       di.scopeCtx.Scope,
+			"scopeId":     di.scopeCtx.ScopeID,
+		}
+
+		chunkID, err := di.client.MergeNode(ctx, []string{"DocumentChunk"},
+			map[string]any{"nodeKey": chunkNodeKey, "scopeId": di.scopeCtx.ScopeID}, chunkProps)
+		if err != nil {
+			return stats, fmt.Errorf("failed to create chunk %d: %w", chunk.ChunkIndex, err)
+		}
+
+		// Create HAS_CHUNK relationship from Document to DocumentChunk.
+		_, err = di.client.MergeRelationship(ctx, docID, chunkID, "HAS_CHUNK",
+			map[string]any{"chunkIndex": chunk.ChunkIndex},
+			map[string]any{"chunkIndex": chunk.ChunkIndex, "scope": di.scopeCtx.Scope, "scopeId": di.scopeCtx.ScopeID})
+		if err != nil {
+			return stats, fmt.Errorf("failed to create HAS_CHUNK for chunk %d: %w", chunk.ChunkIndex, err)
+		}
+	}
+
+	// Remove stale chunks that no longer exist in the document.
+	for staleKey := range existingHashes {
+		di.deleteStaleChunk(ctx, staleKey)
+	}
+
+	return stats, nil
+}
+
+// loadExistingChunkHashes queries Neo4j for existing DocumentChunk nodes for this document and scope.
+func (di *DocumentIndexer) loadExistingChunkHashes(ctx context.Context, docNodeKey string) (map[string]string, error) {
+	cypher := `MATCH (c:DocumentChunk {documentKey: $docKey, scopeId: $scopeId})
+RETURN c.nodeKey AS nodeKey, c.textHash AS textHash`
+	params := map[string]any{
+		"docKey":  docNodeKey,
+		"scopeId": di.scopeCtx.ScopeID,
+	}
+	results, err := di.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, err
+	}
+	hashes := make(map[string]string, len(results))
+	for _, record := range results {
+		m := record.AsMap()
+		nk, _ := m["nodeKey"].(string)
+		th, _ := m["textHash"].(string)
+		if nk != "" {
+			hashes[nk] = th
+		}
+	}
+	return hashes, nil
+}
+
+// deleteStaleChunk removes a DocumentChunk node that no longer corresponds to any chunk in the document.
+func (di *DocumentIndexer) deleteStaleChunk(ctx context.Context, chunkNodeKey string) {
+	cypher := `MATCH (c:DocumentChunk {nodeKey: $nodeKey, scopeId: $scopeId}) DETACH DELETE c`
+	params := map[string]any{
+		"nodeKey": chunkNodeKey,
+		"scopeId": di.scopeCtx.ScopeID,
+	}
+	if _, err := di.client.ExecuteQuery(ctx, cypher, params); err != nil {
+		fmt.Printf("Warning: failed to delete stale chunk %s: %v\n", chunkNodeKey, err)
+	}
+}
+
+// IndexDirectory recursively indexes all documents in a directory
+func (di *DocumentIndexer) IndexDirectory(ctx context.Context, dirPath string) error {
+	fmt.Printf("Indexing documents in directory: %s\n", dirPath)
+
+	return filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Only process document files
+		if di.isDocumentFile(path) {
+			if err := di.IndexDocument(ctx, path); err != nil {
+				fmt.Printf("Warning: failed to index %s: %v\n", path, err)
+				// Continue processing other files
+			}
+		}
+
+		return nil
+	})
+}
+
+// createDocumentNode creates a Document node in Neo4j
+func (di *DocumentIndexer) createDocumentNode(ctx context.Context, doc *models.Document) (string, error) {
+	nodeKey := models.DocumentNodeKey(doc.SourceURL)
+	docProps := map[string]any{
+		"title":     doc.Title,
+		"type":      doc.Type,
+		"sourceUrl": doc.SourceURL,
+		"content":   doc.Content,
+		"nodeKey":   nodeKey,
+		"scope":     di.scopeCtx.Scope,
+		"scopeId":   di.scopeCtx.ScopeID,
+	}
+
+	return di.client.MergeNode(ctx, []string{"Document"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": di.scopeCtx.ScopeID}, docProps)
+}
+
+// createFeatureNode creates a Feature node in Neo4j
+func (di *DocumentIndexer) createFeatureNode(ctx context.Context, feature *models.Feature) (string, error) {
+	nodeKey := models.FeatureNodeKey(feature.Name)
+	featureProps := map[string]any{
+		"name":        feature.Name,
+		"description": feature.Description,
+		"status":      feature.Status,
+		"priority":    feature.Priority,
+		"tags":        feature.Tags,
+		"nodeKey":     nodeKey,
+		"scope":       di.scopeCtx.Scope,
+		"scopeId":     di.scopeCtx.ScopeID,
+	}
+
+	return di.client.MergeNode(ctx, []string{"Feature"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": di.scopeCtx.ScopeID}, featureProps)
+}
+
+// linkToCodeSymbols creates MENTIONS relationships between documents and code symbols
+func (di *DocumentIndexer) linkToCodeSymbols(ctx context.Context, docID string, content string) error {
+	if di.useIntelligentLinking && di.intelligentLinker != nil {
+		// Use intelligent semantic linking
+		result, err := di.intelligentLinker.LinkDocumentToCode(ctx, docID, content)
+		if err != nil {
+			fmt.Printf("Warning: intelligent linking failed, falling back to simple linking: %v\n", err)
+			return di.simpleLinkToCodeSymbols(ctx, docID, content)
+		}
+
+		fmt.Printf("Intelligent linking created %d relationships (%d direct, %d semantic, %d call graph)\n",
+			result.CreatedLinks, len(result.DirectMatches), len(result.SemanticMatches), len(result.CallGraphMatches))
+		return nil
+	}
+
+	// Use simple backtick-based linking
+	return di.simpleLinkToCodeSymbols(ctx, docID, content)
+}
+
+// simpleLinkToCodeSymbols creates MENTIONS relationships using simple backtick extraction
+func (di *DocumentIndexer) simpleLinkToCodeSymbols(ctx context.Context, docID string, content string) error {
+	symbols := extractCodeSymbols(content)
+
+	for _, symbolRef := range symbols {
+		// Try to find matching Symbol nodes in the database
+		cypher := `
+			MATCH (s:Symbol)
+			WHERE s.symbol CONTAINS $symbolRef OR s.displayName CONTAINS $symbolRef
+			RETURN s
+			LIMIT 5
+		`
+
+		results, err := di.client.ExecuteQuery(ctx, cypher, map[string]any{
+			"symbolRef": symbolRef,
+		})
+		if err != nil {
+			continue // Skip if query fails
+		}
+
+		// Create MENTIONS relationships to found symbols
+		for _, record := range results {
+			recordMap := record.AsMap()
+			if symbolObj, ok := recordMap["s"]; ok {
+				if symbolNode, ok := symbolObj.(dbtype.Node); ok {
+					_, err = di.client.CreateRelationship(ctx, docID, symbolNode.ElementId, "MENTIONS",
+						map[string]any{"context": symbolRef, "scope": di.scopeCtx.Scope, "scopeId": di.scopeCtx.ScopeID})
+					if err != nil {
+						continue // Skip failed relationships
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// isDocumentFile checks if a file should be processed as a document
+func (di *DocumentIndexer) isDocumentFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	documentExts := map[string]bool{
+		".md":  true,
+		".txt": true,
+		".rst": true,
+		".adoc": true,
+	}
+	
+	return documentExts[ext]
+}
+
+// GetDocumentStats returns statistics about indexed documents
+func (di *DocumentIndexer) GetDocumentStats(ctx context.Context) (map[string]any, error) {
+	cypher := `
+		MATCH (d:Document)
+		OPTIONAL MATCH (d)-[:DESCRIBES]->(f:Feature)
+		OPTIONAL MATCH (d)-[:MENTIONS]->(s:Symbol)
+		RETURN 
+			count(DISTINCT d) as documentCount,
+			count(DISTINCT f) as featureCount,
+			count(DISTINCT s) as mentionedSymbolCount,
+			collect(DISTINCT d.type) as documentTypes
+	`
+	
+	results, err := di.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get document stats: %w", err)
+	}
+	
+	if len(results) > 0 {
+		return results[0].AsMap(), nil
+	}
+	
+	return map[string]any{}, nil
+}
+
+// SyncExternalDocument fetches a document from an external connector and indexes it.
+func (di *DocumentIndexer) SyncExternalDocument(ctx context.Context, connector DocConnector, docID string) error {
+	extDoc, err := connector.FetchDocument(ctx, docID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch document %s: %w", docID, err)
+	}
+
+	return di.indexExternalDocument(ctx, extDoc)
+}
+
+// SyncExternalSpace fetches all documents from a space and indexes them.
+func (di *DocumentIndexer) SyncExternalSpace(ctx context.Context, connector DocConnector, space string) (int, error) {
+	docs, err := connector.ListDocuments(ctx, space)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list documents in space %s: %w", space, err)
+	}
+
+	synced := 0
+	for _, doc := range docs {
+		fmt.Printf("Syncing: %s (%s)\n", doc.Title, doc.ID)
+		extDoc, err := connector.FetchDocument(ctx, doc.ID)
+		if err != nil {
+			fmt.Printf("Warning: failed to fetch %s: %v\n", doc.ID, err)
+			continue
+		}
+		if err := di.indexExternalDocument(ctx, extDoc); err != nil {
+			fmt.Printf("Warning: failed to index %s: %v\n", doc.ID, err)
+			continue
+		}
+		synced++
+	}
+
+	return synced, nil
+}
+
+// indexExternalDocument indexes a single external document with chunks.
+func (di *DocumentIndexer) indexExternalDocument(ctx context.Context, extDoc *ExternalDocument) error {
+	doc := &models.Document{
+		Title:     extDoc.Title,
+		Type:      fmt.Sprintf("External/%s", extDoc.Source),
+		SourceURL: extDoc.SourceURL,
+		Content:   extDoc.Content,
+	}
+
+	docID, err := di.createDocumentNode(ctx, doc)
+	if err != nil {
+		return fmt.Errorf("failed to create document node: %w", err)
+	}
+
+	// Create chunks.
+	docNodeKey := models.DocumentNodeKey(extDoc.SourceURL)
+	chunkStats, err := di.createDocumentChunks(ctx, docID, docNodeKey, extDoc.Content)
+	if err != nil {
+		return fmt.Errorf("failed to create chunks: %w", err)
+	}
+
+	fmt.Printf("  Chunks: %d total, %d created, %d unchanged, %d updated\n",
+		chunkStats.Total, chunkStats.Created, chunkStats.Unchanged, chunkStats.Updated)
+
+	// Link to code symbols.
+	if err := di.linkToCodeSymbols(ctx, docID, extDoc.Content); err != nil {
+		fmt.Printf("  Warning: failed to link to code symbols: %v\n", err)
+	}
+
+	return nil
+}

--- a/services/indexing-go/documents/parser.go
+++ b/services/indexing-go/documents/parser.go
@@ -1,0 +1,494 @@
+package documents
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+)
+
+// ChunkMeta holds metadata for a document chunk produced by the parser.
+type ChunkMeta struct {
+	Content     string // The chunk text
+	HeadingPath string // Heading hierarchy, e.g. "Architecture > Components"
+	StartOffset int    // Byte offset in original document
+	EndOffset   int    // Byte offset end
+	ChunkIndex  int    // 0-based index within document
+	TextHash    string // SHA-256 hex of Content
+}
+
+// DocumentParser handles parsing and feature extraction from documents
+type DocumentParser struct {
+	chunkSize int
+}
+
+// NewDocumentParser creates a new document parser
+func NewDocumentParser() *DocumentParser {
+	return &DocumentParser{
+		chunkSize: 1000, // Default chunk size in words
+	}
+}
+
+// ParseDocument processes a document file and extracts features
+func (dp *DocumentParser) ParseDocument(filePath string) (*models.Document, []*models.Feature, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read document: %w", err)
+	}
+
+	// Extract document metadata
+	doc := &models.Document{
+		Title:     extractTitle(string(content)),
+		Type:      inferDocumentType(filePath),
+		SourceURL: filePath,
+		Content:   string(content),
+	}
+
+	// Extract features using simulated LLM processing
+	features, err := dp.extractFeatures(string(content), filePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract features: %w", err)
+	}
+
+	return doc, features, nil
+}
+
+// ChunkDocument breaks a document into smaller, semantically coherent chunks
+func (dp *DocumentParser) ChunkDocument(content string) []string {
+	// Split by paragraphs first
+	paragraphs := strings.Split(content, "\n\n")
+	var chunks []string
+	var currentChunk strings.Builder
+	wordCount := 0
+
+	for _, paragraph := range paragraphs {
+		// Clean up the paragraph
+		paragraph = strings.TrimSpace(paragraph)
+		if paragraph == "" {
+			continue
+		}
+
+		// Count words in this paragraph
+		words := strings.Fields(paragraph)
+		paragraphWordCount := len(words)
+
+		// If adding this paragraph would exceed chunk size, save current chunk
+		if wordCount+paragraphWordCount > dp.chunkSize && currentChunk.Len() > 0 {
+			chunks = append(chunks, currentChunk.String())
+			currentChunk.Reset()
+			wordCount = 0
+		}
+
+		// Add paragraph to current chunk
+		if currentChunk.Len() > 0 {
+			currentChunk.WriteString("\n\n")
+		}
+		currentChunk.WriteString(paragraph)
+		wordCount += paragraphWordCount
+	}
+
+	// Add remaining content as final chunk
+	if currentChunk.Len() > 0 {
+		chunks = append(chunks, currentChunk.String())
+	}
+
+	return chunks
+}
+
+// ChunkDocumentWithMeta breaks a document into chunks with heading paths, offsets, and text hashes.
+func (dp *DocumentParser) ChunkDocumentWithMeta(content string) []ChunkMeta {
+	headingRe := regexp.MustCompile(`(?m)^(#{1,6})\s+(.+)$`)
+
+	// Split into paragraphs (double newline separated).
+	paragraphs := strings.Split(content, "\n\n")
+
+	var chunks []ChunkMeta
+	var currentText strings.Builder
+	wordCount := 0
+	chunkStart := 0 // byte offset of the start of the current chunk
+	bytePos := 0    // running byte offset
+	chunkIndex := 0
+
+	// Track heading stack: headings[0] = h1, headings[1] = h2, etc.
+	headings := make([]string, 6)
+
+	flushChunk := func() {
+		text := currentText.String()
+		if strings.TrimSpace(text) == "" {
+			return
+		}
+		h := sha256.Sum256([]byte(text))
+		chunks = append(chunks, ChunkMeta{
+			Content:     text,
+			HeadingPath: buildHeadingPath(headings),
+			StartOffset: chunkStart,
+			EndOffset:   chunkStart + len(text),
+			ChunkIndex:  chunkIndex,
+			TextHash:    hex.EncodeToString(h[:]),
+		})
+		chunkIndex++
+		currentText.Reset()
+		wordCount = 0
+	}
+
+	for i, paragraph := range paragraphs {
+		paragraph = strings.TrimSpace(paragraph)
+		if paragraph == "" {
+			// Account for the double-newline separator.
+			if i < len(paragraphs)-1 {
+				bytePos += 2
+			}
+			continue
+		}
+
+		// Check if this paragraph is/contains a heading and update the stack.
+		for _, line := range strings.Split(paragraph, "\n") {
+			if m := headingRe.FindStringSubmatch(line); m != nil {
+				level := len(m[1]) - 1 // 0-indexed
+				headings[level] = strings.TrimSpace(m[2])
+				// Clear deeper headings.
+				for j := level + 1; j < 6; j++ {
+					headings[j] = ""
+				}
+			}
+		}
+
+		paragraphWords := len(strings.Fields(paragraph))
+
+		// If adding this paragraph would exceed chunk size, flush.
+		if wordCount+paragraphWords > dp.chunkSize && currentText.Len() > 0 {
+			flushChunk()
+			chunkStart = bytePos
+		}
+
+		if currentText.Len() > 0 {
+			currentText.WriteString("\n\n")
+		}
+		currentText.WriteString(paragraph)
+		wordCount += paragraphWords
+
+		// Advance byte position past the paragraph + separator.
+		bytePos += len(paragraph)
+		if i < len(paragraphs)-1 {
+			bytePos += 2 // the \n\n separator
+		}
+	}
+
+	flushChunk()
+	return chunks
+}
+
+// buildHeadingPath joins non-empty heading levels with " > ".
+func buildHeadingPath(headings []string) string {
+	var parts []string
+	for _, h := range headings {
+		if h != "" {
+			parts = append(parts, h)
+		}
+	}
+	return strings.Join(parts, " > ")
+}
+
+// textHash returns the SHA-256 hex string of s.
+func textHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// extractFeatures simulates LLM-based feature extraction
+// In a real implementation, this would call an LLM API
+func (dp *DocumentParser) extractFeatures(content, filePath string) ([]*models.Feature, error) {
+	chunks := dp.ChunkDocument(content)
+	var allFeatures []*models.Feature
+
+	for i, chunk := range chunks {
+		features := dp.simulateLLMExtraction(chunk, filePath, i)
+		allFeatures = append(allFeatures, features...)
+	}
+
+	// Deduplicate and merge similar features
+	return dp.deduplicateFeatures(allFeatures), nil
+}
+
+// simulateLLMExtraction simulates what an LLM would extract from a text chunk
+// This is a simplified rule-based approach for demonstration
+func (dp *DocumentParser) simulateLLMExtraction(chunk, filePath string, chunkIndex int) []*models.Feature {
+	var features []*models.Feature
+
+	// Patterns to identify features
+	patterns := map[string]*regexp.Regexp{
+		"implementation": regexp.MustCompile(`(?i)implement(?:s|ing|ation)?\s+([A-Z][A-Za-z\s]+)`),
+		"feature":        regexp.MustCompile(`(?i)(?:feature|capability|functionality):\s*([A-Z][A-Za-z\s]+)`),
+		"requirement":    regexp.MustCompile(`(?i)(?:require(?:s|ment)?|must|should)\s+([A-Z][A-Za-z\s]+)`),
+		"api":           regexp.MustCompile(`(?i)(?:API|endpoint|route):\s*([A-Z][A-Za-z\s\/]+)`),
+		"service":       regexp.MustCompile(`(?i)(?:service|microservice):\s*([A-Z][A-Za-z\s\-]+)`),
+	}
+
+	// Extract features using patterns
+	for category, pattern := range patterns {
+		matches := pattern.FindAllStringSubmatch(chunk, -1)
+		for _, match := range matches {
+			if len(match) > 1 {
+				featureName := strings.TrimSpace(match[1])
+				if len(featureName) > 3 { // Filter out very short matches
+					feature := &models.Feature{
+						Name:        featureName,
+						Description: extractFeatureDescription(chunk, featureName),
+						Status:      inferFeatureStatus(chunk, featureName),
+						Priority:    "medium", // Default priority
+						Tags:        []string{category, strings.ToLower(inferDocumentType(filePath))},
+					}
+					features = append(features, feature)
+				}
+			}
+		}
+	}
+
+	// Extract section headers as features (for structured documents)
+	headerPattern := regexp.MustCompile(`(?m)^#{1,3}\s+(.+)$`)
+	headerMatches := headerPattern.FindAllStringSubmatch(chunk, -1)
+	for _, match := range headerMatches {
+		if len(match) > 1 {
+			headerText := strings.TrimSpace(match[1])
+			// Skip very generic headers
+			if !isGenericHeader(headerText) {
+				feature := &models.Feature{
+					Name:        headerText,
+					Description: fmt.Sprintf("Section: %s", headerText),
+					Status:      "documented",
+					Priority:    "medium",
+					Tags:        []string{"section", "documentation"},
+				}
+				features = append(features, feature)
+			}
+		}
+	}
+
+	return features
+}
+
+// deduplicateFeatures removes similar features and merges them
+func (dp *DocumentParser) deduplicateFeatures(features []*models.Feature) []*models.Feature {
+	seen := make(map[string]*models.Feature)
+	var result []*models.Feature
+
+	for _, feature := range features {
+		// Create a normalized key for deduplication
+		normalizedName := strings.ToLower(strings.TrimSpace(feature.Name))
+		normalizedName = regexp.MustCompile(`\s+`).ReplaceAllString(normalizedName, " ")
+
+		if existing, exists := seen[normalizedName]; exists {
+			// Merge with existing feature
+			if len(feature.Description) > len(existing.Description) {
+				existing.Description = feature.Description
+			}
+			// Merge tags
+			existing.Tags = append(existing.Tags, feature.Tags...)
+			existing.Tags = removeDuplicateStrings(existing.Tags)
+		} else {
+			seen[normalizedName] = feature
+			result = append(result, feature)
+		}
+	}
+
+	return result
+}
+
+// Helper functions
+
+func extractTitle(content string) string {
+	// Try to find title from markdown header
+	titlePattern := regexp.MustCompile(`(?m)^#\s+(.+)$`)
+	matches := titlePattern.FindStringSubmatch(content)
+	if len(matches) > 1 {
+		return strings.TrimSpace(matches[1])
+	}
+
+	// Try to find title from first line
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" && len(line) > 5 && len(line) < 100 {
+			// Remove markdown formatting
+			line = regexp.MustCompile(`[#*_`+"`"+`]`).ReplaceAllString(line, "")
+			return strings.TrimSpace(line)
+		}
+	}
+
+	return "Untitled Document"
+}
+
+func inferDocumentType(filePath string) string {
+	filename := strings.ToLower(filepath.Base(filePath))
+	ext := filepath.Ext(filename)
+
+	switch ext {
+	case ".md":
+		if strings.Contains(filename, "readme") {
+			return "README"
+		}
+		if strings.Contains(filename, "rfc") {
+			return "RFC"
+		}
+		if strings.Contains(filename, "spec") {
+			return "Specification"
+		}
+		if strings.Contains(filename, "arch") {
+			return "Architecture"
+		}
+		return "Markdown Document"
+	case ".txt":
+		return "Text Document"
+	case ".rst":
+		return "reStructuredText"
+	default:
+		return "Document"
+	}
+}
+
+func extractFeatureDescription(chunk, featureName string) string {
+	// Try to find the sentence containing the feature name
+	sentences := strings.Split(chunk, ".")
+	for _, sentence := range sentences {
+		if strings.Contains(strings.ToLower(sentence), strings.ToLower(featureName)) {
+			return strings.TrimSpace(sentence) + "."
+		}
+	}
+	
+	// Fallback: return first 100 characters of chunk
+	if len(chunk) > 100 {
+		return chunk[:100] + "..."
+	}
+	return chunk
+}
+
+func inferFeatureStatus(chunk, featureName string) string {
+	lowerChunk := strings.ToLower(chunk)
+	
+	statusKeywords := map[string]string{
+		"completed":     "completed",
+		"done":          "completed",
+		"implemented":   "completed",
+		"finished":      "completed",
+		"in progress":   "in_progress",
+		"developing":    "in_progress",
+		"working":       "in_progress",
+		"todo":          "planned",
+		"planned":       "planned",
+		"future":        "planned",
+		"proposed":      "proposed",
+		"deprecated":    "deprecated",
+		"obsolete":      "deprecated",
+	}
+
+	for keyword, status := range statusKeywords {
+		if strings.Contains(lowerChunk, keyword) {
+			return status
+		}
+	}
+
+	return "documented"
+}
+
+func isGenericHeader(header string) bool {
+	genericHeaders := []string{
+		"introduction", "overview", "conclusion", "summary",
+		"table of contents", "contents", "index", "references",
+		"appendix", "notes", "todo", "changelog",
+	}
+	
+	lowerHeader := strings.ToLower(header)
+	for _, generic := range genericHeaders {
+		if strings.Contains(lowerHeader, generic) {
+			return true
+		}
+	}
+	
+	// Skip very short or very long headers
+	return len(header) < 3 || len(header) > 80
+}
+
+func removeDuplicateStrings(slice []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	
+	for _, str := range slice {
+		if !seen[str] {
+			seen[str] = true
+			result = append(result, str)
+		}
+	}
+	
+	return result
+}
+
+// ExtractedData represents the structured output from document parsing
+type ExtractedData struct {
+	Document *models.Document  `json:"document"`
+	Features []*models.Feature `json:"features"`
+	Symbols  []string          `json:"symbols,omitempty"` // References to code symbols
+}
+
+// ParseToJSON parses a document and returns JSON-formatted extracted data
+func (dp *DocumentParser) ParseToJSON(filePath string) ([]byte, error) {
+	doc, features, err := dp.ParseDocument(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	extracted := ExtractedData{
+		Document: doc,
+		Features: features,
+		Symbols:  extractCodeSymbols(doc.Content),
+	}
+
+	return json.MarshalIndent(extracted, "", "  ")
+}
+
+// extractCodeSymbols finds references to code symbols in the document
+func extractCodeSymbols(content string) []string {
+	var symbols []string
+	
+	// Pattern for code references in backticks
+	codePattern := regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*(?:\\(\\))?)`")
+	matches := codePattern.FindAllStringSubmatch(content, -1)
+	
+	for _, match := range matches {
+		if len(match) > 1 {
+			symbol := match[1]
+			// Filter out common words that aren't likely to be code symbols
+			if isLikelyCodeSymbol(symbol) {
+				symbols = append(symbols, symbol)
+			}
+		}
+	}
+	
+	return removeDuplicateStrings(symbols)
+}
+
+func isLikelyCodeSymbol(symbol string) bool {
+	// Filter out common English words
+	commonWords := []string{
+		"the", "and", "or", "but", "if", "then", "else", "when", "where",
+		"what", "how", "why", "who", "which", "that", "this", "these", "those",
+		"can", "will", "would", "should", "could", "may", "might", "must",
+		"is", "are", "was", "were", "be", "been", "being", "have", "has", "had",
+		"do", "does", "did", "get", "got", "set", "put", "let", "make", "take",
+	}
+	
+	lowerSymbol := strings.ToLower(symbol)
+	for _, word := range commonWords {
+		if lowerSymbol == word {
+			return false
+		}
+	}
+	
+	// Must contain at least one capital letter or underscore (typical code patterns)
+	return regexp.MustCompile(`[A-Z_]`).MatchString(symbol)
+}

--- a/services/indexing-go/generated/context.go
+++ b/services/indexing-go/generated/context.go
@@ -1,0 +1,240 @@
+package generated
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// GeneratedDocType constants for the different types of generated docs.
+const (
+	DocTypePRSummary          = "pr_summary"
+	DocTypeFlowSummary        = "flow_summary"
+	DocTypeDocstringSuggestion = "docstring_suggestion"
+)
+
+// ContextGenerator creates and manages generated context nodes in the graph.
+type ContextGenerator struct {
+	client   *neo4j.Client
+	scopeCtx models.ScopeContext
+}
+
+// NewContextGenerator creates a new context generator.
+func NewContextGenerator(client *neo4j.Client) *ContextGenerator {
+	return &ContextGenerator{
+		client:   client,
+		scopeCtx: models.DefaultScope(),
+	}
+}
+
+// SetScope sets the scope context.
+func (g *ContextGenerator) SetScope(scope models.ScopeContext) {
+	g.scopeCtx = scope
+}
+
+// CreatePullRequestNode creates a PullRequest node in the graph.
+func (g *ContextGenerator) CreatePullRequestNode(ctx context.Context, prID, title, author, baseBranch, headBranch, description string) (string, error) {
+	nodeKey := models.PullRequestNodeKey(prID)
+	props := map[string]any{
+		"prId":        prID,
+		"title":       title,
+		"author":      author,
+		"baseBranch":  baseBranch,
+		"headBranch":  headBranch,
+		"status":      "open",
+		"description": description,
+		"nodeKey":     nodeKey,
+		"scope":       g.scopeCtx.Scope,
+		"scopeId":     g.scopeCtx.ScopeID,
+	}
+
+	id, err := g.client.MergeNode(ctx, []string{"PullRequest"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": g.scopeCtx.ScopeID}, props)
+	if err != nil {
+		return "", fmt.Errorf("failed to create PullRequest node: %w", err)
+	}
+	return id, nil
+}
+
+// StorePRSummary creates a GeneratedDoc node with type "pr_summary" and links it
+// to the PullRequest via DOCUMENTS, and to changed files via DERIVED_FROM.
+func (g *ContextGenerator) StorePRSummary(ctx context.Context, prID, title, content, model string, changedFileKeys []string) (string, error) {
+	prNodeKey := models.PullRequestNodeKey(prID)
+	genDocKey := models.GeneratedDocNodeKey(DocTypePRSummary, prNodeKey)
+
+	docProps := map[string]any{
+		"type":       DocTypePRSummary,
+		"title":      title,
+		"content":    content,
+		"model":      model,
+		"sourceType": "pull_request",
+		"sourceKey":  prNodeKey,
+		"nodeKey":    genDocKey,
+		"scope":      g.scopeCtx.Scope,
+		"scopeId":    g.scopeCtx.ScopeID,
+	}
+
+	docID, err := g.client.MergeNode(ctx, []string{"GeneratedDoc"},
+		map[string]any{"nodeKey": genDocKey, "scopeId": g.scopeCtx.ScopeID}, docProps)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GeneratedDoc node: %w", err)
+	}
+
+	// Link GeneratedDoc -[DOCUMENTS]-> PullRequest
+	cypher := `
+		MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+		MATCH (pr:PullRequest {nodeKey: $prNodeKey, scopeId: $scopeId})
+		MERGE (gd)-[:DOCUMENTS]->(pr)`
+	_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"genDocKey": genDocKey,
+		"prNodeKey": prNodeKey,
+		"scopeId":   g.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to create DOCUMENTS edge: %v\n", err)
+	}
+
+	// Link GeneratedDoc -[DERIVED_FROM]-> changed Files
+	for _, fileKey := range changedFileKeys {
+		cypher := `
+			MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+			MATCH (f:File {nodeKey: $fileKey})
+			MERGE (gd)-[:DERIVED_FROM]->(f)`
+		_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+			"genDocKey": genDocKey,
+			"fileKey":   fileKey,
+			"scopeId":   g.scopeCtx.ScopeID,
+		})
+		if err != nil {
+			fmt.Printf("Warning: failed to create DERIVED_FROM edge to %s: %v\n", fileKey, err)
+		}
+	}
+
+	return docID, nil
+}
+
+// StoreFlowSummary creates a GeneratedDoc node with type "flow_summary" and links it
+// to the Flow via DOCUMENTS and DERIVED_FROM.
+func (g *ContextGenerator) StoreFlowSummary(ctx context.Context, flowNodeKey, title, content, model string) (string, error) {
+	genDocKey := models.GeneratedDocNodeKey(DocTypeFlowSummary, flowNodeKey)
+
+	docProps := map[string]any{
+		"type":       DocTypeFlowSummary,
+		"title":      title,
+		"content":    content,
+		"model":      model,
+		"sourceType": "flow",
+		"sourceKey":  flowNodeKey,
+		"nodeKey":    genDocKey,
+		"scope":      g.scopeCtx.Scope,
+		"scopeId":    g.scopeCtx.ScopeID,
+	}
+
+	docID, err := g.client.MergeNode(ctx, []string{"GeneratedDoc"},
+		map[string]any{"nodeKey": genDocKey, "scopeId": g.scopeCtx.ScopeID}, docProps)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GeneratedDoc node: %w", err)
+	}
+
+	// Link GeneratedDoc -[DOCUMENTS]-> Flow
+	cypher := `
+		MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+		MATCH (f:Flow {nodeKey: $flowKey})
+		MERGE (gd)-[:DOCUMENTS]->(f)
+		MERGE (gd)-[:DERIVED_FROM]->(f)`
+	_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"genDocKey": genDocKey,
+		"flowKey":   flowNodeKey,
+		"scopeId":   g.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to create edges to Flow: %v\n", err)
+	}
+
+	return docID, nil
+}
+
+// StoreDocstringSuggestion creates a GeneratedDoc node with type "docstring_suggestion"
+// and links it to the target function/method via DOCUMENTS and DERIVED_FROM.
+func (g *ContextGenerator) StoreDocstringSuggestion(ctx context.Context, targetNodeKey, title, content, model string) (string, error) {
+	genDocKey := models.GeneratedDocNodeKey(DocTypeDocstringSuggestion, targetNodeKey)
+
+	docProps := map[string]any{
+		"type":       DocTypeDocstringSuggestion,
+		"title":      title,
+		"content":    content,
+		"model":      model,
+		"sourceType": "code_symbol",
+		"sourceKey":  targetNodeKey,
+		"nodeKey":    genDocKey,
+		"scope":      g.scopeCtx.Scope,
+		"scopeId":    g.scopeCtx.ScopeID,
+	}
+
+	docID, err := g.client.MergeNode(ctx, []string{"GeneratedDoc"},
+		map[string]any{"nodeKey": genDocKey, "scopeId": g.scopeCtx.ScopeID}, docProps)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GeneratedDoc node: %w", err)
+	}
+
+	// Link to target node (Function or Method)
+	cypher := `
+		MATCH (gd:GeneratedDoc {nodeKey: $genDocKey, scopeId: $scopeId})
+		MATCH (target {nodeKey: $targetKey})
+		WHERE target:Function OR target:Method
+		WITH gd, target LIMIT 1
+		MERGE (gd)-[:DOCUMENTS]->(target)
+		MERGE (gd)-[:DERIVED_FROM]->(target)`
+	_, err = g.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"genDocKey": genDocKey,
+		"targetKey": targetNodeKey,
+		"scopeId":   g.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to create edges to target: %v\n", err)
+	}
+
+	return docID, nil
+}
+
+// ListGeneratedDocs lists generated docs, optionally filtered by type and/or source.
+func (g *ContextGenerator) ListGeneratedDocs(ctx context.Context, docType, sourceKey string) ([]map[string]any, error) {
+	conditions := []string{"gd.scopeId = $scopeId"}
+	params := map[string]any{"scopeId": g.scopeCtx.ScopeID}
+
+	if docType != "" {
+		conditions = append(conditions, "gd.type = $type")
+		params["type"] = docType
+	}
+	if sourceKey != "" {
+		conditions = append(conditions, "gd.sourceKey = $sourceKey")
+		params["sourceKey"] = sourceKey
+	}
+
+	where := ""
+	for i, c := range conditions {
+		if i == 0 {
+			where = "WHERE " + c
+		} else {
+			where += " AND " + c
+		}
+	}
+
+	cypher := fmt.Sprintf(`MATCH (gd:GeneratedDoc) %s
+		RETURN gd.nodeKey AS nodeKey, gd.type AS type, gd.title AS title,
+		       gd.sourceKey AS sourceKey, gd.model AS model
+		ORDER BY gd.title`, where)
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list generated docs: %w", err)
+	}
+
+	var results []map[string]any
+	for _, r := range records {
+		results = append(results, r.AsMap())
+	}
+	return results, nil
+}

--- a/services/indexing-go/project.json
+++ b/services/indexing-go/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "indexing-go",
+  "root": "services/indexing-go",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go build ./services/indexing-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go test ./services/indexing-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    }
+  }
+}

--- a/services/indexing-go/schema/schema.go
+++ b/services/indexing-go/schema/schema.go
@@ -1,0 +1,748 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// SchemaManager handles Neo4j schema creation and management
+type SchemaManager struct {
+	client *neo4j.Client
+}
+
+// NewSchemaManager creates a new schema manager
+func NewSchemaManager(client *neo4j.Client) *SchemaManager {
+	return &SchemaManager{client: client}
+}
+
+// Constraint represents a Neo4j constraint
+type Constraint struct {
+	Name      string
+	NodeLabel string
+	Property  string
+	Type      string // "UNIQUE", "EXISTENCE", "NODE_KEY"
+}
+
+// Index represents a Neo4j index
+type Index struct {
+	Name       string
+	NodeLabel  string
+	Properties []string
+	Type       string // "BTREE", "TEXT", "POINT", "LOOKUP"
+}
+
+// GetConstraints returns all constraint definitions for the code graph schema.
+// Note: Old UNIQUE constraints (symbol_unique, service_name_unique, file_path_unique,
+// class_fqn_unique, interface_fqn_unique, module_fqn_unique) have been removed
+// because the same entity can now exist in multiple scopes (main + PR overlays).
+// Uniqueness is enforced via composite (nodeKey, scopeId) indexes instead.
+func GetConstraints() []Constraint {
+	return []Constraint{}
+}
+
+// GetDroppedConstraints returns the names of old constraints that should be dropped
+// during schema migration. These were single-property UNIQUE constraints that conflict
+// with the multi-scope model.
+func GetDroppedConstraints() []string {
+	return []string{
+		"symbol_unique",
+		"service_name_unique",
+		"file_path_unique",
+		"class_fqn_unique",
+		"interface_fqn_unique",
+		"module_fqn_unique",
+	}
+}
+
+// GetIndexes returns all index definitions for the code graph schema
+func GetIndexes() []Index {
+	return []Index{
+		// Single property indexes for common lookups
+		{
+			Name:       "service_name_idx",
+			NodeLabel:  "Service",
+			Properties: []string{"name"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "file_path_idx",
+			NodeLabel:  "File",
+			Properties: []string{"path"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "file_hash_idx",
+			NodeLabel:  "File",
+			Properties: []string{"hash"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "class_name_idx",
+			NodeLabel:  "Class",
+			Properties: []string{"name"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "class_fqn_idx",
+			NodeLabel:  "Class",
+			Properties: []string{"fqn"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "function_name_idx",
+			NodeLabel:  "Function",
+			Properties: []string{"name"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "function_signature_idx",
+			NodeLabel:  "Function",
+			Properties: []string{"signature"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "method_name_idx",
+			NodeLabel:  "Method",
+			Properties: []string{"name"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "variable_name_idx",
+			NodeLabel:  "Variable",
+			Properties: []string{"name"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "symbol_kind_idx",
+			NodeLabel:  "Symbol",
+			Properties: []string{"kind"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "api_route_path_idx",
+			NodeLabel:  "APIRoute",
+			Properties: []string{"path"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "api_route_method_idx",
+			NodeLabel:  "APIRoute",
+			Properties: []string{"method"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "document_title_idx",
+			NodeLabel:  "Document",
+			Properties: []string{"title"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "document_type_idx",
+			NodeLabel:  "Document",
+			Properties: []string{"type"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "feature_name_idx",
+			NodeLabel:  "Feature",
+			Properties: []string{"name"},
+			Type:       "BTREE",
+		},
+		// Note: Full-text search requires Neo4j Enterprise
+		// Using regular BTREE indexes for basic search functionality
+		{
+			Name:       "search_name_idx",
+			NodeLabel:  "Function",
+			Properties: []string{"name"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "search_displayname_idx",
+			NodeLabel:  "Symbol",
+			Properties: []string{"displayName"},
+			Type:       "BTREE",
+		},
+		// Composite indexes for common query patterns
+		{
+			Name:       "file_service_path_idx",
+			NodeLabel:  "File",
+			Properties: []string{"serviceName", "path"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "symbol_service_idx",
+			NodeLabel:  "Symbol",
+			Properties: []string{"serviceName", "kind"},
+			Type:       "BTREE",
+		},
+		// nodeKey indexes for stable identity (Phase 1)
+		{
+			Name:       "service_nodekey_idx",
+			NodeLabel:  "Service",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "file_nodekey_idx",
+			NodeLabel:  "File",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "symbol_nodekey_idx",
+			NodeLabel:  "Symbol",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "function_nodekey_idx",
+			NodeLabel:  "Function",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "method_nodekey_idx",
+			NodeLabel:  "Method",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "class_nodekey_idx",
+			NodeLabel:  "Class",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "interface_nodekey_idx",
+			NodeLabel:  "Interface",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "module_nodekey_idx",
+			NodeLabel:  "Module",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "variable_nodekey_idx",
+			NodeLabel:  "Variable",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "parameter_nodekey_idx",
+			NodeLabel:  "Parameter",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "apiroute_nodekey_idx",
+			NodeLabel:  "APIRoute",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "document_nodekey_idx",
+			NodeLabel:  "Document",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "feature_nodekey_idx",
+			NodeLabel:  "Feature",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "reference_nodekey_idx",
+			NodeLabel:  "Reference",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		// Composite (nodeKey, scopeId) indexes for scoped merge lookups (Phase 2)
+		{
+			Name:       "service_nodekey_scope_idx",
+			NodeLabel:  "Service",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "file_nodekey_scope_idx",
+			NodeLabel:  "File",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "symbol_nodekey_scope_idx",
+			NodeLabel:  "Symbol",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "function_nodekey_scope_idx",
+			NodeLabel:  "Function",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "method_nodekey_scope_idx",
+			NodeLabel:  "Method",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "class_nodekey_scope_idx",
+			NodeLabel:  "Class",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "interface_nodekey_scope_idx",
+			NodeLabel:  "Interface",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "variable_nodekey_scope_idx",
+			NodeLabel:  "Variable",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "reference_nodekey_scope_idx",
+			NodeLabel:  "Reference",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "document_nodekey_scope_idx",
+			NodeLabel:  "Document",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "feature_nodekey_scope_idx",
+			NodeLabel:  "Feature",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		// Scope filter indexes for querying by scope (Phase 2)
+		{
+			Name:       "function_scope_idx",
+			NodeLabel:  "Function",
+			Properties: []string{"scope", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "symbol_scope_idx",
+			NodeLabel:  "Symbol",
+			Properties: []string{"scope", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "file_scope_idx",
+			NodeLabel:  "File",
+			Properties: []string{"scope", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "service_scope_idx",
+			NodeLabel:  "Service",
+			Properties: []string{"scope", "scopeId"},
+			Type:       "BTREE",
+		},
+		// DocumentChunk indexes (Task 4)
+		{
+			Name:       "docchunk_nodekey_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "docchunk_nodekey_scope_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "docchunk_dockey_scope_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"documentKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "docchunk_texthash_idx",
+			NodeLabel:  "DocumentChunk",
+			Properties: []string{"textHash"},
+			Type:       "BTREE",
+		},
+		// Flow indexes (Task 9)
+		{
+			Name:       "flow_nodekey_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "flow_nodekey_scope_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "flow_entrypoint_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"entrypointKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "flow_type_idx",
+			NodeLabel:  "Flow",
+			Properties: []string{"flowType"},
+			Type:       "BTREE",
+		},
+		// PullRequest indexes (Task 10)
+		{
+			Name:       "pr_nodekey_idx",
+			NodeLabel:  "PullRequest",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "pr_nodekey_scope_idx",
+			NodeLabel:  "PullRequest",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "pr_prid_idx",
+			NodeLabel:  "PullRequest",
+			Properties: []string{"prId"},
+			Type:       "BTREE",
+		},
+		// GeneratedDoc indexes (Task 10)
+		{
+			Name:       "gendoc_nodekey_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"nodeKey"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "gendoc_nodekey_scope_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "gendoc_type_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"type"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "gendoc_sourcekey_idx",
+			NodeLabel:  "GeneratedDoc",
+			Properties: []string{"sourceKey"},
+			Type:       "BTREE",
+		},
+		// Tombstone indexes (Phase 3)
+		{
+			Name:       "tombstone_nodekey_scope_idx",
+			NodeLabel:  "Tombstone",
+			Properties: []string{"nodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+		{
+			Name:       "tombstone_target_scope_idx",
+			NodeLabel:  "Tombstone",
+			Properties: []string{"targetNodeKey", "scopeId"},
+			Type:       "BTREE",
+		},
+	}
+}
+
+// CreateSchema creates all constraints and indexes for the code graph
+func (sm *SchemaManager) CreateSchema(ctx context.Context) error {
+	// Drop legacy constraints that conflict with scope model
+	for _, name := range GetDroppedConstraints() {
+		cypher := fmt.Sprintf("DROP CONSTRAINT %s IF EXISTS", name)
+		if _, err := sm.client.ExecuteQuery(ctx, cypher, nil); err != nil {
+			// Non-fatal: constraint may not exist
+			fmt.Printf("Note: could not drop legacy constraint %s: %v\n", name, err)
+		}
+	}
+
+	// Create constraints
+	if err := sm.createConstraints(ctx); err != nil {
+		return fmt.Errorf("failed to create constraints: %w", err)
+	}
+
+	// Create indexes
+	if err := sm.createIndexes(ctx); err != nil {
+		return fmt.Errorf("failed to create indexes: %w", err)
+	}
+
+	return nil
+}
+
+// createConstraints creates all constraint definitions
+func (sm *SchemaManager) createConstraints(ctx context.Context) error {
+	constraints := GetConstraints()
+	
+	for _, constraint := range constraints {
+		if err := sm.createConstraint(ctx, constraint); err != nil {
+			return fmt.Errorf("failed to create constraint %s: %w", constraint.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// createConstraint creates a single constraint
+func (sm *SchemaManager) createConstraint(ctx context.Context, constraint Constraint) error {
+	var cypher string
+	
+	switch constraint.Type {
+	case "UNIQUE":
+		cypher = fmt.Sprintf(
+			"CREATE CONSTRAINT %s IF NOT EXISTS FOR (n:%s) REQUIRE n.%s IS UNIQUE",
+			constraint.Name, constraint.NodeLabel, constraint.Property,
+		)
+	case "EXISTENCE":
+		cypher = fmt.Sprintf(
+			"CREATE CONSTRAINT %s IF NOT EXISTS FOR (n:%s) REQUIRE n.%s IS NOT NULL",
+			constraint.Name, constraint.NodeLabel, constraint.Property,
+		)
+	case "NODE_KEY":
+		cypher = fmt.Sprintf(
+			"CREATE CONSTRAINT %s IF NOT EXISTS FOR (n:%s) REQUIRE (n.%s) IS NODE KEY",
+			constraint.Name, constraint.NodeLabel, constraint.Property,
+		)
+	default:
+		return fmt.Errorf("unsupported constraint type: %s", constraint.Type)
+	}
+
+	_, err := sm.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return fmt.Errorf("failed to execute constraint creation: %w", err)
+	}
+
+	return nil
+}
+
+// createIndexes creates all index definitions
+func (sm *SchemaManager) createIndexes(ctx context.Context) error {
+	indexes := GetIndexes()
+	
+	for _, index := range indexes {
+		if err := sm.createIndex(ctx, index); err != nil {
+			return fmt.Errorf("failed to create index %s: %w", index.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// createIndex creates a single index
+func (sm *SchemaManager) createIndex(ctx context.Context, index Index) error {
+	var cypher string
+	
+	propertiesStr := strings.Join(index.Properties, ", ")
+	
+	switch index.Type {
+	case "BTREE":
+		if index.NodeLabel == "" {
+			// Create index on all nodes
+			cypher = fmt.Sprintf(
+				"CREATE INDEX %s IF NOT EXISTS FOR (n) ON (%s)",
+				index.Name, propertiesStr,
+			)
+		} else {
+			cypher = fmt.Sprintf(
+				"CREATE INDEX %s IF NOT EXISTS FOR (n:%s) ON (n.%s)",
+				index.Name, index.NodeLabel, strings.Join(index.Properties, ", n."),
+			)
+		}
+	case "FULLTEXT":
+		if index.NodeLabel == "" {
+			// Full-text index on all nodes using APOC
+			cypher = fmt.Sprintf(
+				"CALL apoc.index.fulltext.nodes.create('%s', ['Service', 'File', 'Class', 'Function', 'Method', 'Variable', 'Symbol', 'Document', 'Feature'], [%s])",
+				index.Name, quoteProperties(index.Properties),
+			)
+		} else {
+			cypher = fmt.Sprintf(
+				"CALL apoc.index.fulltext.nodes.create('%s', ['%s'], [%s])",
+				index.Name, index.NodeLabel, quoteProperties(index.Properties),
+			)
+		}
+	case "TEXT":
+		// Legacy TEXT support - try built-in first, fallback to APOC
+		if index.NodeLabel == "" {
+			// Full-text index on all nodes
+			cypher = fmt.Sprintf(
+				"CALL db.index.fulltext.createNodeIndex('%s', ['Service', 'File', 'Class', 'Function', 'Method', 'Variable', 'Symbol', 'Document', 'Feature'], [%s])",
+				index.Name, quoteProperties(index.Properties),
+			)
+		} else {
+			cypher = fmt.Sprintf(
+				"CALL db.index.fulltext.createNodeIndex('%s', ['%s'], [%s])",
+				index.Name, index.NodeLabel, quoteProperties(index.Properties),
+			)
+		}
+	case "LOOKUP":
+		cypher = fmt.Sprintf(
+			"CREATE LOOKUP INDEX %s IF NOT EXISTS FOR (n) ON EACH labels(n)",
+			index.Name,
+		)
+	default:
+		return fmt.Errorf("unsupported index type: %s", index.Type)
+	}
+
+	_, err := sm.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return fmt.Errorf("failed to execute index creation: %w", err)
+	}
+
+	return nil
+}
+
+// DropSchema drops all constraints and indexes
+func (sm *SchemaManager) DropSchema(ctx context.Context) error {
+	// Drop constraints first (constraint-backed indexes can't be dropped separately)
+	if err := sm.dropAllConstraints(ctx); err != nil {
+		return fmt.Errorf("failed to drop constraints: %w", err)
+	}
+
+	// Drop remaining indexes
+	if err := sm.dropAllIndexes(ctx); err != nil {
+		return fmt.Errorf("failed to drop indexes: %w", err)
+	}
+
+	return nil
+}
+
+// dropAllConstraints drops all constraints in the database
+func (sm *SchemaManager) dropAllConstraints(ctx context.Context) error {
+	// Get all constraint names
+	cypher := "SHOW CONSTRAINTS YIELD name"
+	result, err := sm.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list constraints: %w", err)
+	}
+
+	// Drop each constraint
+	for _, record := range result {
+		constraintName, ok := record.AsMap()["name"].(string)
+		if !ok {
+			continue
+		}
+
+		dropCypher := fmt.Sprintf("DROP CONSTRAINT %s IF EXISTS", constraintName)
+		_, err := sm.client.ExecuteQuery(ctx, dropCypher, nil)
+		if err != nil {
+			return fmt.Errorf("failed to drop constraint %s: %w", constraintName, err)
+		}
+	}
+
+	return nil
+}
+
+// dropAllIndexes drops all indexes in the database
+func (sm *SchemaManager) dropAllIndexes(ctx context.Context) error {
+	// Get all index names
+	cypher := "SHOW INDEXES YIELD name"
+	result, err := sm.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list indexes: %w", err)
+	}
+
+	// Drop each index
+	for _, record := range result {
+		indexName, ok := record.AsMap()["name"].(string)
+		if !ok {
+			continue
+		}
+
+		dropCypher := fmt.Sprintf("DROP INDEX %s IF EXISTS", indexName)
+		_, err := sm.client.ExecuteQuery(ctx, dropCypher, nil)
+		if err != nil {
+			return fmt.Errorf("failed to drop index %s: %w", indexName, err)
+		}
+	}
+
+	return nil
+}
+
+// GetSchemaInfo returns information about current schema
+func (sm *SchemaManager) GetSchemaInfo(ctx context.Context) (map[string]any, error) {
+	info := make(map[string]any)
+
+	// Get constraints
+	constraintsCypher := "SHOW CONSTRAINTS"
+	constraintsResult, err := sm.client.ExecuteQuery(ctx, constraintsCypher, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get constraints info: %w", err)
+	}
+
+	var constraints []map[string]any
+	for _, record := range constraintsResult {
+		constraints = append(constraints, record.AsMap())
+	}
+	info["constraints"] = constraints
+
+	// Get indexes
+	indexesCypher := "SHOW INDEXES"
+	indexesResult, err := sm.client.ExecuteQuery(ctx, indexesCypher, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get indexes info: %w", err)
+	}
+
+	var indexes []map[string]any
+	for _, record := range indexesResult {
+		indexes = append(indexes, record.AsMap())
+	}
+	info["indexes"] = indexes
+
+	return info, nil
+}
+
+// ValidateSchema checks if the required schema elements exist
+func (sm *SchemaManager) ValidateSchema(ctx context.Context) error {
+	requiredIndexes := GetIndexes()
+
+	// Check indexes
+	indexesCypher := "SHOW INDEXES YIELD name"
+	indexesResult, err := sm.client.ExecuteQuery(ctx, indexesCypher, nil)
+	if err != nil {
+		return fmt.Errorf("failed to check indexes: %w", err)
+	}
+
+	existingIndexes := make(map[string]bool)
+	for _, record := range indexesResult {
+		if name, ok := record.AsMap()["name"].(string); ok {
+			existingIndexes[name] = true
+		}
+	}
+
+	for _, index := range requiredIndexes {
+		if !existingIndexes[index.Name] {
+			return fmt.Errorf("missing index: %s", index.Name)
+		}
+	}
+
+	return nil
+}
+
+// quoteProperties wraps property names in quotes for full-text index creation
+func quoteProperties(properties []string) string {
+	quoted := make([]string, len(properties))
+	for i, prop := range properties {
+		quoted[i] = fmt.Sprintf("'%s'", prop)
+	}
+	return strings.Join(quoted, ", ")
+}

--- a/services/indexing-go/static/call_graph.go
+++ b/services/indexing-go/static/call_graph.go
@@ -1,0 +1,296 @@
+package static
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"log"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+)
+
+// CallGraphExtractor extracts call relationships from Go AST
+type CallGraphExtractor struct {
+	client      *neo4j.Client
+	fset        *token.FileSet
+	currentFunc string // Current function being analyzed
+	packageName string
+	filePath    string
+}
+
+// NewCallGraphExtractor creates a new call graph extractor
+func NewCallGraphExtractor(client *neo4j.Client) *CallGraphExtractor {
+	return &CallGraphExtractor{
+		client: client,
+	}
+}
+
+// ExtractCallsFromFunction analyzes a function declaration for call relationships
+func (cge *CallGraphExtractor) ExtractCallsFromFunction(ctx context.Context, funcDecl *ast.FuncDecl, funcID string, fset *token.FileSet, packageName, filePath string) error {
+	cge.fset = fset
+	cge.currentFunc = funcID
+	cge.packageName = packageName
+	cge.filePath = filePath
+
+	if funcDecl.Body == nil {
+		return nil // No body to analyze
+	}
+
+	// Walk through the function body to find calls
+	ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			cge.processCallExpression(ctx, node, funcID)
+		case *ast.FuncLit:
+			// Handle anonymous functions/closures
+			if node.Body != nil {
+				ast.Inspect(node.Body, func(inner ast.Node) bool {
+					if callExpr, ok := inner.(*ast.CallExpr); ok {
+						cge.processCallExpression(ctx, callExpr, funcID)
+					}
+					return true
+				})
+			}
+		}
+		return true
+	})
+
+	return nil
+}
+
+// processCallExpression handles individual call expressions
+func (cge *CallGraphExtractor) processCallExpression(ctx context.Context, callExpr *ast.CallExpr, callerID string) {
+	pos := cge.fset.Position(callExpr.Pos())
+
+	// Extract the called function name
+	calledName := cge.extractCalledFunctionName(callExpr)
+	if calledName == "" {
+		return // Skip if we can't determine the called function
+	}
+
+	// Determine if this is a dynamic call (interface method, function pointer, etc.)
+	isDynamic := cge.isDynamicCall(callExpr)
+
+	// Try to find the target function in the database
+	targetFuncID := cge.findTargetFunction(ctx, calledName)
+	if targetFuncID == "" {
+		// Create a placeholder function node for external calls
+		targetFuncID = cge.createPlaceholderFunction(ctx, calledName)
+	}
+
+	if targetFuncID != "" {
+		// Create CALLS relationship
+		relProps := map[string]any{
+			"line":        pos.Line,
+			"isDynamic":   isDynamic,
+			"isRecursive": calledName == cge.getCurrentFunctionName(callerID),
+		}
+
+		_, err := cge.client.CreateRelationship(ctx, callerID, targetFuncID, string(models.CallsRel), relProps)
+		if err != nil {
+			log.Printf("Warning: failed to create CALLS relationship from %s to %s: %v", callerID, targetFuncID, err)
+		}
+	}
+}
+
+// extractCalledFunctionName extracts the function name from a call expression
+func (cge *CallGraphExtractor) extractCalledFunctionName(callExpr *ast.CallExpr) string {
+	switch fun := callExpr.Fun.(type) {
+	case *ast.Ident:
+		// Simple function call: funcName()
+		return fun.Name
+	case *ast.SelectorExpr:
+		// Method call or package function: obj.method() or pkg.func()
+		if ident, ok := fun.X.(*ast.Ident); ok {
+			return fmt.Sprintf("%s.%s", ident.Name, fun.Sel.Name)
+		}
+		// For more complex selectors, just use the method name
+		return fun.Sel.Name
+	case *ast.FuncLit:
+		// Anonymous function call
+		return "<anonymous>"
+	default:
+		// Other complex expressions
+		return "<complex>"
+	}
+}
+
+// isDynamicCall determines if a call is dynamic (through interface, function pointer, etc.)
+func (cge *CallGraphExtractor) isDynamicCall(callExpr *ast.CallExpr) bool {
+	switch callExpr.Fun.(type) {
+	case *ast.Ident:
+		// Could be a function variable
+		return false // For now, assume direct calls
+	case *ast.SelectorExpr:
+		// Could be interface method call
+		return false // For now, assume direct calls
+	case *ast.IndexExpr:
+		// Function from slice/map
+		return true
+	case *ast.ParenExpr:
+		// Parenthesized expression, likely dynamic
+		return true
+	default:
+		return true
+	}
+}
+
+// findTargetFunction searches for the target function in the database
+func (cge *CallGraphExtractor) findTargetFunction(ctx context.Context, functionName string) string {
+	// Try different search strategies
+	queries := []struct {
+		cypher string
+		params map[string]any
+	}{
+		{
+			// Exact name match in same package
+			cypher: `
+				MATCH (f:Function)
+				WHERE f.name = $funcName AND f.packageName = $packageName
+				RETURN f.id AS id
+				LIMIT 1
+			`,
+			params: map[string]any{
+				"funcName":    functionName,
+				"packageName": cge.packageName,
+			},
+		},
+		{
+			// Exact name match anywhere
+			cypher: `
+				MATCH (f:Function)
+				WHERE f.name = $funcName
+				RETURN f.id AS id
+				LIMIT 1
+			`,
+			params: map[string]any{
+				"funcName": functionName,
+			},
+		},
+		{
+			// Method name match (for receiver.method patterns)
+			cypher: `
+				MATCH (f:Function)
+				WHERE f.name CONTAINS $methodName
+				RETURN f.id AS id
+				LIMIT 1
+			`,
+			params: map[string]any{
+				"methodName": strings.Split(functionName, ".")[len(strings.Split(functionName, "."))-1],
+			},
+		},
+	}
+
+	for _, query := range queries {
+		results, err := cge.client.ExecuteQuery(ctx, query.cypher, query.params)
+		if err != nil {
+			continue
+		}
+
+		for _, record := range results {
+			if id, ok := record.AsMap()["id"]; ok {
+				if idStr, ok := id.(string); ok {
+					return idStr
+				}
+			}
+		}
+	}
+
+	return "" // Not found
+}
+
+// createPlaceholderFunction creates a placeholder function node for external calls
+func (cge *CallGraphExtractor) createPlaceholderFunction(ctx context.Context, functionName string) string {
+	// Check if placeholder already exists
+	existing := cge.findTargetFunction(ctx, functionName)
+	if existing != "" {
+		return existing
+	}
+
+	// Create a new placeholder function
+	funcProps := map[string]any{
+		"name":         functionName,
+		"isExternal":   true,
+		"isPlaceholder": true,
+		"packageName":  cge.inferPackageName(functionName),
+		"filePath":     "<external>",
+		"signature":    fmt.Sprintf("%s(...)", functionName),
+	}
+
+	funcID, err := cge.client.MergeNode(ctx, []string{"Function"},
+		map[string]any{"name": functionName, "isPlaceholder": true}, funcProps)
+	if err != nil {
+		log.Printf("Warning: failed to create placeholder function for %s: %v", functionName, err)
+		return ""
+	}
+
+	return funcID
+}
+
+// inferPackageName tries to infer package name from function name
+func (cge *CallGraphExtractor) inferPackageName(functionName string) string {
+	parts := strings.Split(functionName, ".")
+	if len(parts) > 1 {
+		// If it's pkg.func or obj.method, use the first part
+		return parts[0]
+	}
+	return "unknown"
+}
+
+// getCurrentFunctionName extracts the current function name from its ID
+func (cge *CallGraphExtractor) getCurrentFunctionName(funcID string) string {
+	// This would need to be implemented based on how function IDs are structured
+	// For now, return empty to disable recursion detection
+	return ""
+}
+
+// ExtractDataFlows analyzes data flow between functions (simplified version)
+func (cge *CallGraphExtractor) ExtractDataFlows(ctx context.Context, funcDecl *ast.FuncDecl, funcID string) error {
+	if funcDecl.Body == nil {
+		return nil
+	}
+
+	// Simple data flow analysis: track variable assignments and returns
+	var returnVars []string
+	var assignedVars []string
+
+	ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.ReturnStmt:
+			// Track return statements
+			for _, result := range node.Results {
+				if ident, ok := result.(*ast.Ident); ok {
+					returnVars = append(returnVars, ident.Name)
+				}
+			}
+		case *ast.AssignStmt:
+			// Track assignments
+			for _, lhs := range node.Lhs {
+				if ident, ok := lhs.(*ast.Ident); ok {
+					assignedVars = append(assignedVars, ident.Name)
+				}
+			}
+		}
+		return true
+	})
+
+	// Create data flow relationships based on variable usage
+	// This is a simplified version - a full implementation would track
+	// actual data dependencies between function calls
+	for _, varName := range returnVars {
+		// Find functions that use this variable (simplified)
+		cge.createDataFlowRelationship(ctx, funcID, varName, "return")
+	}
+
+	return nil
+}
+
+// createDataFlowRelationship creates FLOWS_TO relationships
+func (cge *CallGraphExtractor) createDataFlowRelationship(ctx context.Context, sourceID, varName, flowType string) {
+	// This is a placeholder for data flow analysis
+	// A full implementation would track actual variable usage across functions
+	log.Printf("Data flow: %s returns %s (%s)", sourceID, varName, flowType)
+}

--- a/services/indexing-go/static/call_graph_scip.go
+++ b/services/indexing-go/static/call_graph_scip.go
@@ -1,0 +1,373 @@
+package static
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+)
+
+// funcRange represents the line span of a function/method body in a Go file.
+type funcRange struct {
+	Name      string
+	DeclLine  int // Line of the function name declaration (matches SCIP's startLine)
+	StartLine int // Body opening brace line
+	EndLine   int // Body closing brace line
+}
+
+// SCIPCallGraphBuilder infers CALLS relationships between Functions/Methods
+// by correlating SCIP Reference nodes with Go AST function body ranges.
+type SCIPCallGraphBuilder struct {
+	client      *neo4j.Client
+	projectPath string
+	modulePath  string // Go module path from go.mod, used to filter external targets
+	scopeCtx    models.ScopeContext
+}
+
+// NewSCIPCallGraphBuilder creates a new call graph builder.
+func NewSCIPCallGraphBuilder(client *neo4j.Client, projectPath string) *SCIPCallGraphBuilder {
+	return &SCIPCallGraphBuilder{
+		client:      client,
+		projectPath: projectPath,
+		modulePath:  readModulePath(projectPath),
+		scopeCtx:    models.DefaultScope(),
+	}
+}
+
+// readModulePath reads the module path from go.mod in the given directory.
+// Returns empty string if go.mod is missing or malformed, which disables
+// filtering (CONTAINS "" is always true).
+func readModulePath(projectPath string) string {
+	f, err := os.Open(filepath.Join(projectPath, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module"))
+		}
+	}
+	return ""
+}
+
+// SetScope sets the scope context for the builder.
+func (cg *SCIPCallGraphBuilder) SetScope(scope models.ScopeContext) {
+	cg.scopeCtx = scope
+}
+
+// BuildCallGraph infers CALLS relationships for all Go source files in the graph.
+func (cg *SCIPCallGraphBuilder) BuildCallGraph(ctx context.Context) error {
+	fmt.Println("Building call graph from SCIP references...")
+
+	// Get all Go source files in the graph.
+	files, err := cg.listGoFiles(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list Go files: %w", err)
+	}
+
+	totalCalls := 0
+	for _, filePath := range files {
+		n, err := cg.processFile(ctx, filePath)
+		if err != nil {
+			fmt.Printf("Warning: call graph for %s: %v\n", filePath, err)
+			continue
+		}
+		totalCalls += n
+	}
+
+	fmt.Printf("Call graph complete: created %d CALLS relationships across %d files\n", totalCalls, len(files))
+	return nil
+}
+
+// listGoFiles returns all file paths with a .go extension that are indexed in the graph.
+func (cg *SCIPCallGraphBuilder) listGoFiles(ctx context.Context) ([]string, error) {
+	query := `
+		MATCH (f:File)
+		WHERE f.path ENDS WITH '.go'
+		  AND f.scopeId = $scopeId
+		RETURN f.path AS path
+	`
+	results, err := cg.client.ExecuteQuery(ctx, query, map[string]any{
+		"scopeId": cg.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0, len(results))
+	for _, rec := range results {
+		p := getStringFromMap(rec.AsMap(), "path")
+		if p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths, nil
+}
+
+// callerInfo pairs an AST-derived body range with the graph node element ID.
+type callerInfo struct {
+	ID        string // Neo4j element ID
+	StartLine int    // AST body start line
+	EndLine   int    // AST body end line
+}
+
+// processFile parses a single Go file with the AST to get function body ranges,
+// maps them to graph node IDs, queries references, and creates CALLS edges.
+func (cg *SCIPCallGraphBuilder) processFile(ctx context.Context, filePath string) (int, error) {
+	fullPath := filePath
+	if !filepath.IsAbs(filePath) {
+		fullPath = filepath.Join(cg.projectPath, filePath)
+	}
+
+	// Parse Go source for function body ranges (AST gives us real start/end).
+	funcRanges, err := parseFuncRanges(fullPath)
+	if err != nil {
+		return 0, err
+	}
+	if len(funcRanges) == 0 {
+		return 0, nil
+	}
+
+	// Load graph node IDs for functions in this file, keyed by base name.
+	// We filter to only functions whose SCIP signature matches this file's
+	// Go package path, so cross-package references stored as Function nodes
+	// are excluded.
+	graphNodes, err := cg.graphNodesByName(ctx, filePath)
+	if err != nil {
+		return 0, err
+	}
+
+	// Build callerInfo list: pair each AST func range with its graph ID.
+	var callers []callerInfo
+	for _, fr := range funcRanges {
+		// Use base name (strip receiver prefix like "SCIPIndexer.")
+		baseName := fr.Name
+		if idx := strings.LastIndex(baseName, "."); idx >= 0 {
+			baseName = baseName[idx+1:]
+		}
+		nodeID, ok := graphNodes[baseName]
+		if !ok {
+			continue
+		}
+		callers = append(callers, callerInfo{
+			ID:        nodeID,
+			StartLine: fr.StartLine,
+			EndLine:   fr.EndLine,
+		})
+	}
+
+	if len(callers) == 0 {
+		return 0, nil
+	}
+
+	// Query: find all references in this file that point to symbols which
+	// have a DEFINES edge from a Function or Method.
+	// Filter targets to only intra-project calls when modulePath is set.
+	// (CONTAINS "" is always true, so empty modulePath disables filtering.)
+	query := `
+		MATCH (ref:Reference {filePath: $filePath, scopeId: $scopeId})
+		      -[:REFERENCES]->(sym:Symbol)
+		      <-[:DEFINES]-(target)
+		WHERE (target:Function OR target:Method)
+		  AND target.signature CONTAINS $modulePath
+		RETURN ref.startLine AS refLine,
+		       elementId(target) AS targetId
+	`
+
+	results, err := cg.client.ExecuteQuery(ctx, query, map[string]any{
+		"filePath":   filePath,
+		"scopeId":    cg.scopeCtx.ScopeID,
+		"modulePath": cg.modulePath,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	created := 0
+	seen := map[string]bool{}
+
+	for _, rec := range results {
+		rm := rec.AsMap()
+		refLine := int(getInt64FromMap(rm, "refLine"))
+		targetID := getStringFromMap(rm, "targetId")
+
+		caller := findEnclosingCaller(callers, refLine)
+		if caller == nil {
+			continue
+		}
+
+		pairKey := caller.ID + "->" + targetID
+		if caller.ID == targetID || seen[pairKey] {
+			continue
+		}
+		seen[pairKey] = true
+
+		_, err := cg.client.MergeRelationship(ctx, caller.ID, targetID, string(models.CallsRel),
+			nil,
+			map[string]any{"line": refLine, "filePath": filePath})
+		if err != nil {
+			fmt.Printf("Warning: failed to create CALLS edge: %v\n", err)
+			continue
+		}
+		created++
+	}
+
+	return created, nil
+}
+
+// graphNodesByName returns a map of base function name -> element ID for
+// functions in the given file whose SCIP signature matches the file's
+// Go package directory. This filters out cross-package reference nodes
+// that SCIP stores as Function nodes in the same filePath.
+func (cg *SCIPCallGraphBuilder) graphNodesByName(ctx context.Context, filePath string) (map[string]string, error) {
+	// Derive the Go package directory from the file path (e.g.,
+	// "pkg/indexer/static/scip_indexer.go" -> "pkg/indexer/static").
+	pkgDir := filepath.Dir(filePath)
+
+	query := `
+		MATCH (f)
+		WHERE (f:Function OR f:Method)
+		  AND f.filePath = $filePath
+		  AND f.scopeId = $scopeId
+		  AND f.signature CONTAINS $pkgDir
+		RETURN elementId(f) AS id, f.name AS name
+	`
+
+	results, err := cg.client.ExecuteQuery(ctx, query, map[string]any{
+		"filePath": filePath,
+		"scopeId":  cg.scopeCtx.ScopeID,
+		"pkgDir":   pkgDir,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]string, len(results))
+	for _, rec := range results {
+		rm := rec.AsMap()
+		id := getStringFromMap(rm, "id")
+		name := getStringFromMap(rm, "name")
+		if id != "" && name != "" {
+			baseName := strings.TrimSuffix(name, "().")
+			m[baseName] = id
+		}
+	}
+	return m, nil
+}
+
+
+// findEnclosingCaller finds the innermost callerInfo whose body range
+// contains the given line number.
+func findEnclosingCaller(callers []callerInfo, line int) *callerInfo {
+	var best *callerInfo
+	bestSpan := int(^uint(0) >> 1)
+
+	for i := range callers {
+		c := &callers[i]
+		if line >= c.StartLine && line <= c.EndLine {
+			span := c.EndLine - c.StartLine
+			if span < bestSpan {
+				best = c
+				bestSpan = span
+			}
+		}
+	}
+	return best
+}
+
+// parseFuncRanges parses a Go source file and returns the line ranges for each
+// function and method body.
+func parseFuncRanges(filePath string) ([]funcRange, error) {
+	src, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filePath, src, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var ranges []funcRange
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+
+		name := fn.Name.Name
+		// For methods, include the receiver type in the name to disambiguate.
+		if fn.Recv != nil && len(fn.Recv.List) > 0 {
+			recvType := exprName(fn.Recv.List[0].Type)
+			if recvType != "" {
+				name = recvType + "." + name
+			}
+		}
+
+		declLine := fset.Position(fn.Name.Pos()).Line
+		startLine := fset.Position(fn.Body.Lbrace).Line
+		endLine := fset.Position(fn.Body.Rbrace).Line
+
+		ranges = append(ranges, funcRange{
+			Name:      name,
+			DeclLine:  declLine,
+			StartLine: startLine,
+			EndLine:   endLine,
+		})
+	}
+
+	return ranges, nil
+}
+
+// exprName extracts the type name from a receiver expression, handling
+// pointer receivers like *Foo.
+func exprName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return exprName(t.X)
+	case *ast.IndexExpr:
+		return exprName(t.X)
+	case *ast.IndexListExpr:
+		return exprName(t.X)
+	}
+	return ""
+}
+
+// findEnclosingFunc finds the innermost function whose body range contains
+// the given line number.
+func findEnclosingFunc(ranges []funcRange, line int) *funcRange {
+	var best *funcRange
+	bestSpan := int(^uint(0) >> 1) // max int
+
+	for i := range ranges {
+		r := &ranges[i]
+		if line >= r.StartLine && line <= r.EndLine {
+			span := r.EndLine - r.StartLine
+			if span < bestSpan {
+				best = r
+				bestSpan = span
+			}
+		}
+	}
+	return best
+}
+
+// isGoFile checks whether a path ends with .go
+func isGoFile(path string) bool {
+	return strings.HasSuffix(path, ".go")
+}

--- a/services/indexing-go/static/helpers.go
+++ b/services/indexing-go/static/helpers.go
@@ -1,0 +1,27 @@
+package static
+
+// getStringFromMap safely extracts a string value from a map.
+func getStringFromMap(m map[string]any, key string) string {
+	if val, ok := m[key]; ok && val != nil {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+// getInt64FromMap safely extracts an int64 value from a map, handling
+// int, int64, and float64 types.
+func getInt64FromMap(m map[string]any, key string) int64 {
+	if val, ok := m[key]; ok && val != nil {
+		switch v := val.(type) {
+		case int64:
+			return v
+		case int:
+			return int64(v)
+		case float64:
+			return int64(v)
+		}
+	}
+	return -1
+}

--- a/services/indexing-go/static/indexer.go
+++ b/services/indexing-go/static/indexer.go
@@ -1,0 +1,1003 @@
+package static
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+	"github.com/context-maximiser/code-graph/pkg/search"
+)
+
+// StaticIndexer indexes Go source code into the graph database
+type StaticIndexer struct {
+	client           *neo4j.Client
+	serviceName      string
+	version          string
+	repoURL          string
+	packageMap       map[string]*models.Module // Cache for package/module nodes
+	symbolMap        map[string]string         // Cache for symbol -> node ID mapping
+	embeddingService search.EmbeddingService   // Optional embedding service
+	vectorSearch     *search.VectorSearchManager
+	callGraphExtractor *CallGraphExtractor     // Call graph analysis
+	fset             *token.FileSet            // File set for position tracking
+}
+
+// NewStaticIndexer creates a new static indexer
+func NewStaticIndexer(client *neo4j.Client, serviceName, version, repoURL string) *StaticIndexer {
+	return &StaticIndexer{
+		client:      client,
+		serviceName: serviceName,
+		version:     version,
+		repoURL:     repoURL,
+		packageMap:  make(map[string]*models.Module),
+		symbolMap:   make(map[string]string),
+		// Embedding service will be set later if needed
+		embeddingService: nil,
+		vectorSearch:     nil,
+		callGraphExtractor: NewCallGraphExtractor(client),
+	}
+}
+
+// SetEmbeddingService sets the embedding service for automatic embedding generation
+func (si *StaticIndexer) SetEmbeddingService(embeddingService search.EmbeddingService) {
+	si.embeddingService = embeddingService
+	if embeddingService != nil {
+		si.vectorSearch = search.NewVectorSearchManager(si.client)
+	}
+}
+
+// generateEmbeddingForNode generates and updates embedding for a newly created node
+func (si *StaticIndexer) generateEmbeddingForNode(ctx context.Context, nodeID string, nodeType string, textParts ...string) {
+	if si.embeddingService == nil || si.vectorSearch == nil {
+		return // Skip if no embedding service configured
+	}
+
+	// Build text for embedding
+	text := strings.Join(textParts, " | ")
+	if text == "" {
+		text = fmt.Sprintf("%s node", nodeType)
+	}
+
+	// Generate embedding
+	embedding, err := si.embeddingService.GenerateEmbedding(ctx, text)
+	if err != nil {
+		log.Printf("Warning: failed to generate embedding for %s node %s: %v", nodeType, nodeID, err)
+		return
+	}
+
+	// Update node with embedding
+	err = si.vectorSearch.UpdateNodeEmbedding(ctx, nodeID, embedding)
+	if err != nil {
+		log.Printf("Warning: failed to update embedding for %s node %s: %v", nodeType, nodeID, err)
+	}
+}
+
+// IndexProject indexes an entire Go project
+func (si *StaticIndexer) IndexProject(ctx context.Context, rootPath string) error {
+	log.Printf("Starting to index project at %s", rootPath)
+	
+	// Create or update the service node
+	serviceID, err := si.createServiceNode(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create service node: %w", err)
+	}
+	log.Printf("Created service node with ID: %s", serviceID)
+
+	// Walk the directory tree and index all Go files
+	err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip vendor, .git, and other directories
+		if d.IsDir() && shouldSkipDir(d.Name()) {
+			return filepath.SkipDir
+		}
+
+		// Only process .go files
+		if !d.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			log.Printf("Indexing file: %s", path)
+			if err := si.indexFile(ctx, path, serviceID); err != nil {
+				log.Printf("Warning: failed to index file %s: %v", path, err)
+				// Continue with other files instead of failing completely
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	log.Printf("Successfully indexed project %s", si.serviceName)
+	return nil
+}
+
+// IndexProjectIncremental performs incremental indexing by only updating changed files
+func (si *StaticIndexer) IndexProjectIncremental(ctx context.Context, rootPath string) error {
+	log.Printf("Starting incremental indexing of project at %s", rootPath)
+
+	// Create or update the service node
+	serviceID, err := si.createServiceNode(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create service node: %w", err)
+	}
+	log.Printf("Updated service node with ID: %s", serviceID)
+
+	// Get existing file hashes from the database
+	existingFiles, err := si.getExistingFileHashes(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get existing file hashes: %w", err)
+	}
+	log.Printf("Found %d existing files in database", len(existingFiles))
+
+	// Track current files to detect deletions
+	currentFiles := make(map[string]bool)
+
+	// Walk the directory tree and index changed files
+	err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip vendor, .git, and other directories
+		if d.IsDir() && shouldSkipDir(d.Name()) {
+			return filepath.SkipDir
+		}
+
+		// Only process .go files
+		if !d.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			currentFiles[path] = true
+
+			// Calculate current file hash
+			currentHash, err := si.calculateFileHash(path)
+			if err != nil {
+				log.Printf("Warning: failed to calculate hash for %s: %v", path, err)
+				return nil
+			}
+
+			// Check if file has changed
+			existingHash, exists := existingFiles[path]
+			if !exists || existingHash != currentHash {
+				log.Printf("Indexing changed file: %s (new: %t)", path, !exists)
+				if err := si.indexFileIncremental(ctx, path, serviceID, currentHash); err != nil {
+					log.Printf("Warning: failed to index file %s: %v", path, err)
+				}
+			} else {
+				log.Printf("Skipping unchanged file: %s", path)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	// Clean up deleted files
+	deletedCount := 0
+	for filePath := range existingFiles {
+		if !currentFiles[filePath] {
+			log.Printf("Removing deleted file: %s", filePath)
+			if err := si.removeFileNodes(ctx, filePath); err != nil {
+				log.Printf("Warning: failed to remove file %s: %v", filePath, err)
+			} else {
+				deletedCount++
+			}
+		}
+	}
+
+	log.Printf("Successfully completed incremental indexing for %s (removed %d deleted files)",
+		si.serviceName, deletedCount)
+	return nil
+}
+
+// createServiceNode creates the service node in the graph
+func (si *StaticIndexer) createServiceNode(ctx context.Context) (string, error) {
+	serviceProps := map[string]any{
+		"name":          si.serviceName,
+		"language":      "Go",
+		"version":       si.version,
+		"repositoryUrl": si.repoURL,
+		"createdAt":     time.Now().UTC().Unix(),
+		"updatedAt":     time.Now().UTC().Unix(),
+	}
+
+	return si.client.MergeNode(ctx, []string{"Service"}, 
+		map[string]any{"name": si.serviceName}, serviceProps)
+}
+
+// indexFile indexes a single Go source file
+func (si *StaticIndexer) indexFile(ctx context.Context, filePath string, serviceID string) error {
+	// Parse the file
+	fset := token.NewFileSet()
+	si.fset = fset // Store fset for call graph extraction
+	node, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("failed to parse file %s: %w", filePath, err)
+	}
+
+	// Calculate file hash
+	fileHash, err := si.calculateFileHash(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to calculate file hash: %w", err)
+	}
+
+	// Create file node
+	fileProps := map[string]any{
+		"path":         filePath,
+		"absolutePath": filePath,
+		"language":     "Go",
+		"hash":         fileHash,
+		"lineCount":    fset.Position(node.End()).Line,
+		"createdAt":    time.Now().UTC().Unix(),
+		"updatedAt":    time.Now().UTC().Unix(),
+	}
+
+	fileID, err := si.client.MergeNode(ctx, []string{"File"}, 
+		map[string]any{"path": filePath}, fileProps)
+	if err != nil {
+		return fmt.Errorf("failed to create file node: %w", err)
+	}
+
+	// Link file to service
+	_, err = si.client.CreateRelationship(ctx, serviceID, fileID, "CONTAINS", nil)
+	if err != nil {
+		return fmt.Errorf("failed to link file to service: %w", err)
+	}
+
+	// Index the package/module
+	packageName := node.Name.Name
+	packageFQN := si.getPackageFQN(filePath, packageName)
+	
+	moduleID, err := si.getOrCreateModule(ctx, packageName, packageFQN, fileID)
+	if err != nil {
+		return fmt.Errorf("failed to create module node: %w", err)
+	}
+
+	// Create a visitor to traverse the AST
+	visitor := &astVisitor{
+		indexer:   si,
+		ctx:       ctx,
+		fileID:    fileID,
+		moduleID:  moduleID,
+		filePath:  filePath,
+		fset:      fset,
+		packageName: packageName,
+	}
+
+	// Visit all nodes in the AST
+	ast.Walk(visitor, node)
+
+	return nil
+}
+
+// astVisitor implements ast.Visitor to traverse and index AST nodes
+type astVisitor struct {
+	indexer     *StaticIndexer
+	ctx         context.Context
+	fileID      string
+	moduleID    string
+	filePath    string
+	fset        *token.FileSet
+	packageName string
+	currentClass string // Track current class/struct for methods
+}
+
+// Visit implements ast.Visitor
+func (v *astVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+
+	switch n := node.(type) {
+	case *ast.FuncDecl:
+		v.indexFunction(n)
+	case *ast.TypeSpec:
+		v.indexType(n)
+	case *ast.GenDecl:
+		v.indexGenDecl(n)
+	case *ast.InterfaceType:
+		v.indexInterface(n)
+	}
+
+	return v
+}
+
+// indexFunction indexes a function declaration
+func (v *astVisitor) indexFunction(fn *ast.FuncDecl) {
+	if fn.Name == nil {
+		return
+	}
+
+	startPos := v.fset.Position(fn.Pos())
+	endPos := v.fset.Position(fn.End())
+
+	// Determine if this is a method or function
+	isMethod := fn.Recv != nil
+	var parentID string
+
+	if isMethod {
+		// Try to find the receiver type and link to it
+		if fn.Recv != nil && len(fn.Recv.List) > 0 {
+			if recv := fn.Recv.List[0]; recv.Type != nil {
+				// Extract receiver type name
+				var recvTypeName string
+				switch t := recv.Type.(type) {
+				case *ast.Ident:
+					recvTypeName = t.Name
+				case *ast.StarExpr:
+					if ident, ok := t.X.(*ast.Ident); ok {
+						recvTypeName = ident.Name
+					}
+				}
+				v.currentClass = recvTypeName
+				// TODO: Link to the actual struct/type node
+				parentID = v.moduleID // For now, link to module
+			}
+		}
+	} else {
+		parentID = v.moduleID
+	}
+
+	// Build function signature
+	signature := v.buildFunctionSignature(fn)
+
+	// Extract return type
+	returnType := ""
+	if fn.Type.Results != nil {
+		returnType = v.extractTypeString(fn.Type.Results)
+	}
+
+	// Check if function is exported
+	isExported := ast.IsExported(fn.Name.Name)
+
+	// Create function/method node with enhanced location metadata
+	funcProps := map[string]any{
+		"name":        fn.Name.Name,
+		"signature":   signature,
+		"returnType":  returnType,
+		"filePath":    v.filePath,
+		"startLine":   startPos.Line,
+		"endLine":     endPos.Line,
+		"startColumn": startPos.Column,
+		"endColumn":   endPos.Column,
+		"startByte":   v.fset.Position(fn.Pos()).Offset,
+		"endByte":     v.fset.Position(fn.End()).Offset,
+		"linesOfCode": endPos.Line - startPos.Line + 1,
+		"isExported":  isExported,
+		"isAsync":     false, // Go doesn't have async functions like JS
+		"complexity":  1,     // TODO: Calculate cyclomatic complexity
+		"docstring":   v.extractDocstring(fn.Doc),
+		"createdAt":   time.Now().UTC().Unix(),
+		"updatedAt":   time.Now().UTC().Unix(),
+	}
+
+	var labels []string
+	if isMethod {
+		labels = []string{"Method"}
+		funcProps["accessModifier"] = "public" // Go methods are public if capitalized
+		funcProps["isStatic"] = false
+	} else {
+		labels = []string{"Function"}
+	}
+
+	funcID, err := v.indexer.client.MergeNode(v.ctx, labels,
+		map[string]any{"signature": signature, "filePath": v.filePath}, funcProps)
+	if err != nil {
+		log.Printf("Failed to create function node %s: %v", fn.Name.Name, err)
+		return
+	}
+
+	// Generate embedding for the function
+	nodeType := "Function"
+	if isMethod {
+		nodeType = "Method"
+	}
+	v.indexer.generateEmbeddingForNode(v.ctx, funcID, nodeType,
+		fn.Name.Name, signature, v.extractDocstring(fn.Doc))
+
+	// Link to parent (module or class)
+	if parentID != "" {
+		_, err = v.indexer.client.CreateRelationship(v.ctx, parentID, funcID, "CONTAINS", nil)
+		if err != nil {
+			log.Printf("Failed to link function to parent: %v", err)
+		}
+	}
+
+	// Create symbol for the function
+	v.createSymbol(fn.Name.Name, "Function", funcID, signature)
+
+	// Index parameters
+	if fn.Type.Params != nil {
+		for i, param := range fn.Type.Params.List {
+			for _, name := range param.Names {
+				v.indexParameter(name, param, i, funcID)
+			}
+		}
+	}
+
+	// Extract call graph relationships from function body
+	if err := v.indexer.extractCallGraph(v.ctx, fn, funcID); err != nil {
+		log.Printf("Warning: failed to extract call graph for function %s: %v", fn.Name.Name, err)
+	}
+}
+
+// indexType indexes type declarations (structs, aliases, etc.)
+func (v *astVisitor) indexType(typeSpec *ast.TypeSpec) {
+	if typeSpec.Name == nil {
+		return
+	}
+
+	startPos := v.fset.Position(typeSpec.Pos())
+	endPos := v.fset.Position(typeSpec.End())
+
+	// Determine the type of declaration
+	switch t := typeSpec.Type.(type) {
+	case *ast.StructType:
+		v.indexStruct(typeSpec.Name.Name, t, startPos, endPos)
+	case *ast.InterfaceType:
+		v.indexInterfaceType(typeSpec.Name.Name, t, startPos, endPos)
+	}
+}
+
+// indexStruct indexes a struct type
+func (v *astVisitor) indexStruct(name string, structType *ast.StructType, startPos, endPos token.Position) {
+	fqn := fmt.Sprintf("%s.%s", v.packageName, name)
+	
+	classProps := map[string]any{
+		"name":           name,
+		"fqn":            fqn,
+		"filePath":       v.filePath,
+		"startLine":      startPos.Line,
+		"endLine":        endPos.Line,
+		"startColumn":    startPos.Column,
+		"endColumn":      endPos.Column,
+		"startByte":      startPos.Offset,
+		"endByte":        endPos.Offset,
+		"linesOfCode":    endPos.Line - startPos.Line + 1,
+		"accessModifier": "public", // Go structs are public if capitalized
+		"isAbstract":     false,
+		"isInterface":    false,
+		"docstring":      "", // TODO: Extract docstring
+		"createdAt":      time.Now().UTC().Unix(),
+		"updatedAt":      time.Now().UTC().Unix(),
+	}
+
+	classID, err := v.indexer.client.MergeNode(v.ctx, []string{"Class"},
+		map[string]any{"fqn": fqn}, classProps)
+	if err != nil {
+		log.Printf("Failed to create struct node %s: %v", name, err)
+		return
+	}
+
+	// Generate embedding for the class
+	v.indexer.generateEmbeddingForNode(v.ctx, classID, "Class", name, fqn)
+
+	// Link to module
+	_, err = v.indexer.client.CreateRelationship(v.ctx, v.moduleID, classID, "CONTAINS", nil)
+	if err != nil {
+		log.Printf("Failed to link struct to module: %v", err)
+	}
+
+	// Create symbol for the struct
+	v.createSymbol(name, "Type", classID, fqn)
+
+	// Index fields
+	if structType.Fields != nil {
+		for _, field := range structType.Fields.List {
+			for _, fieldName := range field.Names {
+				v.indexField(fieldName, field, classID)
+			}
+		}
+	}
+}
+
+// indexInterfaceType indexes an interface type
+func (v *astVisitor) indexInterfaceType(name string, interfaceType *ast.InterfaceType, startPos, endPos token.Position) {
+	fqn := fmt.Sprintf("%s.%s", v.packageName, name)
+	
+	interfaceProps := map[string]any{
+		"name":        name,
+		"fqn":         fqn,
+		"filePath":    v.filePath,
+		"startLine":   startPos.Line,
+		"endLine":     endPos.Line,
+		"startColumn": startPos.Column,
+		"endColumn":   endPos.Column,
+		"startByte":   startPos.Offset,
+		"endByte":     endPos.Offset,
+		"linesOfCode": endPos.Line - startPos.Line + 1,
+		"docstring":   "", // TODO: Extract docstring
+		"createdAt":   time.Now().UTC().Unix(),
+		"updatedAt":   time.Now().UTC().Unix(),
+	}
+
+	interfaceID, err := v.indexer.client.MergeNode(v.ctx, []string{"Interface"}, 
+		map[string]any{"fqn": fqn}, interfaceProps)
+	if err != nil {
+		log.Printf("Failed to create interface node %s: %v", name, err)
+		return
+	}
+
+	// Link to module
+	_, err = v.indexer.client.CreateRelationship(v.ctx, v.moduleID, interfaceID, "CONTAINS", nil)
+	if err != nil {
+		log.Printf("Failed to link interface to module: %v", err)
+	}
+
+	// Create symbol for the interface
+	v.createSymbol(name, "Interface", interfaceID, fqn)
+}
+
+// indexGenDecl indexes general declarations (vars, consts, types)
+func (v *astVisitor) indexGenDecl(gen *ast.GenDecl) {
+	for _, spec := range gen.Specs {
+		switch s := spec.(type) {
+		case *ast.ValueSpec:
+			v.indexValueSpec(s, gen.Tok)
+		}
+	}
+}
+
+// indexValueSpec indexes variable or constant declarations
+func (v *astVisitor) indexValueSpec(spec *ast.ValueSpec, tok token.Token) {
+	for _, name := range spec.Names {
+		if name.Name == "_" { // Skip blank identifier
+			continue
+		}
+
+		startPos := v.fset.Position(name.Pos())
+		endPos := v.fset.Position(name.End())
+
+		// Determine variable type
+		varType := ""
+		if spec.Type != nil {
+			varType = v.extractTypeString(&ast.FieldList{List: []*ast.Field{{Type: spec.Type}}})
+		}
+
+		// Determine scope and if it's a constant
+		scope := "package"
+		isConstant := tok == token.CONST
+		if !ast.IsExported(name.Name) {
+			scope = "private"
+		}
+
+		varProps := map[string]any{
+			"name":         name.Name,
+			"type":         varType,
+			"scope":        scope,
+			"filePath":     v.filePath,
+			"startLine":    startPos.Line,
+			"endLine":      endPos.Line,
+			"isConstant":   isConstant,
+			"initialValue": "", // TODO: Extract initial value
+			"createdAt":    time.Now().UTC().Unix(),
+			"updatedAt":    time.Now().UTC().Unix(),
+		}
+
+		varID, err := v.indexer.client.MergeNode(v.ctx, []string{"Variable"}, 
+			map[string]any{"name": name.Name, "filePath": v.filePath}, varProps)
+		if err != nil {
+			log.Printf("Failed to create variable node %s: %v", name.Name, err)
+			continue
+		}
+
+		// Link to module
+		_, err = v.indexer.client.CreateRelationship(v.ctx, v.moduleID, varID, "CONTAINS", nil)
+		if err != nil {
+			log.Printf("Failed to link variable to module: %v", err)
+		}
+
+		// Create symbol for the variable
+		symbolKind := "Variable"
+		if isConstant {
+			symbolKind = "Constant"
+		}
+		v.createSymbol(name.Name, symbolKind, varID, fmt.Sprintf("%s.%s", v.packageName, name.Name))
+	}
+}
+
+// indexParameter indexes function parameters
+func (v *astVisitor) indexParameter(name *ast.Ident, param *ast.Field, index int, funcID string) {
+	paramType := v.extractTypeString(&ast.FieldList{List: []*ast.Field{param}})
+
+	paramProps := map[string]any{
+		"name":         name.Name,
+		"type":         paramType,
+		"index":        index,
+		"isOptional":   false, // Go doesn't have optional parameters
+		"defaultValue": "",
+		"createdAt":    time.Now().UTC().Unix(),
+		"updatedAt":    time.Now().UTC().Unix(),
+	}
+
+	paramID, err := v.indexer.client.MergeNode(v.ctx, []string{"Parameter"}, 
+		map[string]any{"name": name.Name, "filePath": v.filePath, "index": index}, paramProps)
+	if err != nil {
+		log.Printf("Failed to create parameter node %s: %v", name.Name, err)
+		return
+	}
+
+	// Link to function
+	_, err = v.indexer.client.CreateRelationship(v.ctx, funcID, paramID, "CONTAINS", nil)
+	if err != nil {
+		log.Printf("Failed to link parameter to function: %v", err)
+	}
+
+	// Create symbol for the parameter
+	v.createSymbol(name.Name, "Parameter", paramID, "")
+}
+
+// indexField indexes struct fields
+func (v *astVisitor) indexField(name *ast.Ident, field *ast.Field, classID string) {
+	startPos := v.fset.Position(name.Pos())
+	endPos := v.fset.Position(name.End())
+
+	fieldType := v.extractTypeString(&ast.FieldList{List: []*ast.Field{field}})
+
+	varProps := map[string]any{
+		"name":         name.Name,
+		"type":         fieldType,
+		"scope":        "instance",
+		"filePath":     v.filePath,
+		"startLine":    startPos.Line,
+		"endLine":      endPos.Line,
+		"isConstant":   false,
+		"initialValue": "",
+		"createdAt":    time.Now().UTC().Unix(),
+		"updatedAt":    time.Now().UTC().Unix(),
+	}
+
+	fieldID, err := v.indexer.client.MergeNode(v.ctx, []string{"Variable"}, 
+		map[string]any{"name": name.Name, "filePath": v.filePath}, varProps)
+	if err != nil {
+		log.Printf("Failed to create field node %s: %v", name.Name, err)
+		return
+	}
+
+	// Link to class
+	_, err = v.indexer.client.CreateRelationship(v.ctx, classID, fieldID, "CONTAINS", nil)
+	if err != nil {
+		log.Printf("Failed to link field to class: %v", err)
+	}
+
+	// Create symbol for the field
+	v.createSymbol(name.Name, "Field", fieldID, "")
+}
+
+// Helper methods
+func (v *astVisitor) createSymbol(name, kind, nodeID, descriptor string) {
+	// Create SCIP symbol
+	scipSymbol := models.NewGoSCIPSymbol(v.packageName, v.indexer.version, descriptor)
+
+	symbolProps := map[string]any{
+		"symbol":        scipSymbol.String(),
+		"kind":          kind,
+		"displayName":   name,
+		"documentation": "",
+		"createdAt":     time.Now().UTC().Unix(),
+		"updatedAt":     time.Now().UTC().Unix(),
+	}
+
+	symbolID, err := v.indexer.client.MergeNode(v.ctx, []string{"Symbol"}, 
+		map[string]any{"symbol": scipSymbol.String()}, symbolProps)
+	if err != nil {
+		log.Printf("Failed to create symbol for %s: %v", name, err)
+		return
+	}
+
+	// Create DEFINES relationship
+	_, err = v.indexer.client.CreateRelationship(v.ctx, nodeID, symbolID, "DEFINES", 
+		map[string]any{"isExported": ast.IsExported(name)})
+	if err != nil {
+		log.Printf("Failed to create DEFINES relationship for %s: %v", name, err)
+	}
+
+	// Cache the symbol mapping
+	v.indexer.symbolMap[scipSymbol.String()] = nodeID
+}
+
+func (v *astVisitor) buildFunctionSignature(fn *ast.FuncDecl) string {
+	var parts []string
+	
+	parts = append(parts, fn.Name.Name)
+	parts = append(parts, "(")
+	
+	if fn.Type.Params != nil {
+		var params []string
+		for _, param := range fn.Type.Params.List {
+			paramType := v.extractTypeString(&ast.FieldList{List: []*ast.Field{param}})
+			for _, name := range param.Names {
+				params = append(params, fmt.Sprintf("%s %s", name.Name, paramType))
+			}
+		}
+		parts = append(parts, strings.Join(params, ", "))
+	}
+	
+	parts = append(parts, ")")
+	
+	if fn.Type.Results != nil {
+		parts = append(parts, " ")
+		parts = append(parts, v.extractTypeString(fn.Type.Results))
+	}
+	
+	return strings.Join(parts, "")
+}
+
+func (v *astVisitor) extractTypeString(fieldList *ast.FieldList) string {
+	if fieldList == nil || len(fieldList.List) == 0 {
+		return ""
+	}
+	
+	// Simple type extraction - can be enhanced
+	field := fieldList.List[0]
+	if field.Type != nil {
+		switch t := field.Type.(type) {
+		case *ast.Ident:
+			return t.Name
+		case *ast.StarExpr:
+			if ident, ok := t.X.(*ast.Ident); ok {
+				return "*" + ident.Name
+			}
+		case *ast.SelectorExpr:
+			if pkg, ok := t.X.(*ast.Ident); ok {
+				return pkg.Name + "." + t.Sel.Name
+			}
+		}
+	}
+	
+	return "unknown"
+}
+
+func (v *astVisitor) extractDocstring(commentGroup *ast.CommentGroup) string {
+	if commentGroup == nil {
+		return ""
+	}
+	
+	var parts []string
+	for _, comment := range commentGroup.List {
+		text := strings.TrimPrefix(comment.Text, "//")
+		text = strings.TrimPrefix(text, "/*")
+		text = strings.TrimSuffix(text, "*/")
+		text = strings.TrimSpace(text)
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	
+	return strings.Join(parts, " ")
+}
+
+// getOrCreateModule gets or creates a module node for a package
+func (si *StaticIndexer) getOrCreateModule(ctx context.Context, packageName, fqn, fileID string) (string, error) {
+	// Check cache first
+	if module, exists := si.packageMap[fqn]; exists {
+		// Link file to existing module
+		_, err := si.client.CreateRelationship(ctx, module.ID, fileID, "CONTAINS", nil)
+		return module.ID, err
+	}
+
+	// Create new module
+	moduleProps := map[string]any{
+		"name":       packageName,
+		"fqn":        fqn,
+		"type":       "package",
+		"isExported": true, // Go packages are generally exported
+		"createdAt":  time.Now().UTC().Unix(),
+		"updatedAt":  time.Now().UTC().Unix(),
+	}
+
+	moduleID, err := si.client.MergeNode(ctx, []string{"Module"}, 
+		map[string]any{"fqn": fqn}, moduleProps)
+	if err != nil {
+		return "", fmt.Errorf("failed to create module: %w", err)
+	}
+
+	// Cache the module
+	si.packageMap[fqn] = &models.Module{
+		BaseNode: models.BaseNode{ID: moduleID},
+		Name:     packageName,
+		FQN:      fqn,
+	}
+
+	// Link file to module
+	_, err = si.client.CreateRelationship(ctx, moduleID, fileID, "CONTAINS", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to link file to module: %w", err)
+	}
+
+	return moduleID, nil
+}
+
+// Helper functions
+func (si *StaticIndexer) getPackageFQN(filePath, packageName string) string {
+	// Simple FQN generation - can be enhanced with proper module detection
+	return fmt.Sprintf("%s/%s", si.serviceName, packageName)
+}
+
+func (si *StaticIndexer) calculateFileHash(filePath string) (string, error) {
+	// Read file contents and calculate hash
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+	}
+
+	hash := sha256.Sum256(content)
+	return fmt.Sprintf("%x", hash), nil
+}
+
+// getExistingFileHashes retrieves existing file paths and their hashes from the database
+func (si *StaticIndexer) getExistingFileHashes(ctx context.Context) (map[string]string, error) {
+	query := `
+		MATCH (s:Service {name: $serviceName})-[:CONTAINS]->(f:File)
+		RETURN f.path as path, f.hash as hash
+	`
+
+	params := map[string]any{"serviceName": si.serviceName}
+	results, err := si.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query existing files: %w", err)
+	}
+
+	fileHashes := make(map[string]string)
+	for _, record := range results {
+		recordMap := record.AsMap()
+		path, ok := recordMap["path"].(string)
+		if !ok {
+			continue
+		}
+		hash, ok := recordMap["hash"].(string)
+		if !ok {
+			continue
+		}
+		fileHashes[path] = hash
+	}
+
+	return fileHashes, nil
+}
+
+// indexFileIncremental indexes a single file with incremental logic
+func (si *StaticIndexer) indexFileIncremental(ctx context.Context, filePath, serviceID, fileHash string) error {
+	// First, remove existing nodes for this file to avoid duplicates
+	if err := si.removeFileNodes(ctx, filePath); err != nil {
+		log.Printf("Warning: failed to remove existing nodes for %s: %v", filePath, err)
+	}
+
+	// Now index the file normally with the new hash
+	return si.indexFileWithHash(ctx, filePath, serviceID, fileHash)
+}
+
+// indexFileWithHash is like indexFile but accepts a pre-calculated hash
+func (si *StaticIndexer) indexFileWithHash(ctx context.Context, filePath, serviceID, fileHash string) error {
+	// Parse the file
+	fset := token.NewFileSet()
+	si.fset = fset // Store fset for call graph extraction
+	node, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("failed to parse file %s: %w", filePath, err)
+	}
+
+	// Create file node with the provided hash
+	fileProps := map[string]any{
+		"path":         filePath,
+		"absolutePath": filePath,
+		"language":     "Go",
+		"hash":         fileHash,
+		"lineCount":    fset.Position(node.End()).Line,
+		"createdAt":    time.Now().UTC().Unix(),
+		"updatedAt":    time.Now().UTC().Unix(),
+	}
+
+	fileID, err := si.client.MergeNode(ctx, []string{"File"},
+		map[string]any{"path": filePath}, fileProps)
+	if err != nil {
+		return fmt.Errorf("failed to create file node: %w", err)
+	}
+
+	// Link file to service
+	_, err = si.client.CreateRelationship(ctx, serviceID, fileID, "CONTAINS", nil)
+	if err != nil {
+		return fmt.Errorf("failed to link file to service: %w", err)
+	}
+
+	// Index the package/module
+	packageName := node.Name.Name
+	packageFQN := si.getPackageFQN(filePath, packageName)
+
+	moduleID, err := si.getOrCreateModule(ctx, packageName, packageFQN, fileID)
+	if err != nil {
+		return fmt.Errorf("failed to create module node: %w", err)
+	}
+
+	// Create a visitor to traverse the AST
+	visitor := &astVisitor{
+		indexer:   si,
+		ctx:       ctx,
+		fileID:    fileID,
+		moduleID:  moduleID,
+		filePath:  filePath,
+		fset:      fset,
+		packageName: packageName,
+	}
+
+	// Visit all nodes in the AST
+	ast.Walk(visitor, node)
+
+	return nil
+}
+
+// removeFileNodes removes all nodes associated with a file
+func (si *StaticIndexer) removeFileNodes(ctx context.Context, filePath string) error {
+	query := `
+		MATCH (f:File {path: $filePath})
+		OPTIONAL MATCH (f)-[:CONTAINS|DEFINES|DECLARES|CALLS|BELONGS_TO*]-(related)
+		DETACH DELETE f, related
+	`
+
+	params := map[string]any{"filePath": filePath}
+	_, err := si.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("failed to remove file nodes for %s: %w", filePath, err)
+	}
+
+	log.Printf("Removed nodes for file: %s", filePath)
+	return nil
+}
+
+func shouldSkipDir(dirName string) bool {
+	skipDirs := []string{
+		"vendor", ".git", ".github", "node_modules", ".vscode",
+		"bin", "build", "dist", "tmp", ".idea",
+	}
+	
+	for _, skip := range skipDirs {
+		if dirName == skip {
+			return true
+		}
+	}
+	
+	return false
+}
+
+// indexInterface indexes an interface declaration
+func (v *astVisitor) indexInterface(interfaceType *ast.InterfaceType) {
+	// This method is called when visiting InterfaceType nodes directly
+	// The actual interface indexing is handled in indexInterfaceType
+}
+
+// extractCallGraph analyzes a function for call graph relationships
+func (si *StaticIndexer) extractCallGraph(ctx context.Context, funcDecl *ast.FuncDecl, funcID string) error {
+	if si.callGraphExtractor == nil {
+		return nil // Skip if no call graph extractor
+	}
+
+	// Extract calls from the function using current visitor context
+	// We need to pass the current package and file context
+	packageName := si.serviceName // Use service name as package for now
+	filePath := "" // File path would need to be tracked in visitor
+
+	return si.callGraphExtractor.ExtractCallsFromFunction(ctx, funcDecl, funcID,
+		si.fset, packageName, filePath)
+}
+
+// Helper field to track current fset (needed for call graph extraction)
+var currentFset *token.FileSet
+
+// Helper method to set fset for call graph extraction
+func (si *StaticIndexer) setFileSet(fset *token.FileSet) {
+	si.fset = fset
+}

--- a/services/indexing-go/static/indexer_manager.go
+++ b/services/indexing-go/static/indexer_manager.go
@@ -1,0 +1,492 @@
+package static
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// InstallMethod describes how a SCIP indexer should be installed.
+type InstallMethod string
+
+const (
+	InstallBinaryDownload InstallMethod = "binary"
+	InstallNPM            InstallMethod = "npm"
+	InstallCoursier       InstallMethod = "coursier"
+	InstallGoInstall      InstallMethod = "go_install"
+	InstallComposer       InstallMethod = "composer"
+)
+
+// IndexerRelease describes a downloadable SCIP indexer binary.
+type IndexerRelease struct {
+	Language  Language
+	Binary    string            // e.g. "scip-go"
+	Version   string            // e.g. "v0.1.26"
+	Method    InstallMethod     // primary install method
+	URL       string            // for binary downloads
+	Checksums map[string]string // SHA-256 hex keyed by "os/arch"
+	Package   string            // npm package name or Maven coordinate
+	MainClass string            // for coursier (Java)
+	FallbackCmd string          // fallback install command (e.g. go install ...)
+}
+
+// DefaultReleases returns the known-good release definitions for each language.
+func DefaultReleases() []IndexerRelease {
+	return []IndexerRelease{
+		{
+			Language: LanguageGo,
+			Binary:   "scip-go",
+			Version:  "v0.1.26",
+			Method:   InstallBinaryDownload,
+			URL:      "https://github.com/sourcegraph/scip-go/releases/download/{version}/scip-go_{version_num}_{os}_{arch}.tar.gz",
+			Checksums: map[string]string{
+				"linux/amd64":  "66257b6db74e13c2e756c9abba8e7d34e62eb91d16cdbe087a0b0c170c89c37d",
+				"linux/arm64":  "bc8e5abb959521912d60181de8922e5158a609a2e9d87e6ed2b7801c11c0efab",
+				"darwin/amd64": "768d8048d537f1e2a26735b37fa0481296c6a1010392b2750c88b73716b529cf",
+				"darwin/arm64": "1b87a5e0b2af4e41bc1cc49220e7d3a84a831468ae6944a9574e7d4c1270909c",
+			},
+			FallbackCmd: "go install github.com/sourcegraph/scip-go/cmd/scip-go@v0.1.26",
+		},
+		{
+			Language: LanguageTypeScript,
+			Binary:   "scip-typescript",
+			Version:  "0.3.11",
+			Method:   InstallNPM,
+			Package:  "@sourcegraph/scip-typescript",
+		},
+		{
+			Language: LanguagePython,
+			Binary:   "scip-python",
+			Version:  "0.5.3",
+			Method:   InstallNPM,
+			Package:  "@sourcegraph/scip-python",
+		},
+		{
+			Language: LanguageJava,
+			Binary:   "scip-java",
+			Version:  "0.8.23",
+			Method:   InstallCoursier,
+			Package:  "com.sourcegraph:scip-java_2.13",
+			MainClass: "com.sourcegraph.scip_java.ScipJava",
+		},
+		{
+			Language: LanguagePHP,
+			Binary:   "scip-php",
+			Version:  "0.0.2",
+			Method:   InstallComposer,
+			Package:  "davidrjenni/scip-php",
+		},
+	}
+}
+
+// IndexerManager manages downloading, caching, and resolving SCIP indexer binaries.
+type IndexerManager struct {
+	cacheDir string // e.g. ~/.codegraph/indexers
+	releases []IndexerRelease
+}
+
+// NewIndexerManager creates a new manager using the given cache directory.
+// If cacheDir is empty, defaults to ~/.codegraph/indexers.
+func NewIndexerManager(cacheDir string) *IndexerManager {
+	if cacheDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = "/tmp"
+		}
+		cacheDir = filepath.Join(home, ".codegraph", "indexers")
+	}
+	return &IndexerManager{
+		cacheDir: cacheDir,
+		releases: DefaultReleases(),
+	}
+}
+
+// CacheDir returns the cache directory path.
+func (m *IndexerManager) CacheDir() string {
+	return m.cacheDir
+}
+
+// ResolveBinary returns the path to the SCIP indexer binary for the given language.
+// It checks in order:
+// 1. The local cache directory
+// 2. The system PATH
+// Returns empty string if not found.
+func (m *IndexerManager) ResolveBinary(lang Language) string {
+	config, err := GetLanguageConfig(lang)
+	if err != nil {
+		return ""
+	}
+
+	// Check cache first
+	cachedPath := m.CachedBinaryPath(lang)
+	if cachedPath != "" {
+		if info, err := os.Stat(cachedPath); err == nil && !info.IsDir() {
+			return cachedPath
+		}
+	}
+
+	// Fall back to system PATH
+	if path, err := exec.LookPath(config.SCIPBinary); err == nil {
+		return path
+	}
+
+	return ""
+}
+
+// CachedBinaryPath returns the expected cache path for a language's indexer binary.
+func (m *IndexerManager) CachedBinaryPath(lang Language) string {
+	release := m.findRelease(lang)
+	if release == nil {
+		return ""
+	}
+	return filepath.Join(m.cacheDir, string(lang), release.Version, release.Binary)
+}
+
+// IsInstalled checks if the indexer for the given language is available.
+func (m *IndexerManager) IsInstalled(lang Language) bool {
+	return m.ResolveBinary(lang) != ""
+}
+
+// Install downloads and caches the SCIP indexer for the given language.
+// It dispatches based on the release's InstallMethod.
+func (m *IndexerManager) Install(lang Language) error {
+	release := m.findRelease(lang)
+	if release == nil {
+		// No release definition — fall back to language config
+		config, err := GetLanguageConfig(lang)
+		if err != nil {
+			return fmt.Errorf("unsupported language: %s", lang)
+		}
+		return m.installViaCommand(config)
+	}
+
+	switch release.Method {
+	case InstallBinaryDownload:
+		return m.downloadAndCache(release)
+	case InstallNPM:
+		return m.installNPM(release)
+	case InstallCoursier:
+		return m.installCoursier(release)
+	case InstallGoInstall:
+		return m.installGoInstall(release)
+	case InstallComposer:
+		return m.installComposer(release)
+	default:
+		// Unknown method — fall back to language config
+		config, err := GetLanguageConfig(lang)
+		if err != nil {
+			return fmt.Errorf("unsupported language: %s", lang)
+		}
+		return m.installViaCommand(config)
+	}
+}
+
+// InstallAll installs indexers for the given languages.
+func (m *IndexerManager) InstallAll(languages []Language) (installed []Language, failed map[Language]error) {
+	failed = make(map[Language]error)
+	for _, lang := range languages {
+		if m.IsInstalled(lang) {
+			installed = append(installed, lang)
+			continue
+		}
+		if err := m.Install(lang); err != nil {
+			failed[lang] = err
+		} else {
+			installed = append(installed, lang)
+		}
+	}
+	return
+}
+
+// Status returns the installation status for all known languages.
+func (m *IndexerManager) Status() []IndexerStatus {
+	var statuses []IndexerStatus
+	for _, release := range m.releases {
+		status := IndexerStatus{
+			Language: release.Language,
+			Binary:   release.Binary,
+			Version:  release.Version,
+		}
+		path := m.ResolveBinary(release.Language)
+		if path != "" {
+			status.Installed = true
+			status.Path = path
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses
+}
+
+// IndexerStatus reports installation status for a language.
+type IndexerStatus struct {
+	Language  Language `json:"language"`
+	Binary    string   `json:"binary"`
+	Version   string   `json:"version"`
+	Installed bool     `json:"installed"`
+	Path      string   `json:"path,omitempty"`
+}
+
+// downloadAndCache downloads a binary from URL and stores it in the cache directory.
+// Supports both raw binaries and .tar.gz archives.
+func (m *IndexerManager) downloadAndCache(release *IndexerRelease) error {
+	destDir := filepath.Join(m.cacheDir, string(release.Language), release.Version)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	destPath := filepath.Join(destDir, release.Binary)
+
+	// Resolve platform-specific URL
+	url := m.resolveURL(release)
+	if url == "" {
+		return fmt.Errorf("no download URL for %s on %s/%s", release.Binary, runtime.GOOS, runtime.GOARCH)
+	}
+
+	fmt.Printf("Downloading %s %s from %s...\n", release.Binary, release.Version, url)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
+	}
+
+	tmpFile, err := os.CreateTemp(destDir, release.Binary+"-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	hasher := sha256.New()
+	writer := io.MultiWriter(tmpFile, hasher)
+
+	if _, err := io.Copy(writer, resp.Body); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("download write failed: %w", err)
+	}
+	tmpFile.Close()
+
+	// Verify checksum if provided
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	if expectedHash, ok := release.Checksums[platform]; ok && expectedHash != "" {
+		actualHash := hex.EncodeToString(hasher.Sum(nil))
+		if actualHash != expectedHash {
+			return fmt.Errorf("checksum mismatch for %s: expected %s, got %s",
+				release.Binary, expectedHash, actualHash)
+		}
+	}
+
+	// Extract from tar.gz if needed, otherwise treat as raw binary
+	if strings.HasSuffix(url, ".tar.gz") || strings.HasSuffix(url, ".tgz") {
+		if err := extractTarGz(tmpFile.Name(), release.Binary, destPath); err != nil {
+			return fmt.Errorf("failed to extract archive: %w", err)
+		}
+	} else {
+		// Raw binary — just move it
+		if err := os.Chmod(tmpFile.Name(), 0755); err != nil {
+			return fmt.Errorf("failed to set executable bit: %w", err)
+		}
+		if err := os.Rename(tmpFile.Name(), destPath); err != nil {
+			return fmt.Errorf("failed to move binary to cache: %w", err)
+		}
+	}
+
+	fmt.Printf("Installed %s %s at %s\n", release.Binary, release.Version, destPath)
+	return nil
+}
+
+// extractTarGz extracts binaryName from a .tar.gz archive and writes it to destPath.
+func extractTarGz(archivePath, binaryName, destPath string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open archive: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read: %w", err)
+		}
+
+		// Match the binary by base name (it may be nested in a directory)
+		if filepath.Base(hdr.Name) == binaryName && hdr.Typeflag == tar.TypeReg {
+			out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+			if err != nil {
+				return fmt.Errorf("create dest file: %w", err)
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return fmt.Errorf("extract binary: %w", err)
+			}
+			out.Close()
+			return nil
+		}
+	}
+
+	return fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+// installNPM installs a SCIP indexer via npm.
+func (m *IndexerManager) installNPM(release *IndexerRelease) error {
+	npmPath, err := exec.LookPath("npm")
+	if err != nil {
+		return fmt.Errorf("npm not found on PATH; install Node.js first")
+	}
+
+	pkg := release.Package + "@" + release.Version
+	fmt.Printf("Installing %s via: npm install -g %s\n", release.Binary, pkg)
+
+	cmd := exec.Command(npmPath, "install", "-g", pkg)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("npm install failed: %w", err)
+	}
+	return nil
+}
+
+// installCoursier installs a SCIP indexer via coursier bootstrap.
+func (m *IndexerManager) installCoursier(release *IndexerRelease) error {
+	csPath, err := exec.LookPath("cs")
+	if err != nil {
+		csPath, err = exec.LookPath("coursier")
+		if err != nil {
+			return fmt.Errorf("coursier (cs) not found on PATH; install from https://get-coursier.io")
+		}
+	}
+
+	destDir := filepath.Join(m.cacheDir, string(release.Language), release.Version)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+	destPath := filepath.Join(destDir, release.Binary)
+
+	coordinate := release.Package + ":" + release.Version
+	fmt.Printf("Installing %s via: %s bootstrap %s\n", release.Binary, filepath.Base(csPath), coordinate)
+
+	cmd := exec.Command(csPath, "bootstrap", "--standalone",
+		"-o", destPath,
+		coordinate,
+		"--main", release.MainClass,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("coursier bootstrap failed: %w", err)
+	}
+
+	fmt.Printf("Installed %s %s at %s\n", release.Binary, release.Version, destPath)
+	return nil
+}
+
+// installGoInstall installs a SCIP indexer via go install.
+func (m *IndexerManager) installGoInstall(release *IndexerRelease) error {
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		return fmt.Errorf("go not found on PATH; install Go first")
+	}
+
+	if release.FallbackCmd == "" {
+		return fmt.Errorf("no go install command configured for %s", release.Binary)
+	}
+
+	fmt.Printf("Installing %s via: go install %s\n", release.Binary, release.FallbackCmd)
+
+	// FallbackCmd is like "go install github.com/.../scip-go@v0.1.26"
+	// Extract the package path (everything after "go install ")
+	pkgPath := release.FallbackCmd
+	pkgPath = strings.TrimPrefix(pkgPath, "go install ")
+
+	cmd := exec.Command(goPath, "install", pkgPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("go install failed: %w", err)
+	}
+	return nil
+}
+
+// installComposer installs a SCIP indexer via composer global require.
+func (m *IndexerManager) installComposer(release *IndexerRelease) error {
+	composerPath, err := exec.LookPath("composer")
+	if err != nil {
+		return fmt.Errorf("composer not found on PATH; install Composer first (https://getcomposer.org)")
+	}
+
+	pkg := release.Package + ":" + release.Version
+	fmt.Printf("Installing %s via: composer global require %s\n", release.Binary, pkg)
+
+	cmd := exec.Command(composerPath, "global", "require", pkg)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("composer global require failed: %w", err)
+	}
+	return nil
+}
+
+// installViaCommand runs the language's standard install command.
+func (m *IndexerManager) installViaCommand(config *LanguageConfig) error {
+	if config.InstallCommand == "" || strings.HasPrefix(config.InstallCommand, "See ") {
+		return fmt.Errorf("no automated install available for %s. Please install manually: %s",
+			config.DisplayName, config.InstallDocs)
+	}
+
+	fmt.Printf("Installing %s via: %s\n", config.SCIPBinary, config.InstallCommand)
+	parts := strings.Fields(config.InstallCommand)
+	cmd := exec.Command(parts[0], parts[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("install command failed: %w", err)
+	}
+	return nil
+}
+
+// resolveURL builds a platform-specific download URL from a release's URL pattern.
+func (m *IndexerManager) resolveURL(release *IndexerRelease) string {
+	if release.URL == "" {
+		return ""
+	}
+	url := release.URL
+	url = strings.ReplaceAll(url, "{os}", runtime.GOOS)
+	url = strings.ReplaceAll(url, "{arch}", runtime.GOARCH)
+	url = strings.ReplaceAll(url, "{binary}", release.Binary)
+	url = strings.ReplaceAll(url, "{version}", release.Version)
+	// {version_num} strips the leading "v" (e.g. "v0.1.26" -> "0.1.26")
+	url = strings.ReplaceAll(url, "{version_num}", strings.TrimPrefix(release.Version, "v"))
+	return url
+}
+
+func (m *IndexerManager) findRelease(lang Language) *IndexerRelease {
+	for i := range m.releases {
+		if m.releases[i].Language == lang {
+			return &m.releases[i]
+		}
+	}
+	return nil
+}

--- a/services/indexing-go/static/language_config.go
+++ b/services/indexing-go/static/language_config.go
@@ -1,0 +1,247 @@
+package static
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Language represents a supported programming language
+type Language string
+
+const (
+	LanguageGo         Language = "go"
+	LanguageTypeScript Language = "typescript"
+	LanguageJavaScript Language = "javascript"
+	LanguagePython     Language = "python"
+	LanguageJava       Language = "java"
+	LanguageScala      Language = "scala"
+	LanguageKotlin     Language = "kotlin"
+	LanguagePHP        Language = "php"
+)
+
+// LanguageConfig holds configuration for a specific language's SCIP indexer
+type LanguageConfig struct {
+	Name            Language
+	DisplayName     string
+	SCIPBinary      string
+	FileExtensions  []string
+	InstallCommand  string
+	InstallDocs     string
+	IndexFlags      []string
+	DetectionFiles  []string // Files that indicate this language (e.g., go.mod, package.json)
+}
+
+// LanguageRegistry holds all supported language configurations
+var LanguageRegistry = map[Language]*LanguageConfig{
+	LanguageGo: {
+		Name:           LanguageGo,
+		DisplayName:    "Go",
+		SCIPBinary:     "scip-go",
+		FileExtensions: []string{".go"},
+		InstallCommand: "go install github.com/sourcegraph/scip-go/cmd/scip-go@latest",
+		InstallDocs:    "https://github.com/sourcegraph/scip-go",
+		IndexFlags:     []string{},
+		DetectionFiles: []string{"go.mod", "go.sum"},
+	},
+	LanguageTypeScript: {
+		Name:           LanguageTypeScript,
+		DisplayName:    "TypeScript",
+		SCIPBinary:     "scip-typescript",
+		FileExtensions: []string{".ts", ".tsx"},
+		InstallCommand: "npm install -g @sourcegraph/scip-typescript",
+		InstallDocs:    "https://github.com/sourcegraph/scip-typescript",
+		IndexFlags:     []string{"index"},
+		DetectionFiles: []string{"tsconfig.json", "package.json"},
+	},
+	LanguageJavaScript: {
+		Name:           LanguageJavaScript,
+		DisplayName:    "JavaScript",
+		SCIPBinary:     "scip-typescript", // TypeScript indexer handles JS too
+		FileExtensions: []string{".js", ".jsx"},
+		InstallCommand: "npm install -g @sourcegraph/scip-typescript",
+		InstallDocs:    "https://github.com/sourcegraph/scip-typescript",
+		IndexFlags:     []string{"index"},
+		DetectionFiles: []string{"package.json"},
+	},
+	LanguagePython: {
+		Name:           LanguagePython,
+		DisplayName:    "Python",
+		SCIPBinary:     "scip-python",
+		FileExtensions: []string{".py"},
+		InstallCommand: "npm install -g @sourcegraph/scip-python",
+		InstallDocs:    "https://github.com/sourcegraph/scip-python",
+		IndexFlags:     []string{"index"},
+		DetectionFiles: []string{"requirements.txt", "pyproject.toml", "setup.py", "Pipfile"},
+	},
+	LanguageJava: {
+		Name:           LanguageJava,
+		DisplayName:    "Java",
+		SCIPBinary:     "scip-java",
+		FileExtensions: []string{".java"},
+		InstallCommand: "See installation docs for build tool integration",
+		InstallDocs:    "https://sourcegraph.github.io/scip-java/",
+		IndexFlags:     []string{},
+		DetectionFiles: []string{"pom.xml", "build.gradle", "build.gradle.kts"},
+	},
+	LanguageScala: {
+		Name:           LanguageScala,
+		DisplayName:    "Scala",
+		SCIPBinary:     "scip-java", // scip-java handles Scala too
+		FileExtensions: []string{".scala"},
+		InstallCommand: "See installation docs for build tool integration",
+		InstallDocs:    "https://sourcegraph.github.io/scip-java/",
+		IndexFlags:     []string{},
+		DetectionFiles: []string{"build.sbt", "build.gradle"},
+	},
+	LanguageKotlin: {
+		Name:           LanguageKotlin,
+		DisplayName:    "Kotlin",
+		SCIPBinary:     "scip-java", // scip-java handles Kotlin too
+		FileExtensions: []string{".kt", ".kts"},
+		InstallCommand: "See installation docs for build tool integration",
+		InstallDocs:    "https://sourcegraph.github.io/scip-java/",
+		IndexFlags:     []string{},
+		DetectionFiles: []string{"build.gradle.kts"},
+	},
+	LanguagePHP: {
+		Name:           LanguagePHP,
+		DisplayName:    "PHP",
+		SCIPBinary:     "scip-php",
+		FileExtensions: []string{".php"},
+		InstallCommand: "composer global require davidrjenni/scip-php",
+		InstallDocs:    "https://github.com/davidrjenni/scip-php",
+		IndexFlags:     []string{},
+		DetectionFiles: []string{"composer.json", "composer.lock"},
+	},
+}
+
+// GetLanguageConfig retrieves configuration for a language
+func GetLanguageConfig(lang Language) (*LanguageConfig, error) {
+	config, ok := LanguageRegistry[lang]
+	if !ok {
+		return nil, fmt.Errorf("unsupported language: %s", lang)
+	}
+	return config, nil
+}
+
+// DetectLanguage attempts to detect the primary language of a project
+func DetectLanguage(projectPath string) (Language, error) {
+	// Priority order for detection
+	detectionOrder := []Language{
+		LanguageGo,
+		LanguageTypeScript,
+		LanguageJavaScript,
+		LanguagePython,
+		LanguageJava,
+		LanguageScala,
+		LanguageKotlin,
+	}
+
+	for _, lang := range detectionOrder {
+		config, err := GetLanguageConfig(lang)
+		if err != nil {
+			continue
+		}
+
+		// Check for detection files
+		for _, detectionFile := range config.DetectionFiles {
+			filePath := filepath.Join(projectPath, detectionFile)
+			if _, err := os.Stat(filePath); err == nil {
+				// Special case: distinguish TypeScript from JavaScript
+				if lang == LanguageTypeScript {
+					// Check if tsconfig.json exists
+					tsconfigPath := filepath.Join(projectPath, "tsconfig.json")
+					if _, err := os.Stat(tsconfigPath); err == nil {
+						return LanguageTypeScript, nil
+					}
+					// If only package.json exists, might be JavaScript
+					continue
+				}
+				return lang, nil
+			}
+		}
+	}
+
+	// Fallback: detect by counting file extensions
+	extCounts := make(map[Language]int)
+
+	err := filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip errors
+		}
+		if info.IsDir() {
+			// Skip common directories
+			dirName := info.Name()
+			if dirName == "node_modules" || dirName == ".git" || dirName == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		for lang, config := range LanguageRegistry {
+			for _, langExt := range config.FileExtensions {
+				if ext == langExt {
+					extCounts[lang]++
+					break
+				}
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to walk project directory: %w", err)
+	}
+
+	// Find language with most files
+	var detectedLang Language
+	maxCount := 0
+	for lang, count := range extCounts {
+		if count > maxCount {
+			maxCount = count
+			detectedLang = lang
+		}
+	}
+
+	if maxCount == 0 {
+		return "", fmt.Errorf("could not detect language for project at %s", projectPath)
+	}
+
+	return detectedLang, nil
+}
+
+// InferLanguageFromExtension infers language from file extension
+func InferLanguageFromExtension(filePath string) string {
+	ext := strings.ToLower(filepath.Ext(filePath))
+
+	for _, config := range LanguageRegistry {
+		for _, langExt := range config.FileExtensions {
+			if ext == langExt {
+				return config.DisplayName
+			}
+		}
+	}
+
+	return "unknown"
+}
+
+// GetSupportedLanguages returns a list of all supported languages
+func GetSupportedLanguages() []Language {
+	langs := make([]Language, 0, len(LanguageRegistry))
+	for lang := range LanguageRegistry {
+		langs = append(langs, lang)
+	}
+	return langs
+}
+
+// FormatLanguageList returns a formatted string of supported languages
+func FormatLanguageList() string {
+	var parts []string
+	for _, config := range LanguageRegistry {
+		parts = append(parts, string(config.Name))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/services/indexing-go/static/scip_indexer.go
+++ b/services/indexing-go/static/scip_indexer.go
@@ -1,0 +1,1019 @@
+package static
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/context-maximiser/code-graph/pkg/indexer/generated"
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+)
+
+// PipelineTimer is an optional interface for timing pipeline phases.
+// Implementations include benchmarks.PhaseTimer.
+type PipelineTimer interface {
+	Start(name string)
+	Stop(items int, detail string)
+}
+
+// SubPhaseRecorder is an optional extension of PipelineTimer for recording
+// sub-phase breakdowns within a parent phase.
+type SubPhaseRecorder interface {
+	AddResult(name string, duration time.Duration, items int, detail string)
+}
+
+// SCIPIndexer indexes projects using the SCIP protocol
+type SCIPIndexer struct {
+	client           *neo4j.Client
+	serviceName      string
+	version          string
+	repoURL          string
+	language         Language
+	langConfig       *LanguageConfig
+	scopeCtx         models.ScopeContext
+	timer            PipelineTimer
+	fileContentCache map[string][]byte // cache for calculateByteOffsets
+}
+
+// NewSCIPIndexer creates a new SCIP-based indexer
+func NewSCIPIndexer(client *neo4j.Client, serviceName, version, repoURL string) *SCIPIndexer {
+	// Default to Go for backward compatibility
+	return NewSCIPIndexerWithLanguage(client, serviceName, version, repoURL, LanguageGo)
+}
+
+// NewSCIPIndexerWithLanguage creates a new SCIP-based indexer for a specific language
+func NewSCIPIndexerWithLanguage(client *neo4j.Client, serviceName, version, repoURL string, lang Language) *SCIPIndexer {
+	langConfig, err := GetLanguageConfig(lang)
+	if err != nil {
+		// Fallback to Go if language not found
+		langConfig, _ = GetLanguageConfig(LanguageGo)
+		lang = LanguageGo
+	}
+
+	return &SCIPIndexer{
+		client:      client,
+		serviceName: serviceName,
+		version:     version,
+		repoURL:     repoURL,
+		language:    lang,
+		langConfig:  langConfig,
+		scopeCtx:    models.DefaultScope(),
+	}
+}
+
+// IndexProject indexes a project using SCIP
+func (si *SCIPIndexer) IndexProject(ctx context.Context, projectPath string) error {
+	fmt.Printf("Starting SCIP indexing for %s project at %s\n", si.langConfig.DisplayName, projectPath)
+
+	// Step 1: Generate SCIP index file
+	if si.timer != nil {
+		si.timer.Start("SCIP generation")
+	}
+	scipFile, err := si.generateSCIPIndex(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to generate SCIP index: %w", err)
+	}
+	if si.timer != nil {
+		si.timer.Stop(0, "")
+	}
+	// Only clean up for languages that auto-generate (not Java/Scala/Kotlin)
+	if si.language != LanguageJava && si.language != LanguageScala && si.language != LanguageKotlin {
+		defer os.Remove(scipFile) // Clean up temporary file
+	}
+
+	fmt.Printf("Using SCIP index file: %s\n", scipFile)
+
+	// Step 2: Parse the SCIP file
+	if si.timer != nil {
+		si.timer.Start("Parse SCIP file")
+	}
+	parser := NewSCIPParser()
+	if err := parser.ParseFile(scipFile); err != nil {
+		return fmt.Errorf("failed to parse SCIP file: %w", err)
+	}
+	if si.timer != nil {
+		si.timer.Stop(0, "")
+	}
+
+	// Debug: Print SCIP file contents
+	if err := parser.DebugPrintSCIPFile(); err != nil {
+		fmt.Printf("Warning: failed to debug print SCIP file: %v\n", err)
+	}
+
+	// Step 3: Create service node
+	if si.timer != nil {
+		si.timer.Start("Create service node")
+	}
+	serviceID, err := si.createServiceNode(ctx, projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to create service node: %w", err)
+	}
+	if si.timer != nil {
+		si.timer.Stop(1, "")
+	}
+
+	// Step 4: Index files
+	if si.timer != nil {
+		si.timer.Start("Index files")
+	}
+	files, err := parser.ExtractDocuments()
+	if err != nil {
+		return fmt.Errorf("failed to extract documents: %w", err)
+	}
+
+	fileNodes := make(map[string]string) // filePath -> nodeID mapping
+	for _, file := range files {
+		fileID, err := si.createFileNode(ctx, file, serviceID)
+		if err != nil {
+			fmt.Printf("Warning: failed to create file node for %s: %v\n", file.Path, err)
+			continue
+		}
+		fileNodes[file.Path] = fileID
+	}
+	if si.timer != nil {
+		si.timer.Stop(len(fileNodes), fmt.Sprintf("%d files", len(fileNodes)))
+	}
+
+	fmt.Printf("Created %d file nodes\n", len(fileNodes))
+
+	// Step 5: Extract symbols
+	if si.timer != nil {
+		si.timer.Start("Extract symbols")
+	}
+	symbolDefs, err := parser.ExtractSymbols()
+	if err != nil {
+		return fmt.Errorf("failed to extract symbols: %w", err)
+	}
+	if si.timer != nil {
+		si.timer.Stop(len(symbolDefs), fmt.Sprintf("%d symbols", len(symbolDefs)))
+	}
+
+	// Step 6 & 7: Index symbols (defs then refs) — instrumented inside indexSymbols
+	if err := si.indexSymbols(ctx, symbolDefs, fileNodes); err != nil {
+		return fmt.Errorf("failed to index symbols: %w", err)
+	}
+
+	fmt.Printf("Successfully indexed %d symbols from SCIP data\n", len(symbolDefs))
+
+	// Step 8: Package dependencies
+	if si.timer != nil {
+		si.timer.Start("Package dependencies")
+	}
+	imports, err := parser.ExtractImports(projectPath)
+	if err != nil {
+		fmt.Printf("Warning: failed to extract imports: %v\n", err)
+	} else {
+		fmt.Printf("Extracted %d import statements\n", len(imports))
+		if err := si.indexPackageDependencies(ctx, imports, serviceID); err != nil {
+			fmt.Printf("Warning: failed to index package dependencies: %v\n", err)
+		}
+	}
+	if si.timer != nil {
+		importCount := 0
+		if imports != nil {
+			importCount = len(imports)
+		}
+		si.timer.Stop(importCount, "")
+	}
+
+	// Step 9: Symbol-based API analysis
+	if si.timer != nil {
+		si.timer.Start("API analysis")
+	}
+	fmt.Println("Analyzing API patterns via SCIP symbol matching...")
+	symAnalyzer := NewSymbolAnalyzer(si.client, si.serviceName, si.langConfig.DisplayName, projectPath)
+	symAnalyzer.SetScope(si.scopeCtx)
+	if err := symAnalyzer.AnalyzeBySymbols(ctx); err != nil {
+		fmt.Printf("Warning: symbol-based API analysis failed: %v\n", err)
+	}
+	if si.timer != nil {
+		si.timer.Stop(0, "")
+	}
+
+	// Step 10: Build call graph (Go only, requires AST for function body ranges)
+	if si.timer != nil {
+		si.timer.Start("Call graph")
+	}
+	if si.language == LanguageGo {
+		fmt.Println("Building call graph from SCIP references + Go AST...")
+		cgBuilder := NewSCIPCallGraphBuilder(si.client, projectPath)
+		cgBuilder.SetScope(si.scopeCtx)
+		if err := cgBuilder.BuildCallGraph(ctx); err != nil {
+			fmt.Printf("Warning: call graph construction failed: %v\n", err)
+		}
+	}
+	if si.timer != nil {
+		si.timer.Stop(0, "")
+	}
+
+	// Step 11: Generate context for PR overlays (creates PullRequest node + PR summary)
+	if si.scopeCtx.Scope == models.ScopePR && si.client != nil {
+		ctxGen := generated.NewContextGenerator(si.client)
+		ctxGen.SetScope(si.scopeCtx)
+
+		// Extract PR ID from scopeId (format: "pr-{id}")
+		prID := strings.TrimPrefix(si.scopeCtx.ScopeID, "pr-")
+
+		if _, err := ctxGen.CreatePullRequestNode(ctx, prID,
+			fmt.Sprintf("PR %s: %s indexing", prID, si.serviceName),
+			"", "", "", ""); err != nil {
+			fmt.Printf("Warning: failed to create PullRequest node: %v\n", err)
+		} else {
+			// Store a basic PR summary with indexed file list
+			fileKeys := make([]string, 0)
+			for _, f := range fileNodes {
+				fileKeys = append(fileKeys, f)
+			}
+			summary := fmt.Sprintf("Indexed %d files and %d symbols for service %s",
+				len(fileNodes), len(symbolDefs), si.serviceName)
+			if _, err := ctxGen.StorePRSummary(ctx, prID,
+				fmt.Sprintf("Indexing summary for %s", si.serviceName),
+				summary, "scip-indexer", fileKeys); err != nil {
+				fmt.Printf("Warning: failed to store PR summary: %v\n", err)
+			}
+		}
+	}
+
+	fmt.Println("SCIP indexing completed successfully")
+	return nil
+}
+
+// generateSCIPIndex runs the appropriate SCIP indexer to generate a SCIP index file
+func (si *SCIPIndexer) generateSCIPIndex(projectPath string) (string, error) {
+	// Resolve the SCIP binary: check IndexerManager cache first, then system PATH.
+	mgr := NewIndexerManager("")
+	resolvedBinary := mgr.ResolveBinary(si.language)
+	if resolvedBinary != "" {
+		si.langConfig.SCIPBinary = resolvedBinary
+	} else if _, err := exec.LookPath(si.langConfig.SCIPBinary); err != nil {
+		return "", fmt.Errorf("%s not found in PATH or cache.\nInstall with: codegraph indexers install --language %s\nOr manually: %s\nSee: %s",
+			si.langConfig.SCIPBinary,
+			si.language,
+			si.langConfig.InstallCommand,
+			si.langConfig.InstallDocs)
+	}
+
+	// Get absolute path for project
+	absPath, err := filepath.Abs(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// Create temporary output file with absolute path
+	outputFile := filepath.Join(absPath, "index.scip")
+
+	// Prepare language-specific command
+	var cmd *exec.Cmd
+	switch si.language {
+	case LanguageGo:
+		// scip-go --module-name <name> --module-version <version> --output <file>
+		cmd = exec.Command(si.langConfig.SCIPBinary,
+			"--module-name", si.serviceName,
+			"--module-version", si.version,
+			"--output", outputFile,
+		)
+	case LanguageTypeScript, LanguageJavaScript:
+		// scip-typescript index --output <file>
+		args := append(si.langConfig.IndexFlags, "--output", outputFile)
+
+		// Detect workspace type and add appropriate flags
+		workspaceType := si.detectWorkspaceType(absPath)
+		switch workspaceType {
+		case "pnpm":
+			args = append(args, "--pnpm-workspaces")
+			fmt.Println("Detected pnpm workspace, using --pnpm-workspaces")
+		case "yarn":
+			args = append(args, "--yarn-workspaces")
+			fmt.Println("Detected yarn workspace, using --yarn-workspaces")
+		}
+
+		// If no tsconfig.json at root, use --infer-tsconfig
+		if _, err := os.Stat(filepath.Join(absPath, "tsconfig.json")); os.IsNotExist(err) {
+			args = append(args, "--infer-tsconfig")
+			fmt.Println("No root tsconfig.json found, using --infer-tsconfig")
+		}
+
+		cmd = exec.Command(si.langConfig.SCIPBinary, args...)
+	case LanguagePython:
+		// scip-python index --project-name <name> --output <file>
+		args := append(si.langConfig.IndexFlags,
+			"--project-name", si.serviceName,
+			"--output", outputFile,
+		)
+		cmd = exec.Command(si.langConfig.SCIPBinary, args...)
+	case LanguagePHP:
+		// scip-php generates index.scip in current directory
+		// We need to specify the source directory
+		cmd = exec.Command(si.langConfig.SCIPBinary, "src", "--output", outputFile)
+	case LanguageJava, LanguageScala, LanguageKotlin:
+		// scip-java index
+		// scip-java runs the build tool (Maven/Gradle/sbt) and generates index.scip
+		// in the current directory
+		// Use sh -c to handle shell scripts
+		cmd = exec.Command("sh", "-c", si.langConfig.SCIPBinary+" index")
+	default:
+		return "", fmt.Errorf("unsupported language for SCIP indexing: %s", si.language)
+	}
+
+	// Set working directory to absolute path
+	cmd.Dir = absPath
+
+	// Run the command
+	fmt.Printf("Running: %s in %s\n", cmd.String(), absPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s command failed: %w\nOutput: %s", si.langConfig.SCIPBinary, err, string(output))
+	}
+
+	fmt.Printf("%s output: %s\n", si.langConfig.SCIPBinary, string(output))
+
+	// Verify the output file exists
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		return "", fmt.Errorf("SCIP index file was not generated: %s", outputFile)
+	}
+
+	return outputFile, nil
+}
+
+// detectWorkspaceType detects if the project uses a workspace manager (pnpm, yarn, npm)
+func (si *SCIPIndexer) detectWorkspaceType(projectPath string) string {
+	// Check for pnpm-workspace.yaml
+	if _, err := os.Stat(filepath.Join(projectPath, "pnpm-workspace.yaml")); err == nil {
+		return "pnpm"
+	}
+
+	// Check for yarn workspaces in package.json
+	packageJSONPath := filepath.Join(projectPath, "package.json")
+	if data, err := os.ReadFile(packageJSONPath); err == nil {
+		var packageData struct {
+			Workspaces interface{} `json:"workspaces"`
+		}
+		if err := json.Unmarshal(data, &packageData); err == nil {
+			if packageData.Workspaces != nil {
+				// Check for yarn.lock to distinguish yarn from npm
+				if _, err := os.Stat(filepath.Join(projectPath, "yarn.lock")); err == nil {
+					return "yarn"
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// createServiceNode creates the service node in Neo4j
+func (si *SCIPIndexer) createServiceNode(ctx context.Context, projectPath string) (string, error) {
+	// Try to extract actual package name from package.json for TypeScript/JavaScript
+	actualPackageName := si.serviceName
+	if si.language == LanguageTypeScript || si.language == LanguageJavaScript {
+		if npmName := si.extractNPMPackageName(projectPath); npmName != "" {
+			actualPackageName = npmName
+			fmt.Printf("Detected NPM package name: %s\n", npmName)
+		}
+	}
+
+	nodeKey := models.ServiceNodeKey(si.serviceName)
+	serviceProps := map[string]any{
+		"name":          si.serviceName,
+		"nodeKey":       nodeKey,
+		"packageName":   actualPackageName,
+		"language":      si.langConfig.DisplayName,
+		"version":       si.version,
+		"repositoryUrl": si.repoURL,
+		"scope":         si.scopeCtx.Scope,
+		"scopeId":       si.scopeCtx.ScopeID,
+	}
+
+	return si.client.MergeNode(ctx, []string{"Service"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": si.scopeCtx.ScopeID}, serviceProps)
+}
+
+// extractNPMPackageName reads package.json and extracts the package name
+func (si *SCIPIndexer) extractNPMPackageName(projectPath string) string {
+	packageJSONPath := filepath.Join(projectPath, "package.json")
+	data, err := os.ReadFile(packageJSONPath)
+	if err != nil {
+		return ""
+	}
+
+	var packageData struct {
+		Name string `json:"name"`
+	}
+
+	if err := json.Unmarshal(data, &packageData); err != nil {
+		return ""
+	}
+
+	return packageData.Name
+}
+
+// createFileNode creates a file node in Neo4j
+func (si *SCIPIndexer) createFileNode(ctx context.Context, file *models.File, serviceID string) (string, error) {
+	nodeKey := models.FileNodeKey(file.Path)
+	fileProps := map[string]any{
+		"path":         file.Path,
+		"nodeKey":      nodeKey,
+		"absolutePath": file.Path,
+		"language":     file.Language,
+		"hash":         "",
+		"lineCount":    0,
+		"scope":        si.scopeCtx.Scope,
+		"scopeId":      si.scopeCtx.ScopeID,
+	}
+
+	fileID, err := si.client.MergeNode(ctx, []string{"File"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": si.scopeCtx.ScopeID}, fileProps)
+	if err != nil {
+		return "", err
+	}
+
+	// Link file to service
+	_, err = si.client.CreateRelationship(ctx, serviceID, fileID, "CONTAINS",
+		map[string]any{"scope": si.scopeCtx.Scope, "scopeId": si.scopeCtx.ScopeID})
+	return fileID, err
+}
+
+// computeDefinitionProps computes the label, nodeKey, and properties for a definition node
+// without touching Neo4j. This is the pure-computation half of createDefinitionNode.
+func (si *SCIPIndexer) computeDefinitionProps(symbolInfo *models.SymbolInfo) (label string, nodeKey string, props map[string]any) {
+	switch symbolInfo.Kind {
+	case models.FunctionSymbol:
+		label = "Function"
+	case models.MethodSymbol:
+		label = "Method"
+	case models.TypeSymbol:
+		label = "Class"
+	case models.InterfaceSymbol:
+		label = "Interface"
+	case models.VariableSymbol:
+		label = "Variable"
+	case models.ConstantSymbol:
+		label = "Variable"
+	case models.ParameterSymbol:
+		label = "Parameter"
+	case models.FieldSymbol:
+		label = "Variable"
+	case models.PackageSymbol:
+		label = "Module"
+	default:
+		label = "Variable"
+	}
+
+	switch label {
+	case "Function":
+		nodeKey = models.FunctionNodeKey(symbolInfo.FilePath, symbolInfo.Signature)
+	case "Method":
+		nodeKey = models.MethodNodeKey(symbolInfo.FilePath, symbolInfo.Signature)
+	case "Class":
+		nodeKey = models.ClassNodeKey(symbolInfo.Symbol.String(), symbolInfo.FilePath, symbolInfo.DisplayName)
+	case "Interface":
+		nodeKey = models.InterfaceNodeKey(symbolInfo.Symbol.String(), symbolInfo.FilePath, symbolInfo.DisplayName)
+	case "Variable":
+		nodeKey = models.VariableNodeKey(symbolInfo.FilePath, symbolInfo.DisplayName, symbolInfo.StartLine)
+	case "Parameter":
+		nodeKey = models.ParameterNodeKey(symbolInfo.FilePath, symbolInfo.Signature, symbolInfo.DisplayName, 0)
+	case "Module":
+		nodeKey = models.ModuleNodeKey(symbolInfo.Symbol.String())
+	default:
+		nodeKey = models.VariableNodeKey(symbolInfo.FilePath, symbolInfo.DisplayName, symbolInfo.StartLine)
+	}
+
+	props = map[string]any{
+		"name":        symbolInfo.DisplayName,
+		"nodeKey":     nodeKey,
+		"signature":   symbolInfo.Signature,
+		"filePath":    symbolInfo.FilePath,
+		"startLine":   symbolInfo.StartLine,
+		"endLine":     symbolInfo.EndLine,
+		"startColumn": symbolInfo.StartColumn,
+		"endColumn":   symbolInfo.EndColumn,
+		"scope":       si.scopeCtx.Scope,
+		"scopeId":     si.scopeCtx.ScopeID,
+	}
+
+	if label == "Function" || label == "Method" {
+		if symbolInfo.EndLine > symbolInfo.StartLine {
+			props["linesOfCode"] = symbolInfo.EndLine - symbolInfo.StartLine + 1
+		} else {
+			props["linesOfCode"] = 1
+		}
+		if symbolInfo.FilePath != "" {
+			startByte, endByte := si.calculateByteOffsets(symbolInfo.FilePath,
+				symbolInfo.StartLine, symbolInfo.StartColumn,
+				symbolInfo.EndLine, symbolInfo.EndColumn)
+			if startByte >= 0 && endByte >= 0 {
+				props["startByte"] = startByte
+				props["endByte"] = endByte
+			}
+		}
+	}
+
+	switch label {
+	case "Function", "Method":
+		props["returnType"] = ""
+		props["isExported"] = true
+		props["complexity"] = 1
+		props["docstring"] = symbolInfo.Documentation
+	case "Class":
+		props["fqn"] = symbolInfo.Symbol.String()
+		props["accessModifier"] = "public"
+		props["isAbstract"] = false
+		props["docstring"] = symbolInfo.Documentation
+	case "Variable":
+		props["type"] = ""
+		props["isConstant"] = symbolInfo.Kind == models.ConstantSymbol
+	}
+
+	return label, nodeKey, props
+}
+
+const batchSize = 500
+
+// dedupeByNodeKey keeps only the last item for each nodeKey, preventing
+// UNWIND MERGE race conditions when duplicate keys appear in the same batch.
+func dedupeByNodeKey(items []map[string]any) []map[string]any {
+	seen := make(map[string]int, len(items))
+	for i, item := range items {
+		nk, _ := item["nodeKey"].(string)
+		seen[nk] = i // last-write wins
+	}
+	if len(seen) == len(items) {
+		return items // no duplicates
+	}
+	deduped := make([]map[string]any, 0, len(seen))
+	for _, idx := range seen {
+		deduped = append(deduped, items[idx])
+	}
+	return deduped
+}
+
+// indexSymbols indexes all symbols and their relationships using UNWIND batches.
+func (si *SCIPIndexer) indexSymbols(ctx context.Context, symbolDefs []*models.SymbolDefinition, fileNodes map[string]string) error {
+	fmt.Printf("Indexing %d symbols...\n", len(symbolDefs))
+
+	// Initialize file content cache for byte offset calculations
+	si.fileContentCache = make(map[string][]byte)
+	defer func() { si.fileContentCache = nil }()
+
+	// ── Phase 6: definitions ──────────────────────────────────────────
+	if si.timer != nil {
+		si.timer.Start("Index symbols (defs)")
+	}
+
+	// Pre-compute all items
+	type defItem struct {
+		symbolNodeKey string
+		symbolProps   map[string]any
+		defLabel      string
+		defNodeKey    string
+		defProps      map[string]any
+		filePath      string
+	}
+	items := make([]defItem, 0, len(symbolDefs))
+
+	for _, sd := range symbolDefs {
+		info := sd.Info
+		symNodeKey := models.SymbolNodeKey(info.Symbol.String())
+		symProps := map[string]any{
+			"symbol":        info.Symbol.String(),
+			"nodeKey":       symNodeKey,
+			"kind":          string(info.Kind),
+			"displayName":   info.DisplayName,
+			"documentation": info.Documentation,
+			"scope":         si.scopeCtx.Scope,
+			"scopeId":       si.scopeCtx.ScopeID,
+		}
+
+		di := defItem{
+			symbolNodeKey: symNodeKey,
+			symbolProps:   symProps,
+		}
+
+		if info.FilePath != "" {
+			lbl, nk, props := si.computeDefinitionProps(info)
+			di.defLabel = lbl
+			di.defNodeKey = nk
+			di.defProps = props
+			di.filePath = info.FilePath
+		}
+
+		items = append(items, di)
+	}
+
+	// 1. Batch merge all Symbol nodes (deduplicated)
+	symbolBatch := make([]map[string]any, len(items))
+	for i, it := range items {
+		symbolBatch[i] = map[string]any{
+			"nodeKey": it.symbolNodeKey,
+			"scopeId": si.scopeCtx.ScopeID,
+			"props":   it.symbolProps,
+		}
+	}
+	symbolBatch = dedupeByNodeKey(symbolBatch)
+
+	t := time.Now()
+	symbolIDs, err := si.client.MergeNodesBatch(ctx, "Symbol", symbolBatch, batchSize)
+	tMergeSymbol := time.Since(t)
+	if err != nil {
+		fmt.Printf("Warning: batch merge Symbol nodes failed: %v\n", err)
+		symbolIDs = make(map[string]string)
+	}
+	fmt.Printf("Merged %d Symbol nodes\n", len(symbolIDs))
+
+	// 2. Group definitions by label, deduplicate, batch merge each group
+	labelGroups := make(map[string][]map[string]any)
+	for _, it := range items {
+		if it.defLabel == "" {
+			continue
+		}
+		labelGroups[it.defLabel] = append(labelGroups[it.defLabel], map[string]any{
+			"nodeKey": it.defNodeKey,
+			"scopeId": si.scopeCtx.ScopeID,
+			"props":   it.defProps,
+		})
+	}
+
+	defIDs := make(map[string]string) // defNodeKey → elementId
+	t = time.Now()
+	for lbl, batch := range labelGroups {
+		batch = dedupeByNodeKey(batch)
+		ids, err := si.client.MergeNodesBatch(ctx, lbl, batch, batchSize)
+		if err != nil {
+			fmt.Printf("Warning: batch merge %s nodes failed: %v\n", lbl, err)
+			continue
+		}
+		for nk, id := range ids {
+			defIDs[nk] = id
+		}
+	}
+	tMergeDefinition := time.Since(t)
+	fmt.Printf("Merged %d definition nodes across %d labels\n", len(defIDs), len(labelGroups))
+
+	// 3. Batch create DEFINES rels (defID → symbolID)
+	var definesRels []map[string]any
+	for _, it := range items {
+		if it.defLabel == "" {
+			continue
+		}
+		fromID, ok1 := defIDs[it.defNodeKey]
+		toID, ok2 := symbolIDs[it.symbolNodeKey]
+		if ok1 && ok2 {
+			definesRels = append(definesRels, map[string]any{
+				"fromId": fromID,
+				"toId":   toID,
+				"props":  map[string]any{"isExported": true, "scope": si.scopeCtx.Scope, "scopeId": si.scopeCtx.ScopeID},
+			})
+		}
+	}
+
+	t = time.Now()
+	if err := si.client.CreateRelsBatch(ctx, "DEFINES", definesRels, batchSize); err != nil {
+		fmt.Printf("Warning: batch create DEFINES rels failed: %v\n", err)
+	}
+	tRelDefines := time.Since(t)
+
+	// 4. Batch create CONTAINS rels (fileID → defID)
+	var containsRels []map[string]any
+	for _, it := range items {
+		if it.defLabel == "" {
+			continue
+		}
+		defID, ok1 := defIDs[it.defNodeKey]
+		fileID, ok2 := fileNodes[it.filePath]
+		if ok1 && ok2 {
+			containsRels = append(containsRels, map[string]any{
+				"fromId": fileID,
+				"toId":   defID,
+				"props":  map[string]any{"scope": si.scopeCtx.Scope, "scopeId": si.scopeCtx.ScopeID},
+			})
+		}
+	}
+
+	t = time.Now()
+	if err := si.client.CreateRelsBatch(ctx, "CONTAINS", containsRels, batchSize); err != nil {
+		fmt.Printf("Warning: batch create def CONTAINS rels failed: %v\n", err)
+	}
+	tRelContains := time.Since(t)
+
+	if si.timer != nil {
+		si.timer.Stop(len(symbolDefs), fmt.Sprintf("%d symbols", len(symbolDefs)))
+		if recorder, ok := si.timer.(SubPhaseRecorder); ok {
+			recorder.AddResult("  MergeNodesBatch(Symbol)", tMergeSymbol, len(symbolIDs), "")
+			recorder.AddResult("  MergeNodesBatch(Definition)", tMergeDefinition, len(defIDs), "")
+			recorder.AddResult("  CreateRelsBatch(DEFINES)", tRelDefines, len(definesRels), "")
+			recorder.AddResult("  CreateRelsBatch(CONTAINS)", tRelContains, len(containsRels), "")
+		}
+	}
+
+	// ── Phase 7: references ──────────────────────────────────────────
+	if si.timer != nil {
+		si.timer.Start("Index symbols (refs)")
+	}
+	fmt.Printf("\nCreating reference relationships...\n")
+
+	// Pre-compute all reference items
+	type refItem struct {
+		nodeKey       string
+		props         map[string]any
+		symbolNodeKey string
+		filePath      string
+		refRelProps   map[string]any
+	}
+	var refItems []refItem
+
+	for _, sd := range symbolDefs {
+		symNK := models.SymbolNodeKey(sd.Info.Symbol.String())
+		if _, exists := symbolIDs[symNK]; !exists {
+			continue
+		}
+		for _, ref := range sd.Refs {
+			if ref.IsDefinition {
+				continue
+			}
+			nk := models.ReferenceNodeKey(ref.FilePath, ref.StartLine, ref.StartColumn)
+			refItems = append(refItems, refItem{
+				nodeKey: nk,
+				props: map[string]any{
+					"filePath":    ref.FilePath,
+					"nodeKey":     nk,
+					"startLine":   ref.StartLine,
+					"endLine":     ref.EndLine,
+					"startColumn": ref.StartColumn,
+					"endColumn":   ref.EndColumn,
+					"context":     ref.Context,
+					"scope":       si.scopeCtx.Scope,
+					"scopeId":     si.scopeCtx.ScopeID,
+				},
+				symbolNodeKey: symNK,
+				filePath:      ref.FilePath,
+				refRelProps: map[string]any{
+					"isDefinition": ref.IsDefinition,
+					"line":         ref.StartLine,
+					"column":       ref.StartColumn,
+					"scope":        si.scopeCtx.Scope,
+					"scopeId":      si.scopeCtx.ScopeID,
+				},
+			})
+		}
+	}
+
+	// 1. Batch merge all Reference nodes (deduplicated)
+	refBatch := make([]map[string]any, len(refItems))
+	for i, ri := range refItems {
+		refBatch[i] = map[string]any{
+			"nodeKey": ri.nodeKey,
+			"scopeId": si.scopeCtx.ScopeID,
+			"props":   ri.props,
+		}
+	}
+	refBatch = dedupeByNodeKey(refBatch)
+
+	t = time.Now()
+	refIDs, err := si.client.MergeNodesBatch(ctx, "Reference", refBatch, batchSize)
+	tMergeRef := time.Since(t)
+	if err != nil {
+		fmt.Printf("Warning: batch merge Reference nodes failed: %v\n", err)
+		refIDs = make(map[string]string)
+	}
+	fmt.Printf("Merged %d Reference nodes\n", len(refIDs))
+
+	// 2. Batch create REFERENCES rels (refID → symbolID)
+	var referencesRels []map[string]any
+	for _, ri := range refItems {
+		fromID, ok1 := refIDs[ri.nodeKey]
+		toID, ok2 := symbolIDs[ri.symbolNodeKey]
+		if ok1 && ok2 {
+			referencesRels = append(referencesRels, map[string]any{
+				"fromId": fromID,
+				"toId":   toID,
+				"props":  ri.refRelProps,
+			})
+		}
+	}
+
+	t = time.Now()
+	if err := si.client.CreateRelsBatch(ctx, "REFERENCES", referencesRels, batchSize); err != nil {
+		fmt.Printf("Warning: batch create REFERENCES rels failed: %v\n", err)
+	}
+	tRelReferences := time.Since(t)
+
+	// 3. Batch create CONTAINS rels (fileID → refID)
+	var refContainsRels []map[string]any
+	for _, ri := range refItems {
+		refID, ok1 := refIDs[ri.nodeKey]
+		fileID, ok2 := fileNodes[ri.filePath]
+		if ok1 && ok2 {
+			refContainsRels = append(refContainsRels, map[string]any{
+				"fromId": fileID,
+				"toId":   refID,
+				"props":  map[string]any{"scope": si.scopeCtx.Scope, "scopeId": si.scopeCtx.ScopeID},
+			})
+		}
+	}
+
+	t = time.Now()
+	if err := si.client.CreateRelsBatch(ctx, "CONTAINS", refContainsRels, batchSize); err != nil {
+		fmt.Printf("Warning: batch create ref CONTAINS rels failed: %v\n", err)
+	}
+	tRelRefContains := time.Since(t)
+
+	if si.timer != nil {
+		si.timer.Stop(len(refItems), fmt.Sprintf("%d refs", len(refItems)))
+		if recorder, ok := si.timer.(SubPhaseRecorder); ok {
+			recorder.AddResult("  MergeNodesBatch(Reference)", tMergeRef, len(refIDs), "")
+			recorder.AddResult("  CreateRelsBatch(REFERENCES)", tRelReferences, len(referencesRels), "")
+			recorder.AddResult("  CreateRelsBatch(CONTAINS)", tRelRefContains, len(refContainsRels), "")
+		}
+	}
+
+	fmt.Printf("Completed indexing symbols (created %d reference relationships)\n", len(refItems))
+	return nil
+}
+
+// indexPackageDependencies creates DEPENDS_ON relationships between services based on imports
+func (si *SCIPIndexer) indexPackageDependencies(ctx context.Context, imports []*models.PackageImport, serviceID string) error {
+	if len(imports) == 0 {
+		return nil
+	}
+
+	fmt.Printf("Processing %d imports for dependency relationships...\n", len(imports))
+
+	// Group imports by target package
+	packageMap := make(map[string]int)
+	for _, imp := range imports {
+		if imp.IsExternal {
+			packageMap[imp.TargetPackage]++
+		}
+	}
+
+	createdCount := 0
+
+	// Create DEPENDS_ON relationships for each external package
+	for packageName, count := range packageMap {
+		// Try to find the target service by package name or service name
+		// Multiple matching strategies:
+		// 1. Exact packageName match
+		// 2. Service name in package (e.g., "@try-veil/veil-gateway" matches "veil-gateway")
+		// 3. Package contains service name
+		targetServiceQuery := `
+			MATCH (s:Service)
+			WHERE s.packageName = $packageName
+			   OR s.name = $packageName
+			   OR $packageName CONTAINS s.packageName
+			   OR s.packageName CONTAINS $packageName
+			RETURN elementId(s) AS id, s.name AS name, s.packageName AS packageName
+			ORDER BY
+				CASE
+					WHEN s.packageName = $packageName THEN 0
+					WHEN s.name = $packageName THEN 1
+					ELSE 2
+				END
+			LIMIT 1
+		`
+
+		result, err := si.client.ExecuteQuery(ctx, targetServiceQuery,
+			map[string]any{"packageName": packageName})
+
+		if err != nil || len(result) == 0 {
+			// Target service not indexed yet, log and skip
+			fmt.Printf("  No service found for package: %s\n", packageName)
+			continue
+		}
+
+		targetServiceID := result[0].AsMap()["id"].(string)
+		targetServiceName := result[0].AsMap()["name"].(string)
+
+		// Avoid self-dependencies
+		if targetServiceID == serviceID {
+			continue
+		}
+
+		// Create DEPENDS_ON relationship
+		relProps := map[string]any{
+			"packageName":  packageName,
+			"isDirect":     true,
+			"importCount":  count,
+			"detectedFrom": "import-analysis",
+			"scope":        si.scopeCtx.Scope,
+			"scopeId":      si.scopeCtx.ScopeID,
+		}
+
+		_, err = si.client.CreateRelationship(ctx, serviceID, targetServiceID,
+			string(models.DependsOnRel), relProps)
+
+		if err != nil {
+			fmt.Printf("Warning: failed to create DEPENDS_ON relationship to %s: %v\n", targetServiceName, err)
+		} else {
+			fmt.Printf("Created DEPENDS_ON: %s -> %s (%d imports)\n", si.serviceName, targetServiceName, count)
+			createdCount++
+		}
+	}
+
+	fmt.Printf("Created %d DEPENDS_ON relationships\n", createdCount)
+	return nil
+}
+
+
+// SetSCIPBinary sets the path to the SCIP binary (for testing or custom installations)
+func (si *SCIPIndexer) SetSCIPBinary(binary string) {
+	si.langConfig.SCIPBinary = binary
+}
+
+// ValidateEnvironment checks if the required tools are available.
+// It first tries to resolve the binary from cache or PATH, then attempts
+// auto-install if not found. Set noAutoInstall to skip the install attempt.
+func (si *SCIPIndexer) ValidateEnvironment() error {
+	return si.validateEnvironment(false)
+}
+
+// ValidateEnvironmentNoInstall checks if the required tools are available
+// without attempting auto-install.
+func (si *SCIPIndexer) ValidateEnvironmentNoInstall() error {
+	return si.validateEnvironment(true)
+}
+
+func (si *SCIPIndexer) validateEnvironment(noAutoInstall bool) error {
+	mgr := NewIndexerManager("")
+	if resolved := mgr.ResolveBinary(si.language); resolved != "" {
+		si.langConfig.SCIPBinary = resolved
+		return nil
+	}
+
+	if noAutoInstall {
+		return fmt.Errorf("%s not found in PATH or cache.\nInstall with: %s\nSee: %s",
+			si.langConfig.SCIPBinary,
+			si.langConfig.InstallCommand,
+			si.langConfig.InstallDocs)
+	}
+
+	// Auto-install attempt
+	fmt.Printf("SCIP indexer %q not found, attempting auto-install...\n", si.langConfig.SCIPBinary)
+	if err := mgr.Install(si.language); err != nil {
+		return fmt.Errorf("auto-install failed: %w\nManual install: %s", err, si.langConfig.InstallCommand)
+	}
+	if resolved := mgr.ResolveBinary(si.language); resolved != "" {
+		si.langConfig.SCIPBinary = resolved
+		return nil
+	}
+	return fmt.Errorf("%s not available after install attempt", si.langConfig.SCIPBinary)
+}
+
+// SetScope sets the scope context for the indexer.
+func (si *SCIPIndexer) SetScope(scope models.ScopeContext) {
+	si.scopeCtx = scope
+}
+
+// SetBenchmarkTimer sets an optional phase timer for benchmarking.
+// When set, each phase of IndexProject() will be timed.
+func (si *SCIPIndexer) SetBenchmarkTimer(timer PipelineTimer) {
+	si.timer = timer
+}
+
+// GetLanguage returns the language this indexer is configured for
+func (si *SCIPIndexer) GetLanguage() Language {
+	return si.language
+}
+
+// calculateByteOffsets calculates the start and end byte positions for a code location
+func (si *SCIPIndexer) calculateByteOffsets(filePath string, startLine, startColumn, endLine, endColumn int) (int, int) {
+	// Use cache to avoid re-reading the same file for every symbol
+	content, ok := si.fileContentCache[filePath]
+	if !ok {
+		var err error
+		content, err = os.ReadFile(filePath)
+		if err != nil {
+			return -1, -1
+		}
+		if si.fileContentCache == nil {
+			si.fileContentCache = make(map[string][]byte)
+		}
+		si.fileContentCache[filePath] = content
+	}
+
+	lines := strings.Split(string(content), "\n")
+	if startLine <= 0 || endLine <= 0 || startLine > len(lines) || endLine > len(lines) {
+		return -1, -1
+	}
+
+	// Calculate start byte offset
+	startByte := 0
+	for i := 0; i < startLine-1; i++ {
+		startByte += len(lines[i]) + 1 // +1 for newline character
+	}
+	startByte += startColumn
+
+	// Calculate end byte offset
+	endByte := 0
+	for i := 0; i < endLine-1; i++ {
+		endByte += len(lines[i]) + 1 // +1 for newline character
+	}
+	endByte += endColumn
+
+	return startByte, endByte
+}

--- a/services/indexing-go/static/scip_parser.go
+++ b/services/indexing-go/static/scip_parser.go
@@ -1,0 +1,661 @@
+package static
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"google.golang.org/protobuf/proto"
+)
+
+// SCIPParser parses SCIP index files and extracts code intelligence data
+type SCIPParser struct {
+	index *scip.Index
+}
+
+// NewSCIPParser creates a new SCIP parser
+func NewSCIPParser() *SCIPParser {
+	return &SCIPParser{}
+}
+
+// ParseFile parses a SCIP index file
+func (sp *SCIPParser) ParseFile(scipFilePath string) error {
+	data, err := os.ReadFile(scipFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read SCIP file: %w", err)
+	}
+
+	sp.index = &scip.Index{}
+	err = proto.Unmarshal(data, sp.index)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal SCIP data: %w", err)
+	}
+
+	return nil
+}
+
+// GetMetadata returns the metadata from the SCIP index
+func (sp *SCIPParser) GetMetadata() *scip.Metadata {
+	if sp.index == nil {
+		return nil
+	}
+	return sp.index.Metadata
+}
+
+// ExtractSymbols extracts all symbol information from the SCIP index
+func (sp *SCIPParser) ExtractSymbols() ([]*models.SymbolDefinition, error) {
+	if sp.index == nil {
+		return nil, fmt.Errorf("no SCIP index loaded")
+	}
+
+	// Use a map for O(1) lookups instead of O(n) linear search
+	symbolMap := make(map[string]*models.SymbolDefinition)
+
+	// Process external symbols first
+	for _, symbolInfo := range sp.index.ExternalSymbols {
+		scipSymbol, err := models.ParseSCIPSymbol(symbolInfo.Symbol)
+		if err != nil {
+			continue // Skip invalid symbols
+		}
+
+		symbolDef := &models.SymbolDefinition{
+			Symbol: scipSymbol,
+			Info: &models.SymbolInfo{
+				Symbol:        scipSymbol,
+				Kind:          convertSymbolKind(symbolInfo.Kind),
+				DisplayName:   extractDisplayName(symbolInfo.Symbol),
+				Documentation: strings.Join(symbolInfo.Documentation, " "),
+				Signature:     extractSignature(symbolInfo),
+			},
+			Refs: []*models.SymbolReference{},
+		}
+
+		symbolMap[scipSymbol.String()] = symbolDef
+	}
+
+	// Process documents and their symbols
+	for _, doc := range sp.index.Documents {
+		filePath := doc.RelativePath
+
+		// Skip excluded paths like node_modules, vendor, etc.
+		if shouldExcludePath(filePath) {
+			continue
+		}
+
+		// Process occurrences in this document
+		for _, occurrence := range doc.Occurrences {
+			scipSymbol, err := models.ParseSCIPSymbol(occurrence.Symbol)
+			if err != nil {
+				continue // Skip invalid symbols
+			}
+
+			// Convert SCIP ranges to our format
+			startLine, startColumn := convertRange(occurrence.Range, true)
+			endLine, endColumn := convertRange(occurrence.Range, false)
+
+			ref := &models.SymbolReference{
+				Symbol:      scipSymbol,
+				FilePath:    filePath,
+				StartLine:   startLine,
+				EndLine:     endLine,
+				StartColumn: startColumn,
+				EndColumn:   endColumn,
+				IsDefinition: occurrence.SymbolRoles&int32(scip.SymbolRole_Definition) != 0,
+			}
+
+			// Find or create the symbol definition using map lookup (O(1))
+			symbolKey := scipSymbol.String()
+			targetSymbolDef, exists := symbolMap[symbolKey]
+
+			if !exists {
+				// Create new symbol definition
+				targetSymbolDef = &models.SymbolDefinition{
+					Symbol: scipSymbol,
+					Info: &models.SymbolInfo{
+						Symbol:      scipSymbol,
+						Kind:        inferSymbolKind(occurrence.Symbol),
+						DisplayName: extractDisplayName(occurrence.Symbol),
+						Signature:   occurrence.Symbol, // Use SCIP symbol string as signature for unique nodeKey derivation
+						FilePath:    filePath,
+						StartLine:   startLine,
+						EndLine:     endLine,
+						StartColumn: startColumn,
+						EndColumn:   endColumn,
+					},
+					Refs: []*models.SymbolReference{},
+				}
+				symbolMap[symbolKey] = targetSymbolDef
+			} else if ref.IsDefinition {
+				// Update location to the actual definition site.
+				// Without this, the symbol inherits the location of its
+				// first reference (which may be in a different file).
+				targetSymbolDef.Info.FilePath = filePath
+				targetSymbolDef.Info.StartLine = startLine
+				targetSymbolDef.Info.EndLine = endLine
+				targetSymbolDef.Info.StartColumn = startColumn
+				targetSymbolDef.Info.EndColumn = endColumn
+			}
+
+			// Add reference to symbol definition
+			targetSymbolDef.AddReference(ref)
+		}
+	}
+
+	// Convert map to slice
+	symbolDefs := make([]*models.SymbolDefinition, 0, len(symbolMap))
+	for _, symbolDef := range symbolMap {
+		symbolDefs = append(symbolDefs, symbolDef)
+	}
+
+	return symbolDefs, nil
+}
+
+// shouldExcludePath checks if a file path should be excluded from indexing
+func shouldExcludePath(path string) bool {
+	excludedDirs := []string{
+		"node_modules/",
+		"vendor/",
+		".git/",
+		".next/",
+		".nuxt/",
+		"dist/",
+		"build/",
+		"target/", // Maven/Gradle build output
+		"venv/",   // Python virtual env
+		".venv/",
+		"__pycache__/",
+	}
+
+	for _, dir := range excludedDirs {
+		if strings.Contains(path, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractDocuments extracts file information from the SCIP index
+func (sp *SCIPParser) ExtractDocuments() ([]*models.File, error) {
+	if sp.index == nil {
+		return nil, fmt.Errorf("no SCIP index loaded")
+	}
+
+	var files []*models.File
+	totalDocs := len(sp.index.Documents)
+	excludedCount := 0
+
+	for _, doc := range sp.index.Documents {
+		// Skip excluded paths like node_modules, vendor, etc.
+		if shouldExcludePath(doc.RelativePath) {
+			excludedCount++
+			continue
+		}
+
+		file := &models.File{
+			Path:     doc.RelativePath,
+			Language: inferLanguage(doc.RelativePath),
+			// Note: SCIP doesn't provide file size, line count, or hash
+			// These would need to be computed separately if needed
+		}
+
+		files = append(files, file)
+	}
+
+	if excludedCount > 0 {
+		fmt.Printf("Filtered out %d/%d files from excluded directories (node_modules, vendor, etc.)\n", excludedCount, totalDocs)
+	}
+
+	return files, nil
+}
+
+// GetServiceInfo extracts service information from SCIP metadata
+func (sp *SCIPParser) GetServiceInfo() (*models.Service, error) {
+	metadata := sp.GetMetadata()
+	if metadata == nil {
+		return nil, fmt.Errorf("no metadata found")
+	}
+
+	// Try to infer language from tool info
+	language := "unknown"
+	if metadata.ToolInfo != nil {
+		toolName := strings.ToLower(metadata.ToolInfo.Name)
+		if strings.Contains(toolName, "scip-go") {
+			language = "Go"
+		} else if strings.Contains(toolName, "scip-typescript") || strings.Contains(toolName, "typescript") {
+			language = "TypeScript"
+		} else if strings.Contains(toolName, "scip-python") || strings.Contains(toolName, "python") {
+			language = "Python"
+		} else if strings.Contains(toolName, "scip-java") || strings.Contains(toolName, "java") {
+			language = "Java"
+		}
+	}
+
+	service := &models.Service{
+		Name:     metadata.ProjectRoot,
+		Language: language,
+		Version:  "1.0.0", // Default version since metadata.Version is a ProtocolVersion
+	}
+
+	return service, nil
+}
+
+// Helper functions
+
+func convertSymbolKind(scipKind scip.SymbolInformation_Kind) models.SymbolKind {
+	switch scipKind {
+	case scip.SymbolInformation_UnspecifiedKind:
+		return models.VariableSymbol
+	case scip.SymbolInformation_Namespace:
+		return models.PackageSymbol
+	case scip.SymbolInformation_Type:
+		return models.TypeSymbol
+	case scip.SymbolInformation_Class:
+		return models.TypeSymbol
+	case scip.SymbolInformation_Interface:
+		return models.InterfaceSymbol
+	case scip.SymbolInformation_Function:
+		return models.FunctionSymbol
+	case scip.SymbolInformation_Method:
+		return models.MethodSymbol
+	case scip.SymbolInformation_Field:
+		return models.FieldSymbol
+	case scip.SymbolInformation_Variable:
+		return models.VariableSymbol
+	case scip.SymbolInformation_Constant:
+		return models.ConstantSymbol
+	case scip.SymbolInformation_Parameter:
+		return models.ParameterSymbol
+	default:
+		return models.VariableSymbol
+	}
+}
+
+func inferSymbolKind(symbol string) models.SymbolKind {
+	// Simple heuristic to infer symbol kind from SCIP symbol string
+	if strings.Contains(symbol, "#") && strings.Contains(symbol, "().") {
+		return models.MethodSymbol
+	} else if strings.Contains(symbol, "().") {
+		return models.FunctionSymbol
+	} else if strings.Contains(symbol, "#") {
+		return models.TypeSymbol
+	} else if strings.Contains(symbol, "/") {
+		return models.PackageSymbol
+	} else {
+		return models.VariableSymbol
+	}
+}
+
+func extractDisplayName(symbol string) string {
+	// Extract the last component as display name
+	parts := strings.Split(symbol, " ")
+	if len(parts) < 5 {
+		return symbol
+	}
+	
+	descriptor := parts[4] // SCIP format: scheme manager name version descriptor
+	
+	// Extract the actual name from the descriptor
+	if strings.Contains(descriptor, "#") {
+		// Type or method
+		parts := strings.Split(descriptor, "#")
+		if len(parts) > 1 {
+			return strings.TrimSuffix(parts[len(parts)-1], "()")
+		}
+	} else if strings.Contains(descriptor, "/") {
+		// Package
+		parts := strings.Split(descriptor, "/")
+		return parts[len(parts)-1]
+	}
+	
+	return descriptor
+}
+
+func extractSignature(symbolInfo *scip.SymbolInformation) string {
+	// For now, use the display name as signature
+	// In a full implementation, we might extract more detailed signature info
+	return symbolInfo.Symbol
+}
+
+func convertRange(scipRange []int32, isStart bool) (int, int) {
+	// SCIP ranges come in two forms:
+	// 3-element: [startLine, startCol, endCol] (single-line span)
+	// 4-element: [startLine, startCol, endLine, endCol] (multi-line span)
+	if len(scipRange) < 3 {
+		return 0, 0
+	}
+
+	if isStart {
+		return int(scipRange[0]), int(scipRange[1])
+	}
+
+	// End position
+	if len(scipRange) == 3 {
+		// Single-line: endLine == startLine, endCol is scipRange[2]
+		return int(scipRange[0]), int(scipRange[2])
+	}
+	return int(scipRange[2]), int(scipRange[3])
+}
+
+func inferLanguage(filePath string) string {
+	ext := strings.ToLower(filepath.Ext(filePath))
+
+	switch ext {
+	case ".go":
+		return "Go"
+	case ".ts", ".tsx":
+		return "TypeScript"
+	case ".js", ".jsx":
+		return "JavaScript"
+	case ".py":
+		return "Python"
+	case ".java":
+		return "Java"
+	case ".scala":
+		return "Scala"
+	case ".kt", ".kts":
+		return "Kotlin"
+	case ".rs":
+		return "Rust"
+	case ".rb":
+		return "Ruby"
+	case ".php":
+		return "PHP"
+	case ".c", ".h":
+		return "C"
+	case ".cpp", ".cc", ".cxx", ".hpp":
+		return "C++"
+	case ".cs":
+		return "C#"
+	default:
+		return "unknown"
+	}
+}
+
+// DebugPrintSCIPFile prints a human-readable representation of the SCIP file
+func (sp *SCIPParser) DebugPrintSCIPFile() error {
+	if sp.index == nil {
+		return fmt.Errorf("no SCIP index loaded")
+	}
+
+	fmt.Println("=== SCIP Index Debug Output ===")
+	
+	// Print metadata
+	if metadata := sp.index.Metadata; metadata != nil {
+		fmt.Printf("Project Root: %s\n", metadata.ProjectRoot)
+		fmt.Printf("Version: %s\n", metadata.Version)
+		fmt.Printf("Tool Info: %s %s\n", metadata.ToolInfo.Name, metadata.ToolInfo.Version)
+	}
+
+	// Print external symbols
+	fmt.Printf("\nExternal Symbols (%d):\n", len(sp.index.ExternalSymbols))
+	for i, symbol := range sp.index.ExternalSymbols {
+		if i < 10 { // Limit output
+			fmt.Printf("  %s (Kind: %s)\n", symbol.Symbol, symbol.Kind.String())
+		}
+	}
+	if len(sp.index.ExternalSymbols) > 10 {
+		fmt.Printf("  ... and %d more\n", len(sp.index.ExternalSymbols)-10)
+	}
+
+	// Print documents
+	fmt.Printf("\nDocuments (%d):\n", len(sp.index.Documents))
+	for i, doc := range sp.index.Documents {
+		if i < 5 { // Limit output
+			fmt.Printf("  %s (%d occurrences)\n", doc.RelativePath, len(doc.Occurrences))
+			
+			// Print first few occurrences
+			for j, occ := range doc.Occurrences {
+				if j < 3 {
+					fmt.Printf("    %s [%v] (Roles: %d)\n", occ.Symbol, occ.Range, occ.SymbolRoles)
+				}
+			}
+			if len(doc.Occurrences) > 3 {
+				fmt.Printf("    ... and %d more occurrences\n", len(doc.Occurrences)-3)
+			}
+		}
+	}
+	if len(sp.index.Documents) > 5 {
+		fmt.Printf("  ... and %d more documents\n", len(sp.index.Documents)-5)
+	}
+
+	return nil
+}
+
+// ValidateSCIPFile checks if a file is a valid SCIP file
+func ValidateSCIPFile(filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("cannot open file: %w", err)
+	}
+	defer file.Close()
+
+	// Check if it's a binary protobuf file by trying to read first few bytes
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() {
+		line := scanner.Text()
+		// SCIP files are binary, so text files are definitely not SCIP
+		if len(line) > 0 && line[0] < 32 {
+			// Looks like binary data, could be SCIP
+			return nil
+		}
+	}
+
+	return fmt.Errorf("file does not appear to be a valid SCIP file")
+}
+
+// ExtractImports analyzes source files to extract import statements
+func (sp *SCIPParser) ExtractImports(projectPath string) ([]*models.PackageImport, error) {
+	if sp.index == nil {
+		return nil, fmt.Errorf("no SCIP index loaded")
+	}
+
+	var imports []*models.PackageImport
+	importMap := make(map[string]bool) // Deduplicate imports
+
+	for _, doc := range sp.index.Documents {
+		// Build full file path
+		fullPath := filepath.Join(projectPath, doc.RelativePath)
+
+		// Read file content
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			fmt.Printf("Warning: failed to read file %s: %v\n", fullPath, err)
+			continue
+		}
+
+		sourceCode := string(content)
+		language := inferLanguage(doc.RelativePath)
+
+		// Extract imports based on language
+		var fileImports []*models.PackageImport
+		switch language {
+		case "TypeScript", "JavaScript":
+			fileImports = extractTypeScriptImports(doc.RelativePath, sourceCode)
+		case "Go":
+			fileImports = extractGoImports(doc.RelativePath, sourceCode)
+		case "Python":
+			fileImports = extractPythonImports(doc.RelativePath, sourceCode)
+		case "Java", "Kotlin", "Scala":
+			fileImports = extractJavaImports(doc.RelativePath, sourceCode)
+		}
+
+		// Deduplicate and add to result
+		for _, imp := range fileImports {
+			key := fmt.Sprintf("%s -> %s", imp.SourceFile, imp.TargetPackage)
+			if !importMap[key] {
+				importMap[key] = true
+				imports = append(imports, imp)
+			}
+		}
+	}
+
+	return imports, nil
+}
+
+// extractTypeScriptImports parses TypeScript/JavaScript import statements
+func extractTypeScriptImports(filePath, sourceCode string) []*models.PackageImport {
+	var imports []*models.PackageImport
+
+	// Pattern: import { X, Y } from 'package'
+	namedImportRegex := regexp.MustCompile(`import\s+{([^}]+)}\s+from\s+['"]([^'"]+)['"]`)
+	matches := namedImportRegex.FindAllStringSubmatch(sourceCode, -1)
+	for _, match := range matches {
+		if len(match) > 2 {
+			importedNames := strings.Split(match[1], ",")
+			for i, name := range importedNames {
+				importedNames[i] = strings.TrimSpace(name)
+			}
+
+			packageName := match[2]
+			isExternal := !strings.HasPrefix(packageName, ".") && !strings.HasPrefix(packageName, "/")
+
+			imports = append(imports, &models.PackageImport{
+				SourceFile:    filePath,
+				TargetPackage: packageName,
+				ImportedNames: importedNames,
+				IsExternal:    isExternal,
+			})
+		}
+	}
+
+	// Pattern: import * as X from 'package'
+	namespaceImportRegex := regexp.MustCompile(`import\s+\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]`)
+	matches = namespaceImportRegex.FindAllStringSubmatch(sourceCode, -1)
+	for _, match := range matches {
+		if len(match) > 2 {
+			packageName := match[2]
+			isExternal := !strings.HasPrefix(packageName, ".") && !strings.HasPrefix(packageName, "/")
+
+			imports = append(imports, &models.PackageImport{
+				SourceFile:    filePath,
+				TargetPackage: packageName,
+				ImportedNames: []string{match[1]},
+				IsExternal:    isExternal,
+			})
+		}
+	}
+
+	// Pattern: import X from 'package' (default import)
+	defaultImportRegex := regexp.MustCompile(`import\s+(\w+)\s+from\s+['"]([^'"]+)['"]`)
+	matches = defaultImportRegex.FindAllStringSubmatch(sourceCode, -1)
+	for _, match := range matches {
+		if len(match) > 2 {
+			packageName := match[2]
+			isExternal := !strings.HasPrefix(packageName, ".") && !strings.HasPrefix(packageName, "/")
+
+			imports = append(imports, &models.PackageImport{
+				SourceFile:    filePath,
+				TargetPackage: packageName,
+				ImportedNames: []string{match[1]},
+				IsExternal:    isExternal,
+			})
+		}
+	}
+
+	return imports
+}
+
+// extractGoImports parses Go import statements
+func extractGoImports(filePath, sourceCode string) []*models.PackageImport {
+	var imports []*models.PackageImport
+
+	// Single import: import "package"
+	singleImportRegex := regexp.MustCompile(`import\s+"([^"]+)"`)
+	matches := singleImportRegex.FindAllStringSubmatch(sourceCode, -1)
+	for _, match := range matches {
+		if len(match) > 1 {
+			imports = append(imports, &models.PackageImport{
+				SourceFile:    filePath,
+				TargetPackage: match[1],
+				IsExternal:    !strings.Contains(match[1], "/"),
+			})
+		}
+	}
+
+	// Multi-line import block
+	importBlockRegex := regexp.MustCompile(`import\s*\(\s*([^)]+)\s*\)`)
+	blocks := importBlockRegex.FindAllStringSubmatch(sourceCode, -1)
+	for _, block := range blocks {
+		if len(block) > 1 {
+			// Extract individual imports from block
+			lines := strings.Split(block[1], "\n")
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+				// Remove quotes and alias
+				packageRegex := regexp.MustCompile(`"([^"]+)"`)
+				pkgMatch := packageRegex.FindStringSubmatch(line)
+				if len(pkgMatch) > 1 {
+					imports = append(imports, &models.PackageImport{
+						SourceFile:    filePath,
+						TargetPackage: pkgMatch[1],
+						IsExternal:    strings.Contains(pkgMatch[1], "/"),
+					})
+				}
+			}
+		}
+	}
+
+	return imports
+}
+
+// extractPythonImports parses Python import statements
+func extractPythonImports(filePath, sourceCode string) []*models.PackageImport {
+	var imports []*models.PackageImport
+
+	// Pattern: import package
+	simpleImportRegex := regexp.MustCompile(`^\s*import\s+(\w+(?:\.\w+)*)`)
+	// Pattern: from package import X, Y
+	fromImportRegex := regexp.MustCompile(`^\s*from\s+(\w+(?:\.\w+)*)\s+import\s+(.+)`)
+
+	lines := strings.Split(sourceCode, "\n")
+	for _, line := range lines {
+		// Try from...import first
+		if match := fromImportRegex.FindStringSubmatch(line); len(match) > 2 {
+			importedNames := strings.Split(match[2], ",")
+			for i, name := range importedNames {
+				importedNames[i] = strings.TrimSpace(name)
+			}
+
+			imports = append(imports, &models.PackageImport{
+				SourceFile:    filePath,
+				TargetPackage: match[1],
+				ImportedNames: importedNames,
+				IsExternal:    !strings.HasPrefix(match[1], "."),
+			})
+		} else if match := simpleImportRegex.FindStringSubmatch(line); len(match) > 1 {
+			imports = append(imports, &models.PackageImport{
+				SourceFile:    filePath,
+				TargetPackage: match[1],
+				IsExternal:    !strings.HasPrefix(match[1], "."),
+			})
+		}
+	}
+
+	return imports
+}
+
+// extractJavaImports parses Java/Kotlin/Scala import statements
+func extractJavaImports(filePath, sourceCode string) []*models.PackageImport {
+	var imports []*models.PackageImport
+
+	// Pattern: import package.Class;
+	importRegex := regexp.MustCompile(`import\s+([\w.]+);`)
+	matches := importRegex.FindAllStringSubmatch(sourceCode, -1)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			imports = append(imports, &models.PackageImport{
+				SourceFile:    filePath,
+				TargetPackage: match[1],
+				IsExternal:    true, // Most imports in Java are external
+			})
+		}
+	}
+
+	return imports
+}

--- a/services/indexing-go/static/symbol_analyzer.go
+++ b/services/indexing-go/static/symbol_analyzer.go
@@ -1,0 +1,364 @@
+package static
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+)
+
+// FrameworkPattern describes a known HTTP framework symbol pattern for detection.
+type FrameworkPattern struct {
+	PackagePattern string // SCIP package substring to match (e.g., "net/http")
+	Descriptor     string // Descriptor substring to match (e.g., "HandleFunc")
+	HTTPMethod     string // "GET", "POST", "ANY", etc.
+	Type           string // "endpoint" or "client"
+	Framework      string // "go-http", "gin", "express", etc.
+}
+
+// SymbolAnalyzer detects API endpoints and HTTP client calls by querying
+// SCIP-indexed Symbol/Reference nodes rather than scanning source with regex.
+type SymbolAnalyzer struct {
+	client      *neo4j.Client
+	serviceName string
+	language    string
+	projectPath string
+	scopeCtx    models.ScopeContext
+	patterns    []FrameworkPattern
+}
+
+// NewSymbolAnalyzer creates a new SymbolAnalyzer.
+func NewSymbolAnalyzer(client *neo4j.Client, serviceName, language, projectPath string) *SymbolAnalyzer {
+	sa := &SymbolAnalyzer{
+		client:      client,
+		serviceName: serviceName,
+		language:    language,
+		projectPath: projectPath,
+		scopeCtx:    models.DefaultScope(),
+	}
+	sa.patterns = defaultFrameworkPatterns()
+	return sa
+}
+
+// SetScope sets the scope context for the analyzer.
+func (sa *SymbolAnalyzer) SetScope(scope models.ScopeContext) {
+	sa.scopeCtx = scope
+}
+
+// defaultFrameworkPatterns returns the built-in set of known HTTP framework symbols.
+func defaultFrameworkPatterns() []FrameworkPattern {
+	return []FrameworkPattern{
+		// ── Go standard library ──
+		{PackagePattern: "net/http", Descriptor: "HandleFunc", HTTPMethod: "ANY", Type: "endpoint", Framework: "go-http"},
+		{PackagePattern: "net/http", Descriptor: "Handle", HTTPMethod: "ANY", Type: "endpoint", Framework: "go-http"},
+		{PackagePattern: "net/http", Descriptor: "ServeMux", HTTPMethod: "ANY", Type: "endpoint", Framework: "go-http"},
+		{PackagePattern: "net/http", Descriptor: "ListenAndServe", HTTPMethod: "ANY", Type: "endpoint", Framework: "go-http"},
+		// Go HTTP client
+		{PackagePattern: "net/http", Descriptor: "NewRequest", HTTPMethod: "ANY", Type: "client", Framework: "go-http-client"},
+		{PackagePattern: "net/http", Descriptor: "NewRequestWithContext", HTTPMethod: "ANY", Type: "client", Framework: "go-http-client"},
+		{PackagePattern: "net/http", Descriptor: "Get", HTTPMethod: "GET", Type: "client", Framework: "go-http-client"},
+		{PackagePattern: "net/http", Descriptor: "Post", HTTPMethod: "POST", Type: "client", Framework: "go-http-client"},
+		{PackagePattern: "net/http", Descriptor: "Do", HTTPMethod: "ANY", Type: "client", Framework: "go-http-client"},
+
+		// ── Gin ──
+		{PackagePattern: "github.com/gin-gonic/gin", Descriptor: "GET", HTTPMethod: "GET", Type: "endpoint", Framework: "gin"},
+		{PackagePattern: "github.com/gin-gonic/gin", Descriptor: "POST", HTTPMethod: "POST", Type: "endpoint", Framework: "gin"},
+		{PackagePattern: "github.com/gin-gonic/gin", Descriptor: "PUT", HTTPMethod: "PUT", Type: "endpoint", Framework: "gin"},
+		{PackagePattern: "github.com/gin-gonic/gin", Descriptor: "DELETE", HTTPMethod: "DELETE", Type: "endpoint", Framework: "gin"},
+		{PackagePattern: "github.com/gin-gonic/gin", Descriptor: "PATCH", HTTPMethod: "PATCH", Type: "endpoint", Framework: "gin"},
+		{PackagePattern: "github.com/gin-gonic/gin", Descriptor: "Handle", HTTPMethod: "ANY", Type: "endpoint", Framework: "gin"},
+
+		// ── Echo ──
+		{PackagePattern: "github.com/labstack/echo", Descriptor: "GET", HTTPMethod: "GET", Type: "endpoint", Framework: "echo"},
+		{PackagePattern: "github.com/labstack/echo", Descriptor: "POST", HTTPMethod: "POST", Type: "endpoint", Framework: "echo"},
+		{PackagePattern: "github.com/labstack/echo", Descriptor: "PUT", HTTPMethod: "PUT", Type: "endpoint", Framework: "echo"},
+		{PackagePattern: "github.com/labstack/echo", Descriptor: "DELETE", HTTPMethod: "DELETE", Type: "endpoint", Framework: "echo"},
+
+		// ── Gorilla Mux ──
+		{PackagePattern: "github.com/gorilla/mux", Descriptor: "HandleFunc", HTTPMethod: "ANY", Type: "endpoint", Framework: "gorilla-mux"},
+		{PackagePattern: "github.com/gorilla/mux", Descriptor: "Handle", HTTPMethod: "ANY", Type: "endpoint", Framework: "gorilla-mux"},
+
+		// ── Express (TypeScript/JavaScript) ──
+		{PackagePattern: "express", Descriptor: "get", HTTPMethod: "GET", Type: "endpoint", Framework: "express"},
+		{PackagePattern: "express", Descriptor: "post", HTTPMethod: "POST", Type: "endpoint", Framework: "express"},
+		{PackagePattern: "express", Descriptor: "put", HTTPMethod: "PUT", Type: "endpoint", Framework: "express"},
+		{PackagePattern: "express", Descriptor: "delete", HTTPMethod: "DELETE", Type: "endpoint", Framework: "express"},
+		{PackagePattern: "express", Descriptor: "patch", HTTPMethod: "PATCH", Type: "endpoint", Framework: "express"},
+
+		// ── Elysia (TypeScript) ──
+		{PackagePattern: "elysia", Descriptor: "get", HTTPMethod: "GET", Type: "endpoint", Framework: "elysia"},
+		{PackagePattern: "elysia", Descriptor: "post", HTTPMethod: "POST", Type: "endpoint", Framework: "elysia"},
+		{PackagePattern: "elysia", Descriptor: "put", HTTPMethod: "PUT", Type: "endpoint", Framework: "elysia"},
+		{PackagePattern: "elysia", Descriptor: "delete", HTTPMethod: "DELETE", Type: "endpoint", Framework: "elysia"},
+		{PackagePattern: "elysia", Descriptor: "patch", HTTPMethod: "PATCH", Type: "endpoint", Framework: "elysia"},
+
+		// ── Hono (TypeScript) ──
+		{PackagePattern: "hono", Descriptor: "get", HTTPMethod: "GET", Type: "endpoint", Framework: "hono"},
+		{PackagePattern: "hono", Descriptor: "post", HTTPMethod: "POST", Type: "endpoint", Framework: "hono"},
+		{PackagePattern: "hono", Descriptor: "put", HTTPMethod: "PUT", Type: "endpoint", Framework: "hono"},
+		{PackagePattern: "hono", Descriptor: "delete", HTTPMethod: "DELETE", Type: "endpoint", Framework: "hono"},
+
+		// ── Flask (Python) ──
+		{PackagePattern: "flask", Descriptor: "route", HTTPMethod: "ANY", Type: "endpoint", Framework: "flask"},
+		{PackagePattern: "flask", Descriptor: "add_url_rule", HTTPMethod: "ANY", Type: "endpoint", Framework: "flask"},
+
+		// ── FastAPI (Python) ──
+		{PackagePattern: "fastapi", Descriptor: "get", HTTPMethod: "GET", Type: "endpoint", Framework: "fastapi"},
+		{PackagePattern: "fastapi", Descriptor: "post", HTTPMethod: "POST", Type: "endpoint", Framework: "fastapi"},
+		{PackagePattern: "fastapi", Descriptor: "put", HTTPMethod: "PUT", Type: "endpoint", Framework: "fastapi"},
+		{PackagePattern: "fastapi", Descriptor: "delete", HTTPMethod: "DELETE", Type: "endpoint", Framework: "fastapi"},
+
+		// ── HTTP client libraries ──
+		{PackagePattern: "axios", Descriptor: "get", HTTPMethod: "GET", Type: "client", Framework: "axios"},
+		{PackagePattern: "axios", Descriptor: "post", HTTPMethod: "POST", Type: "client", Framework: "axios"},
+		{PackagePattern: "axios", Descriptor: "put", HTTPMethod: "PUT", Type: "client", Framework: "axios"},
+		{PackagePattern: "axios", Descriptor: "delete", HTTPMethod: "DELETE", Type: "client", Framework: "axios"},
+		{PackagePattern: "axios", Descriptor: "patch", HTTPMethod: "PATCH", Type: "client", Framework: "axios"},
+
+		{PackagePattern: "node-fetch", Descriptor: "default", HTTPMethod: "ANY", Type: "client", Framework: "node-fetch"},
+		{PackagePattern: "requests", Descriptor: "get", HTTPMethod: "GET", Type: "client", Framework: "python-requests"},
+		{PackagePattern: "requests", Descriptor: "post", HTTPMethod: "POST", Type: "client", Framework: "python-requests"},
+	}
+}
+
+// symbolMatch holds a matched reference alongside its framework pattern.
+type symbolMatch struct {
+	Pattern     FrameworkPattern
+	FilePath    string
+	StartLine   int
+	StartColumn int
+	FunctionID  string // element ID of the containing Function/Method (if found)
+}
+
+// AnalyzeBySymbols queries the graph for references to known framework symbols,
+// extracts route paths from source lines, and creates APIRoute / SDKCall nodes.
+func (sa *SymbolAnalyzer) AnalyzeBySymbols(ctx context.Context) error {
+	fmt.Println("Starting symbol-based API analysis...")
+
+	// Collect unique package patterns to query
+	packageSet := map[string]bool{}
+	for _, p := range sa.patterns {
+		packageSet[p.PackagePattern] = true
+	}
+
+	var allMatches []symbolMatch
+
+	for pkg := range packageSet {
+		matches, err := sa.queryReferencesForPackage(ctx, pkg)
+		if err != nil {
+			fmt.Printf("Warning: failed to query references for %s: %v\n", pkg, err)
+			continue
+		}
+		allMatches = append(allMatches, matches...)
+	}
+
+	if len(allMatches) == 0 {
+		fmt.Println("No framework symbol references found in graph.")
+		return nil
+	}
+
+	fmt.Printf("Found %d framework symbol references, creating API nodes...\n", len(allMatches))
+
+	endpointCount := 0
+	clientCount := 0
+
+	for _, m := range allMatches {
+		routePath := sa.extractRoutePathFromSource(m.FilePath, m.StartLine)
+
+		switch m.Pattern.Type {
+		case "endpoint":
+			if err := sa.createEndpointNode(ctx, m, routePath); err != nil {
+				fmt.Printf("Warning: failed to create endpoint node: %v\n", err)
+			} else {
+				endpointCount++
+			}
+		case "client":
+			if err := sa.createClientCallNode(ctx, m, routePath); err != nil {
+				fmt.Printf("Warning: failed to create client call node: %v\n", err)
+			} else {
+				clientCount++
+			}
+		}
+	}
+
+	fmt.Printf("Symbol-based API analysis complete: %d endpoints, %d client calls\n", endpointCount, clientCount)
+	return nil
+}
+
+// queryReferencesForPackage finds all Reference nodes that point at Symbols
+// whose symbol string contains the given package substring, then matches
+// against the descriptor patterns for that package.
+func (sa *SymbolAnalyzer) queryReferencesForPackage(ctx context.Context, pkg string) ([]symbolMatch, error) {
+	query := `
+		MATCH (ref:Reference)-[:REFERENCES]->(sym:Symbol)
+		WHERE sym.symbol CONTAINS $package
+		  AND ref.scopeId = $scopeId
+		RETURN ref.filePath AS filePath,
+		       ref.startLine AS startLine,
+		       ref.startColumn AS startColumn,
+		       sym.symbol AS symbol
+	`
+
+	results, err := sa.client.ExecuteQuery(ctx, query, map[string]any{
+		"package": pkg,
+		"scopeId": sa.scopeCtx.ScopeID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []symbolMatch
+	for _, rec := range results {
+		rm := rec.AsMap()
+		symStr := getStringFromMap(rm, "symbol")
+		filePath := getStringFromMap(rm, "filePath")
+		startLine := int(getInt64FromMap(rm, "startLine"))
+		startCol := int(getInt64FromMap(rm, "startColumn"))
+
+		for _, pat := range sa.patterns {
+			if pat.PackagePattern != pkg {
+				continue
+			}
+			if !strings.Contains(symStr, pat.Descriptor) {
+				continue
+			}
+			matches = append(matches, symbolMatch{
+				Pattern:     pat,
+				FilePath:    filePath,
+				StartLine:   startLine,
+				StartColumn: startCol,
+			})
+			break // one pattern match per reference is enough
+		}
+	}
+
+	return matches, nil
+}
+
+// routePathRegex extracts the first string literal argument from a function call on a line.
+var routePathRegex = regexp.MustCompile(`[(\s,]["'` + "`" + `](/[^"'` + "`" + `]*)["'` + "`" + `]`)
+
+// extractRoutePathFromSource reads the source line at startLine and tries to
+// extract a route path string literal (e.g., "/api/users").
+func (sa *SymbolAnalyzer) extractRoutePathFromSource(filePath string, startLine int) string {
+	fullPath := filePath
+	if !filepath.IsAbs(filePath) {
+		fullPath = filepath.Join(sa.projectPath, filePath)
+	}
+
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		return ""
+	}
+
+	lines := strings.Split(string(content), "\n")
+	if startLine <= 0 || startLine > len(lines) {
+		return ""
+	}
+
+	line := lines[startLine-1]
+	match := routePathRegex.FindStringSubmatch(line)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return ""
+}
+
+// createEndpointNode creates an APIRoute node and EXPOSES_API relationship.
+func (sa *SymbolAnalyzer) createEndpointNode(ctx context.Context, m symbolMatch, routePath string) error {
+	if routePath == "" {
+		// No route path extracted — skip to avoid false positives.
+		return nil
+	}
+
+	nodeKey := models.APIRouteNodeKey(m.Pattern.HTTPMethod, routePath)
+	routeProps := map[string]any{
+		"path":      routePath,
+		"method":    m.Pattern.HTTPMethod,
+		"nodeKey":   nodeKey,
+		"protocol":  "HTTP",
+		"framework": m.Pattern.Framework,
+		"scope":     sa.scopeCtx.Scope,
+		"scopeId":   sa.scopeCtx.ScopeID,
+	}
+
+	routeID, err := sa.client.MergeNode(ctx, []string{"APIRoute"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": sa.scopeCtx.ScopeID}, routeProps)
+	if err != nil {
+		return fmt.Errorf("failed to create APIRoute node: %w", err)
+	}
+
+	// Find the containing function to create EXPOSES_API
+	funcID, err := sa.findContainingFunction(ctx, m.FilePath, m.StartLine)
+	if err != nil || funcID == "" {
+		return nil // No enclosing function; skip relationship
+	}
+
+	_, err = sa.client.MergeRelationship(ctx, funcID, routeID, string(models.ExposesAPIRel), nil, nil)
+	return err
+}
+
+// createClientCallNode creates an SDKCall node and CALLS_API relationship.
+func (sa *SymbolAnalyzer) createClientCallNode(ctx context.Context, m symbolMatch, routePath string) error {
+	target := fmt.Sprintf("%s.%s", m.Pattern.Framework, m.Pattern.Descriptor)
+	nodeKey := models.SDKCallNodeKey(target)
+	callProps := map[string]any{
+		"target":    target,
+		"nodeKey":   nodeKey,
+		"framework": m.Pattern.Framework,
+		"type":      "http_client",
+		"scope":     sa.scopeCtx.Scope,
+		"scopeId":   sa.scopeCtx.ScopeID,
+	}
+	if routePath != "" {
+		callProps["url"] = routePath
+	}
+
+	callID, err := sa.client.MergeNode(ctx, []string{"SDKCall"},
+		map[string]any{"nodeKey": nodeKey, "scopeId": sa.scopeCtx.ScopeID}, callProps)
+	if err != nil {
+		return fmt.Errorf("failed to create SDKCall node: %w", err)
+	}
+
+	funcID, err := sa.findContainingFunction(ctx, m.FilePath, m.StartLine)
+	if err != nil || funcID == "" {
+		return nil
+	}
+
+	_, err = sa.client.MergeRelationship(ctx, funcID, callID, string(models.CallsAPIRel),
+		map[string]any{"line": m.StartLine},
+		map[string]any{"framework": m.Pattern.Framework})
+	return err
+}
+
+// findContainingFunction returns the element ID of the Function or Method
+// whose line range contains the given line number.
+func (sa *SymbolAnalyzer) findContainingFunction(ctx context.Context, filePath string, line int) (string, error) {
+	query := `
+		MATCH (f)
+		WHERE (f:Function OR f:Method)
+		  AND f.filePath = $filePath
+		  AND f.startLine <= $line
+		  AND f.endLine >= $line
+		  AND f.scopeId = $scopeId
+		RETURN elementId(f) AS id
+		ORDER BY (f.endLine - f.startLine) ASC
+		LIMIT 1
+	`
+
+	results, err := sa.client.ExecuteQuery(ctx, query, map[string]any{
+		"filePath": filePath,
+		"line":     line,
+		"scopeId":  sa.scopeCtx.ScopeID,
+	})
+	if err != nil || len(results) == 0 {
+		return "", err
+	}
+
+	return results[0].AsMap()["id"].(string), nil
+}

--- a/services/indexing-go/static/tombstone.go
+++ b/services/indexing-go/static/tombstone.go
@@ -1,0 +1,108 @@
+package static
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/pkg/models"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+)
+
+// TombstoneCreator handles creating tombstone nodes for PR overlays.
+// When files or symbols are deleted in a PR branch, tombstones are created
+// so that queries against the PR scope can hide the corresponding main-scope nodes.
+type TombstoneCreator struct {
+	client   *neo4j.Client
+	scopeCtx models.ScopeContext
+}
+
+// NewTombstoneCreator creates a new TombstoneCreator.
+func NewTombstoneCreator(client *neo4j.Client, scopeCtx models.ScopeContext) *TombstoneCreator {
+	return &TombstoneCreator{
+		client:   client,
+		scopeCtx: scopeCtx,
+	}
+}
+
+// CreateFileDeletedTombstones creates tombstones for a deleted file and all its child definitions.
+// It queries the main scope for the file node and all nodes contained within it,
+// then creates Tombstone nodes in the PR scope for each.
+func (tc *TombstoneCreator) CreateFileDeletedTombstones(ctx context.Context, deletedPaths []string) (int, error) {
+	totalCreated := 0
+
+	for _, filePath := range deletedPaths {
+		fileNodeKey := models.FileNodeKey(filePath)
+
+		// Create tombstone for the file itself
+		if err := tc.createTombstone(ctx, fileNodeKey, "File", models.TombstoneFileDeleted); err != nil {
+			return totalCreated, fmt.Errorf("failed to create file tombstone for %s: %w", filePath, err)
+		}
+		totalCreated++
+
+		// Find all child definitions in main scope that belong to this file
+		cypher := `
+			MATCH (n)
+			WHERE n.filePath = $filePath AND n.scopeId = 'main' AND n.nodeKey IS NOT NULL
+			RETURN n.nodeKey AS nodeKey, labels(n) AS labels
+		`
+		results, err := tc.client.ExecuteQuery(ctx, cypher, map[string]any{
+			"filePath": filePath,
+		})
+		if err != nil {
+			fmt.Printf("Warning: failed to query child nodes for %s: %v\n", filePath, err)
+			continue
+		}
+
+		for _, record := range results {
+			recMap := record.AsMap()
+			childNodeKey, ok := recMap["nodeKey"].(string)
+			if !ok || childNodeKey == "" {
+				continue
+			}
+
+			// Get the primary label
+			var label string
+			if labels, ok := recMap["labels"].([]interface{}); ok && len(labels) > 0 {
+				label, _ = labels[0].(string)
+			}
+
+			if err := tc.createTombstone(ctx, childNodeKey, label, models.TombstoneFileDeleted); err != nil {
+				fmt.Printf("Warning: failed to create tombstone for child %s: %v\n", childNodeKey, err)
+				continue
+			}
+			totalCreated++
+		}
+	}
+
+	return totalCreated, nil
+}
+
+// CreateSymbolRemovedTombstones creates tombstones for removed symbols.
+func (tc *TombstoneCreator) CreateSymbolRemovedTombstones(ctx context.Context, removedNodeKeys []string, label string) (int, error) {
+	created := 0
+	for _, nodeKey := range removedNodeKeys {
+		if err := tc.createTombstone(ctx, nodeKey, label, models.TombstoneSymbolRemoved); err != nil {
+			return created, fmt.Errorf("failed to create tombstone for %s: %w", nodeKey, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// createTombstone creates a single Tombstone node in the PR scope.
+func (tc *TombstoneCreator) createTombstone(ctx context.Context, targetNodeKey, targetLabel string, reason models.TombstoneReason) error {
+	tombstoneKey := models.TombstoneNodeKey(tc.scopeCtx.ScopeID, targetNodeKey)
+
+	props := map[string]any{
+		"nodeKey":       tombstoneKey,
+		"targetNodeKey": targetNodeKey,
+		"targetLabel":   targetLabel,
+		"reason":        string(reason),
+		"scope":         tc.scopeCtx.Scope,
+		"scopeId":       tc.scopeCtx.ScopeID,
+	}
+
+	_, err := tc.client.MergeNode(ctx, []string{"Tombstone"},
+		map[string]any{"nodeKey": tombstoneKey, "scopeId": tc.scopeCtx.ScopeID}, props)
+	return err
+}

--- a/services/retrieval-go/llm/adapters.go
+++ b/services/retrieval-go/llm/adapters.go
@@ -1,0 +1,67 @@
+package llm
+
+import (
+	"context"
+)
+
+// EmbeddingServiceAdapter adapts an LLMProvider to the legacy EmbeddingService interface
+// This ensures backward compatibility with existing code that uses EmbeddingService
+type EmbeddingServiceAdapter struct {
+	provider LLMProvider
+}
+
+// NewEmbeddingServiceAdapter creates an adapter from an LLMProvider
+func NewEmbeddingServiceAdapter(provider LLMProvider) *EmbeddingServiceAdapter {
+	return &EmbeddingServiceAdapter{
+		provider: provider,
+	}
+}
+
+// GenerateEmbedding implements the EmbeddingService interface
+func (a *EmbeddingServiceAdapter) GenerateEmbedding(ctx context.Context, text string) ([]float64, error) {
+	return a.provider.GenerateEmbedding(ctx, text)
+}
+
+// GenerateBatchEmbeddings implements the EmbeddingService interface
+func (a *EmbeddingServiceAdapter) GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	return a.provider.GenerateBatchEmbeddings(ctx, texts)
+}
+
+// LLMServiceAdapter adapts an LLMProvider to the legacy LLMService interface
+// This ensures backward compatibility with existing code that uses LLMService
+type LLMServiceAdapter struct {
+	provider LLMProvider
+}
+
+// NewLLMServiceAdapter creates an adapter from an LLMProvider
+func NewLLMServiceAdapter(provider LLMProvider) *LLMServiceAdapter {
+	return &LLMServiceAdapter{
+		provider: provider,
+	}
+}
+
+// GenerateText implements the LLMService interface
+func (a *LLMServiceAdapter) GenerateText(ctx context.Context, prompt string) (string, error) {
+	return a.provider.GenerateText(ctx, prompt)
+}
+
+// GenerateTextWithSystemPrompt implements the LLMService interface
+func (a *LLMServiceAdapter) GenerateTextWithSystemPrompt(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	return a.provider.GenerateTextWithSystemPrompt(ctx, systemPrompt, userPrompt)
+}
+
+// ProviderWrapper wraps both adapters for convenience
+type ProviderWrapper struct {
+	Provider         LLMProvider
+	EmbeddingService *EmbeddingServiceAdapter
+	LLMService       *LLMServiceAdapter
+}
+
+// WrapProvider creates both adapters from a single provider
+func WrapProvider(provider LLMProvider) *ProviderWrapper {
+	return &ProviderWrapper{
+		Provider:         provider,
+		EmbeddingService: NewEmbeddingServiceAdapter(provider),
+		LLMService:       NewLLMServiceAdapter(provider),
+	}
+}

--- a/services/retrieval-go/llm/config.go
+++ b/services/retrieval-go/llm/config.go
@@ -1,0 +1,180 @@
+package llm
+
+import (
+	"fmt"
+	"os"
+)
+
+// Config holds the configuration for an LLM provider
+type Config struct {
+	// Provider type: "gemini", "litellm", "openai"
+	Provider ProviderType
+
+	// API credentials
+	APIKey  string
+	BaseURL string
+
+	// Model configuration
+	TextModel      string
+	EmbeddingModel string
+
+	// Generation parameters
+	Temperature float64
+	MaxTokens   int
+	TopK        int
+	TopP        float64
+
+	// Additional provider-specific options
+	Options map[string]interface{}
+}
+
+// Validate checks if the configuration is valid
+func (c *Config) Validate() error {
+	if !c.Provider.IsValid() {
+		return fmt.Errorf("invalid provider type: %s", c.Provider)
+	}
+
+	if c.APIKey == "" {
+		return fmt.Errorf("API key is required")
+	}
+
+	// Provider-specific validation
+	switch c.Provider {
+	case ProviderGemini:
+		// Gemini uses fixed Google API base URL
+		if c.TextModel == "" {
+			c.TextModel = "gemini-1.5-flash"
+		}
+		if c.EmbeddingModel == "" {
+			c.EmbeddingModel = "gemini-embedding-001"
+		}
+
+	case ProviderLiteLLM, ProviderOpenAI:
+		// LiteLLM and OpenAI require base URL
+		if c.BaseURL == "" {
+			return fmt.Errorf("%s provider requires base URL", c.Provider)
+		}
+		if c.TextModel == "" {
+			return fmt.Errorf("text model is required for %s provider", c.Provider)
+		}
+		if c.EmbeddingModel == "" {
+			return fmt.Errorf("embedding model is required for %s provider", c.Provider)
+		}
+	}
+
+	// Set defaults for generation parameters
+	if c.Temperature == 0 {
+		c.Temperature = 0.2
+	}
+	if c.MaxTokens == 0 {
+		c.MaxTokens = 1024
+	}
+	if c.TopK == 0 {
+		c.TopK = 40
+	}
+	if c.TopP == 0 {
+		c.TopP = 0.95
+	}
+
+	return nil
+}
+
+// ConfigFromEnv creates a Config from environment variables
+func ConfigFromEnv() Config {
+	provider := os.Getenv("LLM_PROVIDER")
+	if provider == "" {
+		// Backward compatibility: check for GEMINI_API_KEY
+		if os.Getenv("GEMINI_API_KEY") != "" {
+			provider = "gemini"
+		} else {
+			provider = "litellm" // Default to LiteLLM
+		}
+	}
+
+	apiKey := os.Getenv("LLM_API_KEY")
+	if apiKey == "" {
+		// Backward compatibility
+		apiKey = os.Getenv("GEMINI_API_KEY")
+	}
+
+	config := Config{
+		Provider:       ProviderType(provider),
+		APIKey:         apiKey,
+		BaseURL:        os.Getenv("LLM_BASE_URL"),
+		TextModel:      os.Getenv("LLM_TEXT_MODEL"),
+		EmbeddingModel: os.Getenv("LLM_EMBEDDING_MODEL"),
+	}
+
+	// Parse optional parameters
+	if temp := os.Getenv("LLM_TEMPERATURE"); temp != "" {
+		fmt.Sscanf(temp, "%f", &config.Temperature)
+	}
+	if tokens := os.Getenv("LLM_MAX_TOKENS"); tokens != "" {
+		fmt.Sscanf(tokens, "%d", &config.MaxTokens)
+	}
+
+	return config
+}
+
+// DefaultConfig returns a default configuration for the specified provider
+func DefaultConfig(provider ProviderType) Config {
+	config := Config{
+		Provider:    provider,
+		Temperature: 0.2,
+		MaxTokens:   1024,
+		TopK:        40,
+		TopP:        0.95,
+		Options:     make(map[string]interface{}),
+	}
+
+	switch provider {
+	case ProviderGemini:
+		config.TextModel = "gemini-1.5-flash"
+		config.EmbeddingModel = "gemini-embedding-001"
+	case ProviderLiteLLM:
+		config.TextModel = "openai/gpt-4"
+		config.EmbeddingModel = "openai/text-embedding-3-small"
+	case ProviderOpenAI:
+		config.TextModel = "gpt-4"
+		config.EmbeddingModel = "text-embedding-3-small"
+		config.BaseURL = "https://api.openai.com/v1"
+	}
+
+	return config
+}
+
+// WithAPIKey sets the API key
+func (c Config) WithAPIKey(apiKey string) Config {
+	c.APIKey = apiKey
+	return c
+}
+
+// WithBaseURL sets the base URL
+func (c Config) WithBaseURL(baseURL string) Config {
+	c.BaseURL = baseURL
+	return c
+}
+
+// WithTextModel sets the text generation model
+func (c Config) WithTextModel(model string) Config {
+	c.TextModel = model
+	return c
+}
+
+// WithEmbeddingModel sets the embedding model
+func (c Config) WithEmbeddingModel(model string) Config {
+	c.EmbeddingModel = model
+	return c
+}
+
+// WithTemperature sets the temperature parameter
+func (c Config) WithTemperature(temp float64) Config {
+	c.Temperature = temp
+	return c
+}
+
+// WithMaxTokens sets the maximum tokens parameter
+func (c Config) WithMaxTokens(tokens int) Config {
+	c.MaxTokens = tokens
+	return c
+}

--- a/services/retrieval-go/llm/gemini/provider.go
+++ b/services/retrieval-go/llm/gemini/provider.go
@@ -1,0 +1,273 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/context-maximiser/code-graph/pkg/llm"
+	"google.golang.org/genai"
+)
+
+// Provider implements LLM operations using Google's Gemini API
+type Provider struct {
+	apiKey     string
+	textModel  string
+	embModel   string
+	config     llm.Config
+	httpClient *http.Client
+}
+
+// init registers the Gemini provider
+func init() {
+	llm.NewGeminiProvider = newGeminiProvider
+}
+
+// newGeminiProvider creates a new Gemini provider instance
+func newGeminiProvider(config llm.Config) (llm.LLMProvider, error) {
+	return &Provider{
+		apiKey:    config.APIKey,
+		textModel: config.TextModel,
+		embModel:  config.EmbeddingModel,
+		config:    config,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}, nil
+}
+
+// Name returns the provider name
+func (p *Provider) Name() string {
+	return "gemini"
+}
+
+// SupportsEmbeddings returns true as Gemini supports embeddings
+func (p *Provider) SupportsEmbeddings() bool {
+	return true
+}
+
+// SupportsTextGeneration returns true as Gemini supports text generation
+func (p *Provider) SupportsTextGeneration() bool {
+	return true
+}
+
+// Close closes any resources held by the provider
+func (p *Provider) Close() error {
+	p.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// GenerateText generates text from a prompt using Gemini
+func (p *Provider) GenerateText(ctx context.Context, prompt string) (string, error) {
+	return p.GenerateTextWithSystemPrompt(ctx, "", prompt)
+}
+
+// GenerateTextWithSystemPrompt generates text with a system prompt and user prompt
+func (p *Provider) GenerateTextWithSystemPrompt(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	// Construct the full prompt
+	fullPrompt := userPrompt
+	if systemPrompt != "" {
+		fullPrompt = systemPrompt + "\n\n" + userPrompt
+	}
+
+	// Build the request
+	requestBody := geminiTextRequest{
+		Contents: []geminiContent{
+			{
+				Parts: []geminiPart{
+					{Text: fullPrompt},
+				},
+			},
+		},
+		GenerationConfig: geminiGenerationConfig{
+			Temperature:     p.config.Temperature,
+			TopK:            p.config.TopK,
+			TopP:            p.config.TopP,
+			MaxOutputTokens: p.config.MaxTokens,
+		},
+		SafetySettings: []geminiSafetySetting{
+			{Category: "HARM_CATEGORY_HARASSMENT", Threshold: "BLOCK_MEDIUM_AND_ABOVE"},
+			{Category: "HARM_CATEGORY_HATE_SPEECH", Threshold: "BLOCK_MEDIUM_AND_ABOVE"},
+			{Category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", Threshold: "BLOCK_MEDIUM_AND_ABOVE"},
+			{Category: "HARM_CATEGORY_DANGEROUS_CONTENT", Threshold: "BLOCK_MEDIUM_AND_ABOVE"},
+		},
+	}
+
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Make the API request
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s", p.textModel, p.apiKey)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse the response
+	var response geminiTextResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Extract the generated text
+	if len(response.Candidates) == 0 {
+		return "", fmt.Errorf("no candidates in response")
+	}
+
+	if len(response.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("no parts in response")
+	}
+
+	return response.Candidates[0].Content.Parts[0].Text, nil
+}
+
+// GenerateEmbedding generates a single embedding for the given text using Gemini
+func (p *Provider) GenerateEmbedding(ctx context.Context, text string) ([]float64, error) {
+	embeddings, err := p.GenerateBatchEmbeddings(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embeddings returned")
+	}
+
+	return embeddings[0], nil
+}
+
+// GenerateBatchEmbeddings generates embeddings for multiple texts using Gemini
+func (p *Provider) GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	if len(texts) == 0 {
+		return nil, fmt.Errorf("no texts provided")
+	}
+
+	// Create client with API key
+	clientConfig := &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		APIKey:  p.apiKey,
+	}
+	client, err := genai.NewClient(ctx, clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Gemini client: %w", err)
+	}
+
+	var allEmbeddings [][]float64
+
+	// Process texts in batches
+	for _, text := range texts {
+		// Validate text has minimum content
+		trimmedText := strings.TrimSpace(text)
+		if len(trimmedText) < 3 {
+			trimmedText = trimmedText + " code element"
+		}
+
+		// Create content from text
+		contents := genai.Text(trimmedText)
+
+		// Generate embedding with semantic similarity task type and 768 dimensions
+		embedConfig := &genai.EmbedContentConfig{
+			TaskType:             "SEMANTIC_SIMILARITY",
+			OutputDimensionality: genai.Ptr(int32(768)), // 768 dimensions for Neo4j compatibility
+		}
+
+		result, err := client.Models.EmbedContent(ctx, p.embModel, contents, embedConfig)
+		if err != nil {
+			return nil, fmt.Errorf("Gemini embedding failed for text '%s': %w", text[:min(50, len(text))], err)
+		}
+
+		if result == nil || result.Embeddings == nil || len(result.Embeddings) == 0 {
+			return nil, fmt.Errorf("no embedding returned for text '%s'", text[:min(50, len(text))])
+		}
+
+		// Get the first (and only) embedding
+		embedding := result.Embeddings[0]
+		if len(embedding.Values) == 0 {
+			return nil, fmt.Errorf("empty embedding values for text '%s'", text[:min(50, len(text))])
+		}
+
+		// Convert float32 to float64
+		embeddingVec := make([]float64, len(embedding.Values))
+		for i, v := range embedding.Values {
+			embeddingVec[i] = float64(v)
+		}
+
+		allEmbeddings = append(allEmbeddings, embeddingVec)
+	}
+
+	log.Printf("✓ Generated %d embeddings using Gemini %s", len(allEmbeddings), p.embModel)
+	return allEmbeddings, nil
+}
+
+// Helper function for min
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Gemini API request/response structures
+type geminiTextRequest struct {
+	Contents         []geminiContent        `json:"contents"`
+	GenerationConfig geminiGenerationConfig `json:"generationConfig"`
+	SafetySettings   []geminiSafetySetting  `json:"safetySettings"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+	Role  string       `json:"role,omitempty"`
+}
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiGenerationConfig struct {
+	Temperature     float64 `json:"temperature"`
+	TopK            int     `json:"topK"`
+	TopP            float64 `json:"topP"`
+	MaxOutputTokens int     `json:"maxOutputTokens"`
+}
+
+type geminiSafetySetting struct {
+	Category  string `json:"category"`
+	Threshold string `json:"threshold"`
+}
+
+type geminiTextResponse struct {
+	Candidates []geminiCandidate `json:"candidates"`
+}
+
+type geminiCandidate struct {
+	Content       geminiContent `json:"content"`
+	FinishReason  string        `json:"finishReason"`
+	SafetyRatings []struct {
+		Category    string `json:"category"`
+		Probability string `json:"probability"`
+	} `json:"safetyRatings"`
+}

--- a/services/retrieval-go/llm/litellm/provider.go
+++ b/services/retrieval-go/llm/litellm/provider.go
@@ -1,0 +1,167 @@
+package litellm
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/context-maximiser/code-graph/pkg/llm"
+	"github.com/sashabaranov/go-openai"
+)
+
+// Provider implements LLM operations using LiteLLM proxy
+// LiteLLM provides a unified interface to 100+ LLM providers via OpenAI-compatible API
+type Provider struct {
+	client    *openai.Client
+	config    llm.Config
+	textModel string
+	embModel  string
+}
+
+// init registers the LiteLLM provider
+func init() {
+	llm.NewLiteLLMProvider = newLiteLLMProvider
+}
+
+// newLiteLLMProvider creates a new LiteLLM provider instance
+func newLiteLLMProvider(config llm.Config) (llm.LLMProvider, error) {
+	if config.BaseURL == "" {
+		return nil, fmt.Errorf("LiteLLM provider requires base URL (LiteLLM proxy server URL)")
+	}
+
+	clientConfig := openai.DefaultConfig(config.APIKey)
+	clientConfig.BaseURL = config.BaseURL
+
+	client := openai.NewClientWithConfig(clientConfig)
+
+	log.Printf("🔗 LiteLLM provider initialized: %s", config.BaseURL)
+	log.Printf("   Text Model: %s", config.TextModel)
+	log.Printf("   Embedding Model: %s", config.EmbeddingModel)
+
+	return &Provider{
+		client:    client,
+		config:    config,
+		textModel: config.TextModel,
+		embModel:  config.EmbeddingModel,
+	}, nil
+}
+
+// Name returns the provider name
+func (p *Provider) Name() string {
+	return "litellm"
+}
+
+// SupportsEmbeddings returns true as LiteLLM supports embeddings
+func (p *Provider) SupportsEmbeddings() bool {
+	return true
+}
+
+// SupportsTextGeneration returns true as LiteLLM supports text generation
+func (p *Provider) SupportsTextGeneration() bool {
+	return true
+}
+
+// Close closes any resources held by the provider
+func (p *Provider) Close() error {
+	// OpenAI client doesn't require explicit cleanup
+	return nil
+}
+
+// GenerateText generates text from a prompt using LiteLLM
+func (p *Provider) GenerateText(ctx context.Context, prompt string) (string, error) {
+	return p.GenerateTextWithSystemPrompt(ctx, "", prompt)
+}
+
+// GenerateTextWithSystemPrompt generates text with a system prompt and user prompt
+// Note: LiteLLM uses the OpenAI-compatible chat completion format
+func (p *Provider) GenerateTextWithSystemPrompt(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	messages := []openai.ChatCompletionMessage{
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: userPrompt,
+		},
+	}
+
+	// Add system prompt if provided
+	if systemPrompt != "" {
+		messages = []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: systemPrompt,
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: userPrompt,
+			},
+		}
+	}
+
+	// LiteLLM expects model names with provider prefix (e.g., "openai/gpt-4", "anthropic/claude-3")
+	req := openai.ChatCompletionRequest{
+		Model:       p.textModel,
+		Messages:    messages,
+		Temperature: float32(p.config.Temperature),
+		MaxTokens:   p.config.MaxTokens,
+		TopP:        float32(p.config.TopP),
+	}
+
+	resp, err := p.client.CreateChatCompletion(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("LiteLLM chat completion failed: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response")
+	}
+
+	return resp.Choices[0].Message.Content, nil
+}
+
+// GenerateEmbedding generates a single embedding for the given text
+func (p *Provider) GenerateEmbedding(ctx context.Context, text string) ([]float64, error) {
+	embeddings, err := p.GenerateBatchEmbeddings(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embeddings returned")
+	}
+
+	return embeddings[0], nil
+}
+
+// GenerateBatchEmbeddings generates embeddings for multiple texts
+// Note: LiteLLM model names should include provider prefix (e.g., "openai/text-embedding-3-small")
+func (p *Provider) GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	if len(texts) == 0 {
+		return nil, fmt.Errorf("no texts provided")
+	}
+
+	req := openai.EmbeddingRequest{
+		Model: openai.EmbeddingModel(p.embModel),
+		Input: texts,
+	}
+
+	resp, err := p.client.CreateEmbeddings(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("LiteLLM embedding failed: %w", err)
+	}
+
+	if len(resp.Data) != len(texts) {
+		return nil, fmt.Errorf("expected %d embeddings, got %d", len(texts), len(resp.Data))
+	}
+
+	// Convert float32 embeddings to float64
+	var embeddings [][]float64
+	for _, data := range resp.Data {
+		embedding := make([]float64, len(data.Embedding))
+		for i, v := range data.Embedding {
+			embedding[i] = float64(v)
+		}
+		embeddings = append(embeddings, embedding)
+	}
+
+	log.Printf("✓ Generated %d embeddings via LiteLLM (%s)", len(embeddings), p.embModel)
+	return embeddings, nil
+}

--- a/services/retrieval-go/llm/openai/provider.go
+++ b/services/retrieval-go/llm/openai/provider.go
@@ -1,0 +1,158 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/pkg/llm"
+	"github.com/sashabaranov/go-openai"
+)
+
+// Provider implements LLM operations using OpenAI-compatible APIs
+// This provider works with OpenAI, Azure OpenAI, and other compatible services
+type Provider struct {
+	client    *openai.Client
+	config    llm.Config
+	textModel string
+	embModel  string
+}
+
+// init registers the OpenAI provider
+func init() {
+	llm.NewOpenAIProvider = newOpenAIProvider
+}
+
+// newOpenAIProvider creates a new OpenAI-compatible provider instance
+func newOpenAIProvider(config llm.Config) (llm.LLMProvider, error) {
+	clientConfig := openai.DefaultConfig(config.APIKey)
+
+	// Set custom base URL if provided (for Azure, local deployments, etc.)
+	if config.BaseURL != "" {
+		clientConfig.BaseURL = config.BaseURL
+	}
+
+	client := openai.NewClientWithConfig(clientConfig)
+
+	return &Provider{
+		client:    client,
+		config:    config,
+		textModel: config.TextModel,
+		embModel:  config.EmbeddingModel,
+	}, nil
+}
+
+// Name returns the provider name
+func (p *Provider) Name() string {
+	return "openai"
+}
+
+// SupportsEmbeddings returns true as OpenAI supports embeddings
+func (p *Provider) SupportsEmbeddings() bool {
+	return true
+}
+
+// SupportsTextGeneration returns true as OpenAI supports text generation
+func (p *Provider) SupportsTextGeneration() bool {
+	return true
+}
+
+// Close closes any resources held by the provider
+func (p *Provider) Close() error {
+	// OpenAI client doesn't require explicit cleanup
+	return nil
+}
+
+// GenerateText generates text from a prompt using OpenAI chat completion
+func (p *Provider) GenerateText(ctx context.Context, prompt string) (string, error) {
+	return p.GenerateTextWithSystemPrompt(ctx, "", prompt)
+}
+
+// GenerateTextWithSystemPrompt generates text with a system prompt and user prompt
+func (p *Provider) GenerateTextWithSystemPrompt(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	messages := []openai.ChatCompletionMessage{
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: userPrompt,
+		},
+	}
+
+	// Add system prompt if provided
+	if systemPrompt != "" {
+		messages = []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: systemPrompt,
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: userPrompt,
+			},
+		}
+	}
+
+	req := openai.ChatCompletionRequest{
+		Model:       p.textModel,
+		Messages:    messages,
+		Temperature: float32(p.config.Temperature),
+		MaxTokens:   p.config.MaxTokens,
+		TopP:        float32(p.config.TopP),
+	}
+
+	resp, err := p.client.CreateChatCompletion(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("OpenAI chat completion failed: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response")
+	}
+
+	return resp.Choices[0].Message.Content, nil
+}
+
+// GenerateEmbedding generates a single embedding for the given text
+func (p *Provider) GenerateEmbedding(ctx context.Context, text string) ([]float64, error) {
+	embeddings, err := p.GenerateBatchEmbeddings(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embeddings returned")
+	}
+
+	return embeddings[0], nil
+}
+
+// GenerateBatchEmbeddings generates embeddings for multiple texts
+func (p *Provider) GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	if len(texts) == 0 {
+		return nil, fmt.Errorf("no texts provided")
+	}
+
+	req := openai.EmbeddingRequest{
+		Model: openai.EmbeddingModel(p.embModel),
+		Input: texts,
+	}
+
+	resp, err := p.client.CreateEmbeddings(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("OpenAI embedding failed: %w", err)
+	}
+
+	if len(resp.Data) != len(texts) {
+		return nil, fmt.Errorf("expected %d embeddings, got %d", len(texts), len(resp.Data))
+	}
+
+	// Convert float32 embeddings to float64
+	var embeddings [][]float64
+	for _, data := range resp.Data {
+		embedding := make([]float64, len(data.Embedding))
+		for i, v := range data.Embedding {
+			embedding[i] = float64(v)
+		}
+		embeddings = append(embeddings, embedding)
+	}
+
+	return embeddings, nil
+}

--- a/services/retrieval-go/llm/provider.go
+++ b/services/retrieval-go/llm/provider.go
@@ -1,0 +1,73 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+)
+
+// LLMProvider defines a unified interface for all LLM operations
+// This interface abstracts away provider-specific implementations (Gemini, LiteLLM, OpenAI, etc.)
+type LLMProvider interface {
+	// Text generation methods
+	GenerateText(ctx context.Context, prompt string) (string, error)
+	GenerateTextWithSystemPrompt(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+
+	// Embedding generation methods
+	GenerateEmbedding(ctx context.Context, text string) ([]float64, error)
+	GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error)
+
+	// Provider metadata
+	Name() string
+	SupportsEmbeddings() bool
+	SupportsTextGeneration() bool
+	Close() error
+}
+
+// NewProvider creates a new LLM provider based on the configuration
+func NewProvider(config Config) (LLMProvider, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid provider config: %w", err)
+	}
+
+	switch config.Provider {
+	case ProviderGemini:
+		return NewGeminiProvider(config)
+	case ProviderLiteLLM:
+		return NewLiteLLMProvider(config)
+	case ProviderOpenAI:
+		return NewOpenAIProvider(config)
+	default:
+		return nil, fmt.Errorf("unknown provider type: %s (supported: gemini, litellm, openai)", config.Provider)
+	}
+}
+
+// Provider factory functions (implemented in subpackages)
+var (
+	NewGeminiProvider   func(Config) (LLMProvider, error)
+	NewLiteLLMProvider  func(Config) (LLMProvider, error)
+	NewOpenAIProvider   func(Config) (LLMProvider, error)
+)
+
+// ProviderType represents supported LLM providers
+type ProviderType string
+
+const (
+	ProviderGemini   ProviderType = "gemini"
+	ProviderLiteLLM  ProviderType = "litellm"
+	ProviderOpenAI   ProviderType = "openai"
+)
+
+// IsValid checks if the provider type is supported
+func (p ProviderType) IsValid() bool {
+	switch p {
+	case ProviderGemini, ProviderLiteLLM, ProviderOpenAI:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the provider type
+func (p ProviderType) String() string {
+	return string(p)
+}

--- a/services/retrieval-go/project.json
+++ b/services/retrieval-go/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "retrieval-go",
+  "root": "services/retrieval-go",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go build ./services/retrieval-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go test ./services/retrieval-go/...",
+        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
+      }
+    }
+  }
+}

--- a/services/retrieval-go/query/advanced.go
+++ b/services/retrieval-go/query/advanced.go
@@ -1,0 +1,290 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// AdvancedQueryService provides complex analysis queries
+type AdvancedQueryService struct {
+	queryBuilder *neo4j.QueryBuilder
+}
+
+// NewAdvancedQueryService creates a new advanced query service
+func NewAdvancedQueryService(client *neo4j.Client) *AdvancedQueryService {
+	return &AdvancedQueryService{
+		queryBuilder: neo4j.NewQueryBuilder(client),
+	}
+}
+
+// ImpactAnalysisRequest represents an impact analysis request
+type ImpactAnalysisRequest struct {
+	FunctionSymbol string `json:"functionSymbol"`
+	MaxDepth       int    `json:"maxDepth,omitempty"`
+}
+
+// ImpactAnalysisResponse represents the impact analysis results
+type ImpactAnalysisResponse struct {
+	FunctionSymbol     string              `json:"functionSymbol"`
+	AffectedEndpoints  []*models.APIRoute  `json:"affectedEndpoints"`
+	AffectedFunctions  []*FunctionRef      `json:"affectedFunctions"`
+	EndpointCount      int                 `json:"endpointCount"`
+	FunctionCount      int                 `json:"functionCount"`
+	MaxDepthReached    int                 `json:"maxDepthReached"`
+}
+
+// FunctionRef represents a function reference in impact analysis
+type FunctionRef struct {
+	Name      string `json:"name"`
+	Signature string `json:"signature"`
+	FilePath  string `json:"filePath"`
+	Type      string `json:"type"` // Function or Method
+	Depth     int    `json:"depth"`
+}
+
+// AnalyzeImpact performs impact analysis for a function
+func (aqs *AdvancedQueryService) AnalyzeImpact(ctx context.Context, req ImpactAnalysisRequest) (*ImpactAnalysisResponse, error) {
+	// Find affected API endpoints
+	endpoints, err := aqs.queryBuilder.FindAPIEndpointsAffectedByFunction(ctx, req.FunctionSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find affected endpoints: %w", err)
+	}
+
+	// TODO: Find affected functions with depth tracking
+	// This would require a more complex query to track call chains
+	
+	return &ImpactAnalysisResponse{
+		FunctionSymbol:    req.FunctionSymbol,
+		AffectedEndpoints: endpoints,
+		AffectedFunctions: []*FunctionRef{}, // TODO: Implement
+		EndpointCount:     len(endpoints),
+		FunctionCount:     0, // TODO: Implement
+		MaxDepthReached:   0, // TODO: Implement
+	}, nil
+}
+
+// DataFlowRequest represents a data flow tracing request
+type DataFlowRequest struct {
+	ParameterSymbol string `json:"parameterSymbol"`
+	MaxSteps        int    `json:"maxSteps,omitempty"`
+}
+
+// DataFlowResponse represents data flow analysis results
+type DataFlowResponse struct {
+	ParameterSymbol string                    `json:"parameterSymbol"`
+	FlowPaths       []*DataFlowPath           `json:"flowPaths"`
+	Destinations    []*models.SymbolReference `json:"destinations"`
+	PathCount       int                       `json:"pathCount"`
+}
+
+// DataFlowPath represents a single data flow path
+type DataFlowPath struct {
+	Steps       []*DataFlowStep `json:"steps"`
+	Destination *DataFlowStep   `json:"destination"`
+	Length      int             `json:"length"`
+}
+
+// DataFlowStep represents a step in a data flow path
+type DataFlowStep struct {
+	Symbol     string `json:"symbol"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	FilePath   string `json:"filePath"`
+	Line       int    `json:"line"`
+	FlowType   string `json:"flowType"` // direct, indirect, conditional
+}
+
+// TraceDataFlow traces the flow of data from a parameter
+func (aqs *AdvancedQueryService) TraceDataFlow(ctx context.Context, req DataFlowRequest) (*DataFlowResponse, error) {
+	references, err := aqs.queryBuilder.TraceDataFlow(ctx, req.ParameterSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to trace data flow: %w", err)
+	}
+
+	// TODO: Build data flow paths from the references
+	// This requires a more sophisticated analysis of the flow relationships
+	
+	return &DataFlowResponse{
+		ParameterSymbol: req.ParameterSymbol,
+		FlowPaths:       []*DataFlowPath{}, // TODO: Implement
+		Destinations:    references,
+		PathCount:       len(references),
+	}, nil
+}
+
+// DependencyAnalysisRequest represents a dependency analysis request
+type DependencyAnalysisRequest struct {
+	ServiceName      string `json:"serviceName"`
+	IncludeInternal  bool   `json:"includeInternal"`
+	IncludeTransitive bool   `json:"includeTransitive"`
+}
+
+// ServiceDependency represents a service dependency
+type ServiceDependency struct {
+	ServiceName      string   `json:"serviceName"`
+	Version          string   `json:"version,omitempty"`
+	Type             string   `json:"type"` // direct, transitive
+	CallingFunctions []string `json:"callingFunctions"`
+	CallCount        int      `json:"callCount"`
+}
+
+// DependencyAnalysisResponse represents dependency analysis results
+type DependencyAnalysisResponse struct {
+	ServiceName  string               `json:"serviceName"`
+	Dependencies []*ServiceDependency `json:"dependencies"`
+	DependencyCount int               `json:"dependencyCount"`
+}
+
+// AnalyzeDependencies analyzes service dependencies
+func (aqs *AdvancedQueryService) AnalyzeDependencies(ctx context.Context, req DependencyAnalysisRequest) (*DependencyAnalysisResponse, error) {
+	dependencies, err := aqs.queryBuilder.DiscoverServiceDependencies(ctx, req.ServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover dependencies: %w", err)
+	}
+
+	// Group dependencies by service
+	depMap := make(map[string]*ServiceDependency)
+	for _, dep := range dependencies {
+		if depData, ok := dep["foreignServiceName"].([]interface{}); ok && len(depData) > 2 {
+			serviceName := fmt.Sprintf("%v", depData[2])
+			
+			if existing, found := depMap[serviceName]; found {
+				if callingFunc, ok := dep["callingFunction"].(string); ok {
+					existing.CallingFunctions = append(existing.CallingFunctions, callingFunc)
+					existing.CallCount++
+				}
+			} else {
+				newDep := &ServiceDependency{
+					ServiceName: serviceName,
+					Type:        "direct",
+					CallCount:   1,
+				}
+				if callingFunc, ok := dep["callingFunction"].(string); ok {
+					newDep.CallingFunctions = []string{callingFunc}
+				}
+				depMap[serviceName] = newDep
+			}
+		}
+	}
+
+	// Convert map to slice
+	var serviceDeps []*ServiceDependency
+	for _, dep := range depMap {
+		serviceDeps = append(serviceDeps, dep)
+	}
+
+	return &DependencyAnalysisResponse{
+		ServiceName:     req.ServiceName,
+		Dependencies:    serviceDeps,
+		DependencyCount: len(serviceDeps),
+	}, nil
+}
+
+// ComplexityAnalysisRequest represents a complexity analysis request
+type ComplexityAnalysisRequest struct {
+	ServiceName string `json:"serviceName,omitempty"`
+	FilePath    string `json:"filePath,omitempty"`
+}
+
+// ComplexityMetrics represents complexity metrics for a code element
+type ComplexityMetrics struct {
+	Name               string  `json:"name"`
+	Type               string  `json:"type"`
+	FilePath           string  `json:"filePath"`
+	CyclomaticComplexity int   `json:"cyclomaticComplexity"`
+	LinesOfCode        int     `json:"linesOfCode"`
+	ParameterCount     int     `json:"parameterCount"`
+	CallCount          int     `json:"callCount"`
+	ComplexityScore    float64 `json:"complexityScore"`
+}
+
+// ComplexityAnalysisResponse represents complexity analysis results
+type ComplexityAnalysisResponse struct {
+	ServiceName string               `json:"serviceName,omitempty"`
+	FilePath    string               `json:"filePath,omitempty"`
+	Functions   []*ComplexityMetrics `json:"functions"`
+	Classes     []*ComplexityMetrics `json:"classes"`
+	Summary     *ComplexitySummary   `json:"summary"`
+}
+
+// ComplexitySummary represents overall complexity summary
+type ComplexitySummary struct {
+	TotalFunctions     int     `json:"totalFunctions"`
+	AverageComplexity  float64 `json:"averageComplexity"`
+	MaxComplexity      int     `json:"maxComplexity"`
+	HighComplexityCount int    `json:"highComplexityCount"`
+}
+
+// AnalyzeComplexity analyzes code complexity metrics
+func (aqs *AdvancedQueryService) AnalyzeComplexity(ctx context.Context, req ComplexityAnalysisRequest) (*ComplexityAnalysisResponse, error) {
+	// This is a placeholder implementation
+	// In a full implementation, we would query the database for complexity metrics
+	// and calculate various complexity scores
+	
+	return &ComplexityAnalysisResponse{
+		ServiceName: req.ServiceName,
+		FilePath:    req.FilePath,
+		Functions:   []*ComplexityMetrics{},
+		Classes:     []*ComplexityMetrics{},
+		Summary: &ComplexitySummary{
+			TotalFunctions:      0,
+			AverageComplexity:   0.0,
+			MaxComplexity:       0,
+			HighComplexityCount: 0,
+		},
+	}, nil
+}
+
+// CallGraphRequest represents a call graph request
+type CallGraphRequest struct {
+	RootFunction string `json:"rootFunction"`
+	MaxDepth     int    `json:"maxDepth,omitempty"`
+	Direction    string `json:"direction"` // "outgoing", "incoming", "both"
+}
+
+// CallGraphNode represents a node in the call graph
+type CallGraphNode struct {
+	Symbol    string   `json:"symbol"`
+	Name      string   `json:"name"`
+	Type      string   `json:"type"`
+	FilePath  string   `json:"filePath"`
+	Depth     int      `json:"depth"`
+	CallCount int      `json:"callCount"`
+	Children  []string `json:"children"` // References to other nodes by symbol
+}
+
+// CallGraphResponse represents call graph analysis results
+type CallGraphResponse struct {
+	RootFunction string                    `json:"rootFunction"`
+	Direction    string                    `json:"direction"`
+	Nodes        map[string]*CallGraphNode `json:"nodes"`
+	Edges        []*CallGraphEdge          `json:"edges"`
+	MaxDepth     int                       `json:"maxDepth"`
+}
+
+// CallGraphEdge represents an edge in the call graph
+type CallGraphEdge struct {
+	From      string `json:"from"`
+	To        string `json:"to"`
+	CallType  string `json:"callType"` // direct, indirect
+	Line      int    `json:"line,omitempty"`
+	Recursive bool   `json:"recursive,omitempty"`
+}
+
+// BuildCallGraph builds a call graph starting from a function
+func (aqs *AdvancedQueryService) BuildCallGraph(ctx context.Context, req CallGraphRequest) (*CallGraphResponse, error) {
+	// This is a placeholder implementation
+	// In a full implementation, we would traverse the CALLS relationships
+	// to build a comprehensive call graph
+	
+	return &CallGraphResponse{
+		RootFunction: req.RootFunction,
+		Direction:    req.Direction,
+		Nodes:        make(map[string]*CallGraphNode),
+		Edges:        []*CallGraphEdge{},
+		MaxDepth:     0,
+	}, nil
+}

--- a/services/retrieval-go/query/flow_spine.go
+++ b/services/retrieval-go/query/flow_spine.go
@@ -1,0 +1,328 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// FlowStep represents a single step in a flow spine.
+type FlowStep struct {
+	NodeKey string `json:"nodeKey"`
+	Name    string `json:"name"`
+	Label   string `json:"label"` // Function, Method, Service, APIRoute
+	Order   int    `json:"order"`
+}
+
+// FlowSpineResult holds the generated flow and its steps.
+type FlowSpineResult struct {
+	FlowNodeKey string     `json:"flowNodeKey"`
+	FlowName    string     `json:"flowName"`
+	FlowType    string     `json:"flowType"`
+	Steps       []FlowStep `json:"steps"`
+}
+
+// FlowSpineGenerator creates Flow spine nodes from API endpoints and call graphs.
+type FlowSpineGenerator struct {
+	client   *neo4j.Client
+	scopeCtx models.ScopeContext
+}
+
+// NewFlowSpineGenerator creates a new generator.
+func NewFlowSpineGenerator(client *neo4j.Client) *FlowSpineGenerator {
+	return &FlowSpineGenerator{
+		client:   client,
+		scopeCtx: models.DefaultScope(),
+	}
+}
+
+// SetScope sets the scope context for flow generation.
+func (g *FlowSpineGenerator) SetScope(scope models.ScopeContext) {
+	g.scopeCtx = scope
+}
+
+// GenerateFromAPIEndpoints discovers API endpoints and builds flow spines by
+// traversing the call graph from each handler function up to maxDepth.
+func (g *FlowSpineGenerator) GenerateFromAPIEndpoints(ctx context.Context, maxDepth int) ([]FlowSpineResult, error) {
+	if maxDepth <= 0 {
+		maxDepth = 2
+	}
+
+	// Find API endpoints and their handler functions.
+	cypher := `
+		MATCH (route:APIRoute)
+		WHERE route.scopeId = $scopeId OR route.scopeId = 'main'
+		OPTIONAL MATCH (route)<-[:EXPOSES_API]-(handler)
+		WHERE handler:Function OR handler:Method
+		RETURN route.nodeKey AS routeKey, route.method AS method, route.path AS path,
+		       handler.nodeKey AS handlerKey, handler.name AS handlerName,
+		       labels(handler) AS handlerLabels`
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, map[string]any{"scopeId": g.scopeCtx.ScopeID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query API endpoints: %w", err)
+	}
+
+	var results []FlowSpineResult
+	for _, r := range records {
+		m := r.AsMap()
+		routeKey := strVal(m, "routeKey")
+		method := strVal(m, "method")
+		path := strVal(m, "path")
+		handlerKey := strVal(m, "handlerKey")
+		handlerName := strVal(m, "handlerName")
+
+		if routeKey == "" {
+			continue
+		}
+
+		flowName := fmt.Sprintf("%s %s", method, path)
+		flowNodeKey := models.FlowNodeKey("api", routeKey)
+
+		steps := []FlowStep{
+			{NodeKey: routeKey, Name: flowName, Label: "APIRoute", Order: 0},
+		}
+
+		// If there's a handler, traverse its call graph.
+		if handlerKey != "" {
+			handlerLabel := "Function"
+			if labels, ok := m["handlerLabels"].([]any); ok {
+				for _, l := range labels {
+					if s, ok := l.(string); ok && s == "Method" {
+						handlerLabel = "Method"
+						break
+					}
+				}
+			}
+			steps = append(steps, FlowStep{
+				NodeKey: handlerKey, Name: handlerName, Label: handlerLabel, Order: 1,
+			})
+
+			// Traverse CALLS edges from handler.
+			callees, err := g.traceCallees(ctx, handlerKey, maxDepth-1, 2)
+			if err != nil {
+				fmt.Printf("Warning: failed to trace callees for %s: %v\n", handlerKey, err)
+			} else {
+				steps = append(steps, callees...)
+			}
+		}
+
+		// Persist the Flow node and HAS_STEP edges.
+		if err := g.persistFlow(ctx, flowNodeKey, flowName, "api", routeKey, maxDepth, steps); err != nil {
+			fmt.Printf("Warning: failed to persist flow %s: %v\n", flowName, err)
+			continue
+		}
+
+		results = append(results, FlowSpineResult{
+			FlowNodeKey: flowNodeKey,
+			FlowName:    flowName,
+			FlowType:    "api",
+			Steps:       steps,
+		})
+	}
+
+	return results, nil
+}
+
+// traceCallees recursively follows CALLS edges from a given function nodeKey.
+func (g *FlowSpineGenerator) traceCallees(ctx context.Context, nodeKey string, remainingDepth, nextOrder int) ([]FlowStep, error) {
+	if remainingDepth <= 0 {
+		return nil, nil
+	}
+
+	cypher := `
+		MATCH (caller {nodeKey: $nodeKey})-[:CALLS]->(callee)
+		WHERE (caller.scopeId = $scopeId OR caller.scopeId = 'main')
+		  AND (callee:Function OR callee:Method)
+		  AND (callee.scopeId = $scopeId OR callee.scopeId = 'main')
+		RETURN callee.nodeKey AS calleeKey, callee.name AS calleeName, labels(callee) AS calleeLabels
+		LIMIT 20`
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, map[string]any{"nodeKey": nodeKey, "scopeId": g.scopeCtx.ScopeID})
+	if err != nil {
+		return nil, err
+	}
+
+	var steps []FlowStep
+	order := nextOrder
+	for _, r := range records {
+		m := r.AsMap()
+		calleeKey := strVal(m, "calleeKey")
+		calleeName := strVal(m, "calleeName")
+		if calleeKey == "" {
+			continue
+		}
+
+		calleeLabel := "Function"
+		if labels, ok := m["calleeLabels"].([]any); ok {
+			for _, l := range labels {
+				if s, ok := l.(string); ok && s == "Method" {
+					calleeLabel = "Method"
+					break
+				}
+			}
+		}
+
+		steps = append(steps, FlowStep{
+			NodeKey: calleeKey, Name: calleeName, Label: calleeLabel, Order: order,
+		})
+		order++
+
+		// Recurse deeper.
+		deeper, err := g.traceCallees(ctx, calleeKey, remainingDepth-1, order)
+		if err != nil {
+			continue
+		}
+		steps = append(steps, deeper...)
+		order += len(deeper)
+	}
+
+	return steps, nil
+}
+
+// persistFlow creates/merges a Flow node and its HAS_STEP relationships.
+func (g *FlowSpineGenerator) persistFlow(ctx context.Context, flowNodeKey, name, flowType, entrypointKey string, maxDepth int, steps []FlowStep) error {
+	flowProps := map[string]any{
+		"name":          name,
+		"entrypointKey": entrypointKey,
+		"flowType":      flowType,
+		"maxDepth":      maxDepth,
+		"nodeKey":       flowNodeKey,
+		"scope":         g.scopeCtx.Scope,
+		"scopeId":       g.scopeCtx.ScopeID,
+	}
+
+	flowID, err := g.client.MergeNode(ctx, []string{"Flow"},
+		map[string]any{"nodeKey": flowNodeKey, "scopeId": g.scopeCtx.ScopeID}, flowProps)
+	if err != nil {
+		return fmt.Errorf("failed to create Flow node: %w", err)
+	}
+
+	// Create HAS_STEP edges to each step's node.
+	for _, step := range steps {
+		cypher := `
+			MATCH (target {nodeKey: $targetKey})
+			WHERE (target:Function OR target:Method OR target:APIRoute OR target:Service)
+			  AND (target.scopeId = $scopeId OR target.scopeId = 'main')
+			WITH target LIMIT 1
+			MATCH (flow:Flow {nodeKey: $flowKey, scopeId: $scopeId})
+			MERGE (flow)-[r:HAS_STEP {order: $order}]->(target)
+			SET r.stepName = $stepName, r.scope = $scope, r.scopeId = $scopeId`
+
+		_, err := g.client.ExecuteQuery(ctx, cypher, map[string]any{
+			"flowKey":   flowNodeKey,
+			"scopeId":   g.scopeCtx.ScopeID,
+			"scope":     g.scopeCtx.Scope,
+			"targetKey": step.NodeKey,
+			"order":     step.Order,
+			"stepName":  step.Name,
+		})
+		if err != nil {
+			fmt.Printf("Warning: failed to create HAS_STEP for step %d (%s): %v\n", step.Order, step.Name, err)
+		}
+	}
+
+	_ = flowID // used by MergeNode
+	return nil
+}
+
+// GetFlow retrieves a flow spine by its nodeKey.
+func (g *FlowSpineGenerator) GetFlow(ctx context.Context, flowNodeKey string) (*FlowSpineResult, error) {
+	cypher := `
+		MATCH (f:Flow {nodeKey: $flowKey})
+		WHERE f.scopeId = $scopeId OR f.scopeId = 'main'
+		OPTIONAL MATCH (f)-[r:HAS_STEP]->(step)
+		WHERE step.scopeId = $scopeId OR step.scopeId = 'main'
+		RETURN f.name AS flowName, f.flowType AS flowType, f.nodeKey AS flowNodeKey,
+		       step.nodeKey AS stepKey, step.name AS stepName, labels(step) AS stepLabels,
+		       r.order AS stepOrder
+		ORDER BY r.order`
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, map[string]any{"flowKey": flowNodeKey, "scopeId": g.scopeCtx.ScopeID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get flow: %w", err)
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("flow not found: %s", flowNodeKey)
+	}
+
+	first := records[0].AsMap()
+	result := &FlowSpineResult{
+		FlowNodeKey: strVal(first, "flowNodeKey"),
+		FlowName:    strVal(first, "flowName"),
+		FlowType:    strVal(first, "flowType"),
+	}
+
+	for _, r := range records {
+		m := r.AsMap()
+		stepKey := strVal(m, "stepKey")
+		if stepKey == "" {
+			continue
+		}
+		order := 0
+		if o, ok := m["stepOrder"].(int64); ok {
+			order = int(o)
+		}
+
+		stepLabel := "Function"
+		if labels, ok := m["stepLabels"].([]any); ok {
+			for _, l := range labels {
+				if s, ok := l.(string); ok {
+					if s == "Method" || s == "APIRoute" || s == "Service" {
+						stepLabel = s
+						break
+					}
+				}
+			}
+		}
+
+		result.Steps = append(result.Steps, FlowStep{
+			NodeKey: stepKey,
+			Name:    strVal(m, "stepName"),
+			Label:   stepLabel,
+			Order:   order,
+		})
+	}
+
+	return result, nil
+}
+
+// ListFlows lists all flow spines, optionally filtered by type.
+func (g *FlowSpineGenerator) ListFlows(ctx context.Context, flowType string) ([]FlowSpineResult, error) {
+	var cypher string
+	params := map[string]any{}
+
+	params["scopeId"] = g.scopeCtx.ScopeID
+	if flowType != "" {
+		cypher = `MATCH (f:Flow {flowType: $flowType})
+			WHERE f.scopeId = $scopeId OR f.scopeId = 'main'
+			RETURN f.nodeKey AS flowNodeKey, f.name AS flowName, f.flowType AS flowType
+			ORDER BY f.name`
+		params["flowType"] = flowType
+	} else {
+		cypher = `MATCH (f:Flow)
+			WHERE f.scopeId = $scopeId OR f.scopeId = 'main'
+			RETURN f.nodeKey AS flowNodeKey, f.name AS flowName, f.flowType AS flowType
+			ORDER BY f.name`
+	}
+
+	records, err := g.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list flows: %w", err)
+	}
+
+	var results []FlowSpineResult
+	for _, r := range records {
+		m := r.AsMap()
+		results = append(results, FlowSpineResult{
+			FlowNodeKey: strVal(m, "flowNodeKey"),
+			FlowName:    strVal(m, "flowName"),
+			FlowType:    strVal(m, "flowType"),
+		})
+	}
+
+	return results, nil
+}

--- a/services/retrieval-go/query/lsp.go
+++ b/services/retrieval-go/query/lsp.go
@@ -1,0 +1,300 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// LSPService provides Language Server Protocol-like functionality
+type LSPService struct {
+	queryBuilder *neo4j.QueryBuilder
+}
+
+// NewLSPService creates a new LSP service
+func NewLSPService(client *neo4j.Client) *LSPService {
+	return &LSPService{
+		queryBuilder: neo4j.NewQueryBuilder(client),
+	}
+}
+
+// GoToDefinitionRequest represents a go-to-definition request
+type GoToDefinitionRequest struct {
+	Symbol   string `json:"symbol"`
+	FilePath string `json:"filePath,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Column   int    `json:"column,omitempty"`
+}
+
+// GoToDefinitionResponse represents the response
+type GoToDefinitionResponse struct {
+	Symbol     *models.SCIPSymbol `json:"symbol"`
+	Definition *models.SymbolInfo `json:"definition"`
+	Found      bool               `json:"found"`
+}
+
+// FindReferencesRequest represents a find-references request  
+type FindReferencesRequest struct {
+	Symbol          string `json:"symbol"`
+	IncludeDeclaration bool `json:"includeDeclaration"`
+}
+
+// FindReferencesResponse represents the response
+type FindReferencesResponse struct {
+	Symbol     *models.SCIPSymbol      `json:"symbol"`
+	References []*models.SymbolReference `json:"references"`
+	Count      int                     `json:"count"`
+}
+
+// FindImplementationsRequest represents a find-implementations request
+type FindImplementationsRequest struct {
+	InterfaceSymbol string `json:"interfaceSymbol"`
+}
+
+// FindImplementationsResponse represents the response
+type FindImplementationsResponse struct {
+	Interface       *models.SCIPSymbol `json:"interface"`
+	Implementations []*models.Class    `json:"implementations"`
+	Count           int                `json:"count"`
+}
+
+// GoToDefinition finds the definition of a symbol
+func (lsp *LSPService) GoToDefinition(ctx context.Context, req GoToDefinitionRequest) (*GoToDefinitionResponse, error) {
+	symbolInfo, err := lsp.queryBuilder.FindSymbolDefinition(ctx, req.Symbol)
+	if err != nil {
+		return &GoToDefinitionResponse{Found: false}, nil
+	}
+
+	return &GoToDefinitionResponse{
+		Symbol:     symbolInfo.Symbol,
+		Definition: symbolInfo,
+		Found:      true,
+	}, nil
+}
+
+// FindReferences finds all references to a symbol
+func (lsp *LSPService) FindReferences(ctx context.Context, req FindReferencesRequest) (*FindReferencesResponse, error) {
+	references, err := lsp.queryBuilder.FindAllReferences(ctx, req.Symbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find references: %w", err)
+	}
+
+	// Parse the symbol
+	scipSymbol, err := models.ParseSCIPSymbol(req.Symbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse symbol: %w", err)
+	}
+
+	// If includeDeclaration is true, add the definition as well
+	if req.IncludeDeclaration {
+		// TODO: Add the definition to the references list
+	}
+
+	return &FindReferencesResponse{
+		Symbol:     scipSymbol,
+		References: references,
+		Count:      len(references),
+	}, nil
+}
+
+// FindImplementations finds all implementations of an interface
+func (lsp *LSPService) FindImplementations(ctx context.Context, req FindImplementationsRequest) (*FindImplementationsResponse, error) {
+	implementations, err := lsp.queryBuilder.FindImplementations(ctx, req.InterfaceSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find implementations: %w", err)
+	}
+
+	scipSymbol, err := models.ParseSCIPSymbol(req.InterfaceSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse interface symbol: %w", err)
+	}
+
+	return &FindImplementationsResponse{
+		Interface:       scipSymbol,
+		Implementations: implementations,
+		Count:           len(implementations),
+	}, nil
+}
+
+// SearchRequest represents a search request
+type SearchRequest struct {
+	Query     string   `json:"query"`
+	NodeTypes []string `json:"nodeTypes,omitempty"`
+	Limit     int      `json:"limit,omitempty"`
+}
+
+// SearchResult represents a search result item
+type SearchResult struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Type        string            `json:"type"`
+	FilePath    string            `json:"filePath,omitempty"`
+	Signature   string            `json:"signature,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Properties  map[string]any    `json:"properties,omitempty"`
+}
+
+// SearchResponse represents the search response
+type SearchResponse struct {
+	Query   string          `json:"query"`
+	Results []*SearchResult `json:"results"`
+	Count   int             `json:"count"`
+	Limit   int             `json:"limit"`
+}
+
+// Search performs a search across code symbols
+func (lsp *LSPService) Search(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
+	limit := req.Limit
+	if limit == 0 {
+		limit = 50
+	}
+
+	nodeTypes := req.NodeTypes
+	if len(nodeTypes) == 0 {
+		nodeTypes = []string{"Function", "Method", "Class", "Interface", "Variable"}
+	}
+
+	records, err := lsp.queryBuilder.SearchNodes(ctx, req.Query, nodeTypes, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search nodes: %w", err)
+	}
+
+	var results []*SearchResult
+	for _, record := range records {
+		recordMap := record.AsMap()
+		
+		if node, ok := recordMap["n"]; ok {
+			if nodeMap, ok := node.(map[string]any); ok {
+				result := &SearchResult{
+					Properties: nodeMap,
+				}
+
+				// Extract common properties
+				if name, ok := nodeMap["name"].(string); ok {
+					result.Name = name
+				}
+				if filePath, ok := nodeMap["filePath"].(string); ok {
+					result.FilePath = filePath
+				}
+				if signature, ok := nodeMap["signature"].(string); ok {
+					result.Signature = signature
+				}
+				if description, ok := nodeMap["description"].(string); ok {
+					result.Description = description
+				}
+
+				// Extract node type from labels
+				if labels, ok := recordMap["nodeLabels"].([]interface{}); ok && len(labels) > 0 {
+					if label, ok := labels[0].(string); ok {
+						result.Type = label
+					}
+				}
+
+				results = append(results, result)
+			}
+		}
+	}
+
+	return &SearchResponse{
+		Query:   req.Query,
+		Results: results,
+		Count:   len(results),
+		Limit:   limit,
+	}, nil
+}
+
+// CompletionRequest represents a code completion request
+type CompletionRequest struct {
+	FilePath string `json:"filePath"`
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+	Prefix   string `json:"prefix"`
+}
+
+// CompletionItem represents a completion item
+type CompletionItem struct {
+	Label         string `json:"label"`
+	Kind          string `json:"kind"`
+	Detail        string `json:"detail,omitempty"`
+	Documentation string `json:"documentation,omitempty"`
+	InsertText    string `json:"insertText,omitempty"`
+}
+
+// CompletionResponse represents the completion response
+type CompletionResponse struct {
+	Items []CompletionItem `json:"items"`
+	Count int              `json:"count"`
+}
+
+// GetCompletion provides code completion suggestions
+func (lsp *LSPService) GetCompletion(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
+	// For now, implement a simple completion based on searching for symbols
+	// that start with the prefix
+	searchReq := SearchRequest{
+		Query:     req.Prefix,
+		NodeTypes: []string{"Function", "Method", "Variable", "Class"},
+		Limit:     20,
+	}
+
+	searchResp, err := lsp.Search(ctx, searchReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get completions: %w", err)
+	}
+
+	var items []CompletionItem
+	for _, result := range searchResp.Results {
+		item := CompletionItem{
+			Label:      result.Name,
+			Kind:       result.Type,
+			Detail:     result.Signature,
+			InsertText: result.Name,
+		}
+
+		// Set documentation if available
+		if docstring, ok := result.Properties["docstring"].(string); ok && docstring != "" {
+			item.Documentation = docstring
+		}
+
+		items = append(items, item)
+	}
+
+	return &CompletionResponse{
+		Items: items,
+		Count: len(items),
+	}, nil
+}
+
+// HoverRequest represents a hover request
+type HoverRequest struct {
+	FilePath string `json:"filePath"`
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+}
+
+// HoverResponse represents hover information
+type HoverResponse struct {
+	Content   string `json:"content"`
+	Range     *Range `json:"range,omitempty"`
+	Found     bool   `json:"found"`
+}
+
+// Range represents a text range
+type Range struct {
+	StartLine   int `json:"startLine"`
+	StartColumn int `json:"startColumn"`
+	EndLine     int `json:"endLine"`
+	EndColumn   int `json:"endColumn"`
+}
+
+// GetHover provides hover information for a symbol at a position
+func (lsp *LSPService) GetHover(ctx context.Context, req HoverRequest) (*HoverResponse, error) {
+	// This is a simplified implementation
+	// In a full implementation, we would need to map file positions to symbols
+	// For now, return a placeholder response
+	return &HoverResponse{
+		Content: "Hover information not yet implemented",
+		Found:   false,
+	}, nil
+}

--- a/services/retrieval-go/query/overlay.go
+++ b/services/retrieval-go/query/overlay.go
@@ -1,0 +1,190 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// OverlayResolver handles overlay-aware queries that merge main + PR scope results
+// with deterministic precedence: overlay nodes win over main nodes for the same nodeKey,
+// and tombstoned main nodes are hidden.
+type OverlayResolver struct {
+	client *neo4j.Client
+}
+
+// NewOverlayResolver creates a new overlay resolver.
+func NewOverlayResolver(client *neo4j.Client) *OverlayResolver {
+	return &OverlayResolver{client: client}
+}
+
+// ResolveNode looks up a node by nodeKey with overlay precedence:
+// 1. If the node exists in the overlay scope, return the overlay version.
+// 2. If the node is tombstoned in the overlay, return nil (hidden).
+// 3. Otherwise return the main scope version.
+func (r *OverlayResolver) ResolveNode(ctx context.Context, nodeKey, scopeID string) (map[string]any, error) {
+	if scopeID == "" || scopeID == "main" {
+		return r.resolveMainOnly(ctx, nodeKey)
+	}
+
+	// Check overlay scope first
+	cypher := `
+		MATCH (n {nodeKey: $nodeKey, scopeId: $scopeId})
+		RETURN n, labels(n) AS nodeLabels
+		LIMIT 1`
+	records, err := r.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"nodeKey": nodeKey,
+		"scopeId": scopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("overlay lookup failed: %w", err)
+	}
+	if len(records) > 0 {
+		return records[0].AsMap(), nil
+	}
+
+	// Check for tombstone
+	tombCypher := `
+		MATCH (t:Tombstone {targetNodeKey: $nodeKey, scopeId: $scopeId})
+		RETURN t LIMIT 1`
+	tombRecords, err := r.client.ExecuteQuery(ctx, tombCypher, map[string]any{
+		"nodeKey": nodeKey,
+		"scopeId": scopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("tombstone check failed: %w", err)
+	}
+	if len(tombRecords) > 0 {
+		return nil, nil // Node is tombstoned — hidden
+	}
+
+	// Fall through to main scope
+	return r.resolveMainOnly(ctx, nodeKey)
+}
+
+func (r *OverlayResolver) resolveMainOnly(ctx context.Context, nodeKey string) (map[string]any, error) {
+	cypher := `
+		MATCH (n {nodeKey: $nodeKey})
+		WHERE n.scopeId = 'main' OR n.scopeId IS NULL
+		RETURN n, labels(n) AS nodeLabels
+		LIMIT 1`
+	records, err := r.client.ExecuteQuery(ctx, cypher, map[string]any{"nodeKey": nodeKey})
+	if err != nil {
+		return nil, fmt.Errorf("main scope lookup failed: %w", err)
+	}
+	if len(records) > 0 {
+		return records[0].AsMap(), nil
+	}
+	return nil, nil
+}
+
+// ResolveSymbol looks up a symbol by its SCIP string with overlay precedence.
+func (r *OverlayResolver) ResolveSymbol(ctx context.Context, symbol, scopeID string) (map[string]any, error) {
+	if scopeID == "" || scopeID == "main" {
+		return r.resolveSymbolMain(ctx, symbol)
+	}
+
+	// Overlay first
+	cypher := `
+		MATCH (s:Symbol {symbol: $symbol, scopeId: $scopeId})
+		RETURN s, labels(s) AS nodeLabels
+		LIMIT 1`
+	records, err := r.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"symbol":  symbol,
+		"scopeId": scopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("overlay symbol lookup failed: %w", err)
+	}
+	if len(records) > 0 {
+		return records[0].AsMap(), nil
+	}
+
+	// Check tombstone
+	tombCypher := `
+		MATCH (t:Tombstone {targetNodeKey: $symbol, scopeId: $scopeId})
+		RETURN t LIMIT 1`
+	tombRecords, err := r.client.ExecuteQuery(ctx, tombCypher, map[string]any{
+		"symbol":  symbol,
+		"scopeId": scopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("tombstone check failed: %w", err)
+	}
+	if len(tombRecords) > 0 {
+		return nil, nil
+	}
+
+	return r.resolveSymbolMain(ctx, symbol)
+}
+
+func (r *OverlayResolver) resolveSymbolMain(ctx context.Context, symbol string) (map[string]any, error) {
+	cypher := `
+		MATCH (s:Symbol {symbol: $symbol})
+		WHERE s.scopeId = 'main' OR s.scopeId IS NULL
+		RETURN s, labels(s) AS nodeLabels
+		LIMIT 1`
+	records, err := r.client.ExecuteQuery(ctx, cypher, map[string]any{"symbol": symbol})
+	if err != nil {
+		return nil, fmt.Errorf("main symbol lookup failed: %w", err)
+	}
+	if len(records) > 0 {
+		return records[0].AsMap(), nil
+	}
+	return nil, nil
+}
+
+// ResolveFlow looks up a flow with overlay precedence.
+func (r *OverlayResolver) ResolveFlow(ctx context.Context, flowNodeKey, scopeID string) (map[string]any, error) {
+	if scopeID == "" || scopeID == "main" {
+		return r.resolveFlowMain(ctx, flowNodeKey)
+	}
+
+	cypher := `
+		MATCH (f:Flow {nodeKey: $flowKey, scopeId: $scopeId})
+		RETURN f, labels(f) AS nodeLabels
+		LIMIT 1`
+	records, err := r.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"flowKey": flowNodeKey,
+		"scopeId": scopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("overlay flow lookup failed: %w", err)
+	}
+	if len(records) > 0 {
+		return records[0].AsMap(), nil
+	}
+
+	tombCypher := `
+		MATCH (t:Tombstone {targetNodeKey: $flowKey, scopeId: $scopeId})
+		RETURN t LIMIT 1`
+	tombRecords, err := r.client.ExecuteQuery(ctx, tombCypher, map[string]any{
+		"flowKey": flowNodeKey,
+		"scopeId": scopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("tombstone check failed: %w", err)
+	}
+	if len(tombRecords) > 0 {
+		return nil, nil
+	}
+
+	return r.resolveFlowMain(ctx, flowNodeKey)
+}
+
+func (r *OverlayResolver) resolveFlowMain(ctx context.Context, flowNodeKey string) (map[string]any, error) {
+	cypher := `
+		MATCH (f:Flow {nodeKey: $flowKey})
+		WHERE f.scopeId = 'main' OR f.scopeId IS NULL
+		RETURN f, labels(f) AS nodeLabels
+		LIMIT 1`
+	records, err := r.client.ExecuteQuery(ctx, cypher, map[string]any{"flowKey": flowNodeKey})
+	if err != nil {
+		return nil, fmt.Errorf("main flow lookup failed: %w", err)
+	}
+	if len(records) > 0 {
+		return records[0].AsMap(), nil
+	}
+	return nil, nil
+}

--- a/services/retrieval-go/query/service_deps.go
+++ b/services/retrieval-go/query/service_deps.go
@@ -1,0 +1,150 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// InterServiceEdge represents a dependency between two services.
+type InterServiceEdge struct {
+	FromService string   `json:"fromService"`
+	ToService   string   `json:"toService"`
+	RelType     string   `json:"relType"` // CALLS_SERVICE, PUBLISHES_TO, etc.
+	Confidence  float64  `json:"confidence"`
+	Source      string   `json:"source"` // How this was detected.
+	Evidence    []string `json:"evidence,omitempty"`
+}
+
+// ServiceDepsQuery queries and manages inter-service dependencies.
+type ServiceDepsQuery struct {
+	client *neo4j.Client
+}
+
+// NewServiceDepsQuery creates a new service dependency query handler.
+func NewServiceDepsQuery(client *neo4j.Client) *ServiceDepsQuery {
+	return &ServiceDepsQuery{client: client}
+}
+
+// GetDependencies returns all service-level dependencies for a given service.
+// If scopeID is non-empty, includes overlay-scoped edges.
+func (q *ServiceDepsQuery) GetDependencies(ctx context.Context, serviceName, scopeID string) ([]InterServiceEdge, error) {
+	scopeFilter := ""
+	params := map[string]any{"name": serviceName}
+
+	if scopeID != "" {
+		scopeFilter = " AND (r.scopeId = $scopeId OR r.scopeId = 'main')"
+		params["scopeId"] = scopeID
+	}
+
+	cypher := fmt.Sprintf(`
+		MATCH (s:Service {name: $name})-[r:CALLS_SERVICE]->(t:Service)
+		WHERE 1=1%s
+		RETURN s.name AS from, t.name AS to, type(r) AS relType,
+		       r.confidence AS confidence, r.source AS source, r.evidence AS evidence
+		UNION ALL
+		MATCH (s:Service)-[r:CALLS_SERVICE]->(t:Service {name: $name})
+		WHERE 1=1%s
+		RETURN s.name AS from, t.name AS to, type(r) AS relType,
+		       r.confidence AS confidence, r.source AS source, r.evidence AS evidence
+	`, scopeFilter, scopeFilter)
+
+	records, err := q.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query service deps: %w", err)
+	}
+
+	var deps []InterServiceEdge
+	for _, r := range records {
+		m := r.AsMap()
+		dep := InterServiceEdge{
+			FromService: strVal(m, "from"),
+			ToService:   strVal(m, "to"),
+			RelType:     strVal(m, "relType"),
+			Source:      strVal(m, "source"),
+		}
+		if conf, ok := m["confidence"].(float64); ok {
+			dep.Confidence = conf
+		}
+		if ev, ok := m["evidence"].([]any); ok {
+			for _, e := range ev {
+				if s, ok := e.(string); ok {
+					dep.Evidence = append(dep.Evidence, s)
+				}
+			}
+		}
+		deps = append(deps, dep)
+	}
+	return deps, nil
+}
+
+// CreateServiceEdge creates a CALLS_SERVICE relationship between two services.
+func (q *ServiceDepsQuery) CreateServiceEdge(ctx context.Context, from, to string, confidence float64, source string, evidence []string, scopeID string) error {
+	if scopeID == "" {
+		scopeID = "main"
+	}
+
+	cypher := `
+		MATCH (s:Service {name: $from})
+		MATCH (t:Service {name: $to})
+		MERGE (s)-[r:CALLS_SERVICE {scopeId: $scopeId}]->(t)
+		SET r.confidence = $confidence,
+		    r.source = $source,
+		    r.evidence = $evidence,
+		    r.scope = CASE WHEN $scopeId = 'main' THEN 'main' ELSE 'pr' END,
+		    r.scopeId = $scopeId`
+
+	params := map[string]any{
+		"from":       from,
+		"to":         to,
+		"confidence": confidence,
+		"source":     source,
+		"evidence":   evidence,
+		"scopeId":    scopeID,
+	}
+
+	_, err := q.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return fmt.Errorf("failed to create CALLS_SERVICE edge: %w", err)
+	}
+	return nil
+}
+
+// InferServiceDependencies analyzes SDKCall nodes (created by the symbol analyzer
+// via CALLS_API relationships) to infer CALLS_SERVICE edges between services.
+func (q *ServiceDepsQuery) InferServiceDependencies(ctx context.Context, scopeID string) (int, error) {
+	if scopeID == "" {
+		scopeID = "main"
+	}
+
+	cypher := `
+		MATCH (caller:Service)-[:CONTAINS*]->(f:File)-[:CONTAINS]->(fn)-[:CALLS_API]->(call:SDKCall)
+		WHERE call.url IS NOT NULL
+		  AND (call.scopeId = $scopeId OR call.scopeId = 'main')
+		WITH caller, call
+		MATCH (target:Service)-[:CONTAINS*]->(targetFile:File)
+		WHERE call.url CONTAINS target.name AND caller.name <> target.name
+		WITH DISTINCT caller, target, collect(call.url) AS urls
+		MERGE (caller)-[r:CALLS_SERVICE {scopeId: $scopeId}]->(target)
+		SET r.confidence = 0.7,
+		    r.source = 'sdk_call_inference',
+		    r.evidence = urls,
+		    r.scope = CASE WHEN $scopeId = 'main' THEN 'main' ELSE 'pr' END,
+		    r.scopeId = $scopeId
+		RETURN caller.name AS from, target.name AS to, size(urls) AS evidenceCount`
+
+	records, err := q.client.ExecuteQuery(ctx, cypher, map[string]any{"scopeId": scopeID})
+	if err != nil {
+		return 0, fmt.Errorf("failed to infer service deps: %w", err)
+	}
+
+	return len(records), nil
+}
+
+func strVal(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/services/retrieval-go/search/chunk_linker.go
+++ b/services/retrieval-go/search/chunk_linker.go
@@ -1,0 +1,291 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// ChunkLinker creates MENTIONS relationships between DocumentChunk nodes and code nodes.
+// Each MENTIONS edge carries provenance: confidence, reasons, model, createdAt.
+type ChunkLinker struct {
+	client  *neo4j.Client
+	scopeID string // Scope filter for target node lookup
+}
+
+// NewChunkLinker creates a new chunk-level linker.
+func NewChunkLinker(client *neo4j.Client) *ChunkLinker {
+	return &ChunkLinker{client: client, scopeID: "main"}
+}
+
+// SetScope sets the scope ID used for target node lookups.
+// This ensures chunk linking only finds code nodes visible in the given scope.
+func (cl *ChunkLinker) SetScope(scopeID string) {
+	if scopeID == "" {
+		scopeID = "main"
+	}
+	cl.scopeID = scopeID
+}
+
+// ChunkMentionEdge represents a MENTIONS relationship from a DocumentChunk to a code node.
+type ChunkMentionEdge struct {
+	ChunkNodeKey  string   // Source DocumentChunk nodeKey.
+	TargetNodeKey string   // Target code node nodeKey.
+	TargetLabel   string   // Target node's Neo4j label.
+	Confidence    float64  // 0.0 to 1.0.
+	Reasons       []string // Why this link was created.
+	Model         string   // Linking model/method used.
+}
+
+// LinkChunksForDocument finds all DocumentChunk nodes for a given document and
+// creates MENTIONS relationships to code symbols found in each chunk's content.
+func (cl *ChunkLinker) LinkChunksForDocument(ctx context.Context, docNodeKey, scopeID string) (int, error) {
+	// Fetch all chunks for this document.
+	chunks, err := cl.loadDocumentChunks(ctx, docNodeKey, scopeID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load chunks: %w", err)
+	}
+
+	totalLinks := 0
+	for _, chunk := range chunks {
+		edges := cl.analyzeChunkForMentions(ctx, chunk)
+		for _, edge := range edges {
+			if err := cl.createMentionEdge(ctx, edge, scopeID); err != nil {
+				log.Printf("Warning: failed to create mention edge from %s to %s: %v",
+					edge.ChunkNodeKey, edge.TargetNodeKey, err)
+				continue
+			}
+			totalLinks++
+		}
+	}
+
+	return totalLinks, nil
+}
+
+// chunkData holds data for a single chunk loaded from Neo4j.
+type chunkData struct {
+	NodeKey     string
+	Content     string
+	HeadingPath string
+	ElementID   string
+}
+
+func (cl *ChunkLinker) loadDocumentChunks(ctx context.Context, docNodeKey, scopeID string) ([]chunkData, error) {
+	cypher := `MATCH (c:DocumentChunk {documentKey: $docKey, scopeId: $scopeId})
+RETURN c.nodeKey AS nodeKey, c.content AS content, c.headingPath AS headingPath, elementId(c) AS eid`
+	params := map[string]any{
+		"docKey":  docNodeKey,
+		"scopeId": scopeID,
+	}
+	records, err := cl.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var chunks []chunkData
+	for _, r := range records {
+		m := r.AsMap()
+		chunks = append(chunks, chunkData{
+			NodeKey:     strVal(m, "nodeKey"),
+			Content:     strVal(m, "content"),
+			HeadingPath: strVal(m, "headingPath"),
+			ElementID:   strVal(m, "eid"),
+		})
+	}
+	return chunks, nil
+}
+
+// analyzeChunkForMentions extracts code references from a chunk's content
+// and tries to match them to code nodes in the graph.
+func (cl *ChunkLinker) analyzeChunkForMentions(ctx context.Context, chunk chunkData) []ChunkMentionEdge {
+	var edges []ChunkMentionEdge
+
+	// Extract backtick code references.
+	codeRefs := extractBacktickRefs(chunk.Content)
+	for _, ref := range codeRefs {
+		matches := cl.findCodeNodesByName(ctx, ref)
+		for _, match := range matches {
+			edges = append(edges, ChunkMentionEdge{
+				ChunkNodeKey:  chunk.NodeKey,
+				TargetNodeKey: match.nodeKey,
+				TargetLabel:   match.label,
+				Confidence:    0.8,
+				Reasons:       []string{"backtick_reference", fmt.Sprintf("mentioned as `%s`", ref)},
+				Model:         "backtick_extraction",
+			})
+		}
+	}
+
+	// Extract heading-based context references.
+	headingRefs := extractHeadingRefs(chunk.HeadingPath)
+	for _, ref := range headingRefs {
+		matches := cl.findCodeNodesByName(ctx, ref)
+		for _, match := range matches {
+			edges = append(edges, ChunkMentionEdge{
+				ChunkNodeKey:  chunk.NodeKey,
+				TargetNodeKey: match.nodeKey,
+				TargetLabel:   match.label,
+				Confidence:    0.6,
+				Reasons:       []string{"heading_reference", fmt.Sprintf("heading contains '%s'", ref)},
+				Model:         "heading_extraction",
+			})
+		}
+	}
+
+	// Deduplicate: keep highest-confidence edge per target.
+	return deduplicateEdges(edges)
+}
+
+type codeNodeMatch struct {
+	nodeKey string
+	label   string
+}
+
+func (cl *ChunkLinker) findCodeNodesByName(ctx context.Context, name string) []codeNodeMatch {
+	cypher := `
+		MATCH (n)
+		WHERE (n:Function OR n:Method OR n:Class OR n:Interface OR n:Symbol)
+		AND (n.name = $name OR n.displayName = $name OR n.signature CONTAINS $name)
+		AND (n.scopeId = $scopeId OR n.scopeId = 'main')
+		RETURN n.nodeKey AS nodeKey, labels(n)[0] AS label
+		LIMIT 3`
+	params := map[string]any{"name": name, "scopeId": cl.scopeID}
+
+	records, err := cl.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil
+	}
+
+	var matches []codeNodeMatch
+	for _, r := range records {
+		m := r.AsMap()
+		nk := strVal(m, "nodeKey")
+		label := strVal(m, "label")
+		if nk != "" {
+			matches = append(matches, codeNodeMatch{nodeKey: nk, label: label})
+		}
+	}
+	return matches
+}
+
+func (cl *ChunkLinker) createMentionEdge(ctx context.Context, edge ChunkMentionEdge, scopeID string) error {
+	cypher := `
+		MATCH (chunk:DocumentChunk {nodeKey: $chunkKey, scopeId: $scopeId})
+		MATCH (target {nodeKey: $targetKey})
+		WHERE target.scopeId = $scopeId OR target.scopeId = 'main'
+		WITH chunk, target LIMIT 1
+		MERGE (chunk)-[r:MENTIONS]->(target)
+		SET r.confidence = $confidence,
+		    r.reasons = $reasons,
+		    r.model = $model,
+		    r.createdAt = $createdAt,
+		    r.scopeId = $scopeId`
+	params := map[string]any{
+		"chunkKey":   edge.ChunkNodeKey,
+		"targetKey":  edge.TargetNodeKey,
+		"scopeId":    scopeID,
+		"confidence": edge.Confidence,
+		"reasons":    edge.Reasons,
+		"model":      edge.Model,
+		"createdAt":  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	_, err := cl.client.ExecuteQuery(ctx, cypher, params)
+	return err
+}
+
+// extractBacktickRefs extracts code references from backtick expressions.
+func extractBacktickRefs(content string) []string {
+	pattern := regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*(?:\\(\\))?)`")
+	matches := pattern.FindAllStringSubmatch(content, -1)
+
+	seen := make(map[string]bool)
+	var refs []string
+	for _, m := range matches {
+		if len(m) > 1 {
+			ref := m[1]
+			if !seen[ref] && isCodeLikeReference(ref) {
+				seen[ref] = true
+				refs = append(refs, ref)
+			}
+		}
+	}
+	return refs
+}
+
+// extractHeadingRefs extracts potential code references from a heading path.
+func extractHeadingRefs(headingPath string) []string {
+	if headingPath == "" {
+		return nil
+	}
+
+	// Look for CamelCase or PascalCase words in headings.
+	pattern := regexp.MustCompile(`([A-Z][a-z]+(?:[A-Z][a-z]+)+)`)
+	matches := pattern.FindAllString(headingPath, -1)
+
+	seen := make(map[string]bool)
+	var refs []string
+	for _, m := range matches {
+		if !seen[m] {
+			seen[m] = true
+			refs = append(refs, m)
+		}
+	}
+	return refs
+}
+
+// isCodeLikeReference checks if a backtick reference looks like code.
+func isCodeLikeReference(ref string) bool {
+	if len(ref) < 2 {
+		return false
+	}
+	// Must contain uppercase, underscore, or dot.
+	return regexp.MustCompile(`[A-Z_.]`).MatchString(ref)
+}
+
+// deduplicateEdges keeps the highest-confidence edge per target.
+func deduplicateEdges(edges []ChunkMentionEdge) []ChunkMentionEdge {
+	best := make(map[string]ChunkMentionEdge)
+	for _, e := range edges {
+		key := e.ChunkNodeKey + "→" + e.TargetNodeKey
+		if existing, ok := best[key]; !ok || e.Confidence > existing.Confidence {
+			// Merge reasons.
+			if ok {
+				e.Reasons = append(existing.Reasons, e.Reasons...)
+			}
+			best[key] = e
+		}
+	}
+
+	result := make([]ChunkMentionEdge, 0, len(best))
+	for _, e := range best {
+		result = append(result, e)
+	}
+	return result
+}
+
+func strVal(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// removeDuplicateStringsSearch deduplicates a string slice.
+func removeDuplicateStringsSearch(slice []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, s := range slice {
+		lower := strings.ToLower(s)
+		if !seen[lower] {
+			seen[lower] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/services/retrieval-go/search/code_summarizer.go
+++ b/services/retrieval-go/search/code_summarizer.go
@@ -1,0 +1,364 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// CodeSubgraph represents a connected set of functions that implement business logic
+type CodeSubgraph struct {
+	EntryPoint   FunctionNode   `json:"entryPoint"`
+	Functions    []FunctionNode `json:"functions"`
+	CallDepth    int            `json:"callDepth"`
+	TotalLines   int            `json:"totalLines"`
+	Summary      string         `json:"summary"`      // LLM-generated summary
+	Embedding    []float64      `json:"embedding"`    // Embedding of the summary
+	Confidence   float64        `json:"confidence"`   // Confidence in the summary
+}
+
+// FunctionNode represents a function in the subgraph
+type FunctionNode struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Signature   string `json:"signature"`
+	SourceCode  string `json:"sourceCode"`
+	FilePath    string `json:"filePath"`
+	StartLine   int    `json:"startLine"`
+	EndLine     int    `json:"endLine"`
+	DocString   string `json:"docString"`
+}
+
+// CodeSubgraphSummarizer extracts and summarizes code subgraphs using LLM
+type CodeSubgraphSummarizer struct {
+	client           *neo4j.Client
+	embeddingService EmbeddingService
+	llmService       LLMService
+	maxDepth         int
+	maxFunctions     int
+}
+
+// NewCodeSubgraphSummarizer creates a new code subgraph summarizer
+func NewCodeSubgraphSummarizer(client *neo4j.Client, embeddingService EmbeddingService) *CodeSubgraphSummarizer {
+	return &CodeSubgraphSummarizer{
+		client:           client,
+		embeddingService: embeddingService,
+		llmService:       nil, // Optional LLM service for text generation
+		maxDepth:         3,   // Maximum call depth to traverse
+		maxFunctions:     15,  // Maximum functions to include in subgraph
+	}
+}
+
+// WithLLMService sets the LLM service for text generation
+func (css *CodeSubgraphSummarizer) WithLLMService(llmService LLMService) *CodeSubgraphSummarizer {
+	css.llmService = llmService
+	return css
+}
+
+// ExtractAndSummarizeSubgraph extracts a code subgraph starting from an entry point and generates an LLM summary
+func (css *CodeSubgraphSummarizer) ExtractAndSummarizeSubgraph(ctx context.Context, entryPointID string) (*CodeSubgraph, error) {
+	log.Printf("Extracting subgraph from entry point: %s", entryPointID)
+
+	// Step 1: Extract the subgraph using graph traversal
+	subgraph, err := css.extractSubgraph(ctx, entryPointID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract subgraph: %w", err)
+	}
+
+	if len(subgraph.Functions) == 0 {
+		return nil, fmt.Errorf("no functions found in subgraph")
+	}
+
+	log.Printf("Extracted subgraph with %d functions", len(subgraph.Functions))
+
+	// Step 2: Generate LLM summary of the code logic
+	summary, confidence, err := css.generateCodeSummary(ctx, subgraph)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate code summary: %w", err)
+	}
+
+	subgraph.Summary = summary
+	subgraph.Confidence = confidence
+
+	// Step 3: Generate embedding from the summary (skip if pre-computed embedding exists)
+	if subgraph.Embedding == nil || len(subgraph.Embedding) == 0 {
+		embedding, err := css.embeddingService.GenerateEmbedding(ctx, summary)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate embedding: %w", err)
+		}
+
+		subgraph.Embedding = embedding
+		log.Printf("Generated summary (%d chars) and embedding (%d dims) for subgraph", len(summary), len(embedding))
+	} else {
+		log.Printf("Using pre-computed embedding (%d dims) for subgraph with summary (%d chars)",
+			len(subgraph.Embedding), len(summary))
+	}
+
+	return subgraph, nil
+}
+
+// extractSubgraph traverses the call graph to extract a connected subgraph
+func (css *CodeSubgraphSummarizer) extractSubgraph(ctx context.Context, entryPointID string) (*CodeSubgraph, error) {
+	// Query to get entry point function details including pre-computed embedding
+	entryPointCypher := `
+		MATCH (f:Function {id: $functionId})
+		RETURN f.id AS id, f.name AS name, f.signature AS signature,
+			   f.sourceCode AS sourceCode, f.filePath AS filePath,
+			   f.startLine AS startLine, f.endLine AS endLine,
+			   f.docstring AS docstring, f.embedding AS embedding
+	`
+
+	results, err := css.client.ExecuteQuery(ctx, entryPointCypher, map[string]any{
+		"functionId": entryPointID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get entry point function: %w", err)
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("entry point function not found: %s", entryPointID)
+	}
+
+	// Create entry point function node
+	entryRecord := results[0].AsMap()
+	entryPoint := FunctionNode{
+		ID:         entryRecord["id"].(string),
+		Name:       getStringValue(entryRecord, "name"),
+		Signature:  getStringValue(entryRecord, "signature"),
+		SourceCode: getStringValue(entryRecord, "sourceCode"),
+		FilePath:   getStringValue(entryRecord, "filePath"),
+		StartLine:  getIntValue(entryRecord, "startLine"),
+		EndLine:    getIntValue(entryRecord, "endLine"),
+		DocString:  getStringValue(entryRecord, "docstring"),
+	}
+
+	// Check if pre-computed embedding exists
+	var precomputedEmbedding []float64
+	if embeddingVal, ok := entryRecord["embedding"]; ok && embeddingVal != nil {
+		// Neo4j returns embeddings as []interface{}, need to convert to []float64
+		if embeddingSlice, ok := embeddingVal.([]interface{}); ok {
+			precomputedEmbedding = make([]float64, len(embeddingSlice))
+			for i, val := range embeddingSlice {
+				if floatVal, ok := val.(float64); ok {
+					precomputedEmbedding[i] = floatVal
+				}
+			}
+			log.Printf("Found pre-computed embedding (%d dims) for function %s", len(precomputedEmbedding), entryPoint.Name)
+		}
+	}
+
+	// Query to get connected functions via CALLS and FLOWS_TO relationships
+	subgraphCypher := fmt.Sprintf(`
+		MATCH (entry:Function {id: $entryId})
+		MATCH path = (entry)-[:CALLS|FLOWS_TO*1..%d]->(connected:Function)
+		WHERE connected.id <> $entryId
+		WITH connected, min(length(path)) as depth
+		RETURN DISTINCT connected.id AS id, connected.name AS name,
+			   connected.signature AS signature, connected.sourceCode AS sourceCode,
+			   connected.filePath AS filePath, connected.startLine AS startLine,
+			   connected.endLine AS endLine, connected.docstring AS docstring,
+			   depth
+		ORDER BY depth, connected.name
+		LIMIT %d
+	`, css.maxDepth, css.maxFunctions)
+
+	subgraphResults, err := css.client.ExecuteQuery(ctx, subgraphCypher, map[string]any{
+		"entryId": entryPointID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subgraph functions: %w", err)
+	}
+
+	// Create function nodes for the subgraph
+	var functions []FunctionNode
+	functions = append(functions, entryPoint) // Add entry point first
+
+	maxDepth := 0
+	totalLines := entryPoint.EndLine - entryPoint.StartLine + 1
+
+	for _, record := range subgraphResults {
+		recordMap := record.AsMap()
+		depth := getIntValue(recordMap, "depth")
+		if depth > maxDepth {
+			maxDepth = depth
+		}
+
+		functionNode := FunctionNode{
+			ID:         recordMap["id"].(string),
+			Name:       getStringValue(recordMap, "name"),
+			Signature:  getStringValue(recordMap, "signature"),
+			SourceCode: getStringValue(recordMap, "sourceCode"),
+			FilePath:   getStringValue(recordMap, "filePath"),
+			StartLine:  getIntValue(recordMap, "startLine"),
+			EndLine:    getIntValue(recordMap, "endLine"),
+			DocString:  getStringValue(recordMap, "docstring"),
+		}
+
+		totalLines += functionNode.EndLine - functionNode.StartLine + 1
+		functions = append(functions, functionNode)
+	}
+
+	subgraph := &CodeSubgraph{
+		EntryPoint:   entryPoint,
+		Functions:    functions,
+		CallDepth:    maxDepth,
+		TotalLines:   totalLines,
+	}
+
+	// If we found a pre-computed embedding, include it in the subgraph
+	if precomputedEmbedding != nil && len(precomputedEmbedding) > 0 {
+		subgraph.Embedding = precomputedEmbedding
+	}
+
+	return subgraph, nil
+}
+
+// generateCodeSummary uses LLM to create a natural language summary of the code subgraph
+func (css *CodeSubgraphSummarizer) generateCodeSummary(ctx context.Context, subgraph *CodeSubgraph) (string, float64, error) {
+	// Construct a prompt for the LLM
+	prompt := css.buildSummaryPrompt(subgraph)
+
+	// Try to use LLM service if available
+	if css.llmService != nil {
+		log.Println("Using LLM service for code summarization")
+		summary, err := css.llmService.GenerateText(ctx, prompt)
+		if err != nil {
+			log.Printf("Warning: LLM summarization failed, falling back to heuristic: %v", err)
+			return css.generateFallbackSummary(subgraph), 0.6, nil
+		}
+
+		// Clean up the summary
+		summary = strings.TrimSpace(summary)
+
+		// Higher confidence for LLM-generated summaries
+		confidence := 0.9
+
+		log.Printf("Generated LLM code summary: %s (confidence: %.2f)", summary, confidence)
+		return summary, confidence, nil
+	}
+
+	// Fallback: Use heuristic-based summary generation
+	log.Println("No LLM service available, using heuristic summarization")
+	summary := css.generateFallbackSummary(subgraph)
+	confidence := 0.7
+
+	// Enhance summary based on function patterns
+	if css.containsPattern(subgraph, []string{"validate", "check", "verify"}) {
+		summary = "This code implements validation and verification logic. " + summary
+	}
+	if css.containsPattern(subgraph, []string{"create", "generate", "build"}) {
+		summary = "This code implements creation and generation logic. " + summary
+	}
+	if css.containsPattern(subgraph, []string{"auth", "login", "token"}) {
+		summary = "This code implements authentication and authorization logic. " + summary
+	}
+
+	log.Printf("Generated heuristic code summary: %s (confidence: %.2f)", summary, confidence)
+	return summary, confidence, nil
+}
+
+// buildSummaryPrompt constructs the prompt for LLM code summarization
+func (css *CodeSubgraphSummarizer) buildSummaryPrompt(subgraph *CodeSubgraph) string {
+	var promptBuilder strings.Builder
+
+	promptBuilder.WriteString("Analyze the following code subgraph and provide a concise, natural language summary ")
+	promptBuilder.WriteString("that describes the PURPOSE and BEHAVIOR of this code logic. ")
+	promptBuilder.WriteString("Focus on WHAT the code accomplishes from a business/functional perspective, not HOW it's implemented.\n\n")
+
+	promptBuilder.WriteString(fmt.Sprintf("ENTRY POINT: %s\n", subgraph.EntryPoint.Name))
+	if subgraph.EntryPoint.DocString != "" {
+		promptBuilder.WriteString(fmt.Sprintf("Documentation: %s\n", subgraph.EntryPoint.DocString))
+	}
+	promptBuilder.WriteString("\n")
+
+	// Add function signatures and documentation
+	promptBuilder.WriteString("FUNCTIONS IN SUBGRAPH:\n")
+	for i, function := range subgraph.Functions {
+		if i >= 10 { // Limit to first 10 functions for prompt efficiency
+			promptBuilder.WriteString(fmt.Sprintf("... and %d more functions\n", len(subgraph.Functions)-i))
+			break
+		}
+
+		promptBuilder.WriteString(fmt.Sprintf("%d. %s\n", i+1, function.Signature))
+		if function.DocString != "" {
+			promptBuilder.WriteString(fmt.Sprintf("   Doc: %s\n", function.DocString))
+		}
+
+		// Include limited source code for context (first few lines)
+		if function.SourceCode != "" {
+			lines := strings.Split(function.SourceCode, "\n")
+			maxLines := 5
+			if len(lines) > maxLines {
+				promptBuilder.WriteString(fmt.Sprintf("   Code preview:\n   %s\n   ... (%d more lines)\n",
+					strings.Join(lines[:maxLines], "\n   "), len(lines)-maxLines))
+			} else {
+				promptBuilder.WriteString(fmt.Sprintf("   Code:\n   %s\n", strings.Join(lines, "\n   ")))
+			}
+		}
+		promptBuilder.WriteString("\n")
+	}
+
+	promptBuilder.WriteString("\nProvide a 2-3 sentence summary that captures the core business logic and purpose of this code subgraph. ")
+	promptBuilder.WriteString("Focus on the high-level business value, not implementation details.")
+
+	return promptBuilder.String()
+}
+
+// generateFallbackSummary creates a basic summary when LLM is unavailable
+func (css *CodeSubgraphSummarizer) generateFallbackSummary(subgraph *CodeSubgraph) string {
+	var summary strings.Builder
+
+	summary.WriteString(fmt.Sprintf("Code subgraph starting from %s", subgraph.EntryPoint.Name))
+
+	if len(subgraph.Functions) > 1 {
+		summary.WriteString(fmt.Sprintf(" involving %d connected functions", len(subgraph.Functions)))
+	}
+
+	// Add function name patterns
+	var functionNames []string
+	for _, fn := range subgraph.Functions {
+		if len(functionNames) < 5 { // Limit for readability
+			functionNames = append(functionNames, fn.Name)
+		}
+	}
+
+	if len(functionNames) > 0 {
+		summary.WriteString(fmt.Sprintf(": %s", strings.Join(functionNames, ", ")))
+		if len(subgraph.Functions) > len(functionNames) {
+			summary.WriteString(fmt.Sprintf(" and %d others", len(subgraph.Functions)-len(functionNames)))
+		}
+	}
+
+	summary.WriteString(".")
+
+	return summary.String()
+}
+
+// containsPattern checks if the subgraph contains functions matching certain patterns
+func (css *CodeSubgraphSummarizer) containsPattern(subgraph *CodeSubgraph, patterns []string) bool {
+	for _, function := range subgraph.Functions {
+		functionNameLower := strings.ToLower(function.Name)
+		for _, pattern := range patterns {
+			if strings.Contains(functionNameLower, pattern) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Helper functions for type conversion
+func getIntValue(m map[string]any, key string) int {
+	if val, ok := m[key]; ok {
+		if i64, ok := val.(int64); ok {
+			return int(i64)
+		}
+		if i, ok := val.(int); ok {
+			return i
+		}
+	}
+	return 0
+}

--- a/services/retrieval-go/search/comment_embedding_service.go
+++ b/services/retrieval-go/search/comment_embedding_service.go
@@ -1,0 +1,326 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// CommentEmbeddingService handles embedding generation specifically for docstrings and comments
+type CommentEmbeddingService struct {
+	client           *neo4j.Client
+	embeddingService EmbeddingService
+}
+
+// NewCommentEmbeddingService creates a new comment-focused embedding service
+func NewCommentEmbeddingService(client *neo4j.Client, embeddingService EmbeddingService) *CommentEmbeddingService {
+	return &CommentEmbeddingService{
+		client:           client,
+		embeddingService: embeddingService,
+	}
+}
+
+// CommentEmbeddingUpdate represents a comment embedding update
+type CommentEmbeddingUpdate struct {
+	CommentId     string
+	Text          string
+	ParentNodeId  string
+	ParentType    string  // Function, Method, Class, etc.
+	ParentName    string
+	Embedding     []float64
+}
+
+// ExtractAndEmbedDocstrings extracts docstrings from functions/classes and creates comment embeddings
+func (ces *CommentEmbeddingService) ExtractAndEmbedDocstrings(ctx context.Context, batchSize int, dryRun bool) error {
+	// Extract docstrings from Functions
+	if err := ces.extractDocstringsForNodeType(ctx, "Function", batchSize, dryRun); err != nil {
+		return fmt.Errorf("failed to extract function docstrings: %w", err)
+	}
+
+	// Extract docstrings from Methods
+	if err := ces.extractDocstringsForNodeType(ctx, "Method", batchSize, dryRun); err != nil {
+		return fmt.Errorf("failed to extract method docstrings: %w", err)
+	}
+
+	// Extract docstrings from Classes
+	if err := ces.extractDocstringsForNodeType(ctx, "Class", batchSize, dryRun); err != nil {
+		return fmt.Errorf("failed to extract class docstrings: %w", err)
+	}
+
+	return nil
+}
+
+// extractDocstringsForNodeType extracts and embeds docstrings for a specific node type
+func (ces *CommentEmbeddingService) extractDocstringsForNodeType(ctx context.Context, nodeType string, batchSize int, dryRun bool) error {
+	fmt.Printf("📝 Processing %s docstrings...\n", nodeType)
+
+	// Query nodes with docstrings that don't have comment embeddings yet
+	query := fmt.Sprintf(`
+		MATCH (n:%s)
+		WHERE n.docstring IS NOT NULL AND n.docstring <> ""
+		AND NOT EXISTS {
+			MATCH (n)-[:HAS_COMMENT]->(c:Comment)
+			WHERE c.isDocstring = true AND c.embedding IS NOT NULL
+		}
+		RETURN elementId(n) as nodeId, n.name as name, n.docstring as docstring, n.signature as signature
+		LIMIT 1000
+	`, nodeType)
+
+	results, err := ces.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return fmt.Errorf("failed to query %s nodes: %w", nodeType, err)
+	}
+
+	if len(results) == 0 {
+		fmt.Printf("   No %s nodes need docstring embeddings\n", nodeType)
+		return nil
+	}
+
+	fmt.Printf("   Found %d %s nodes with unprocessed docstrings\n", len(results), nodeType)
+
+	// Process in batches
+	var commentUpdates []CommentEmbeddingUpdate
+	for i, record := range results {
+		recordMap := record.AsMap()
+		nodeId, _ := recordMap["nodeId"].(string)
+		name, _ := recordMap["name"].(string)
+		docstring, _ := recordMap["docstring"].(string)
+		signature, _ := recordMap["signature"].(string)
+
+		// Create comment text by combining docstring with context
+		var textParts []string
+		if signature != "" {
+			textParts = append(textParts, fmt.Sprintf("Function: %s", signature))
+		} else if name != "" {
+			textParts = append(textParts, fmt.Sprintf("%s: %s", nodeType, name))
+		}
+		textParts = append(textParts, docstring)
+
+		commentText := strings.Join(textParts, "\n")
+
+		commentUpdates = append(commentUpdates, CommentEmbeddingUpdate{
+			CommentId:    fmt.Sprintf("%s_docstring_%d", nodeId, i),
+			Text:         commentText,
+			ParentNodeId: nodeId,
+			ParentType:   nodeType,
+			ParentName:   name,
+		})
+
+		// Process batch when full
+		if len(commentUpdates) >= batchSize {
+			if err := ces.processBatch(ctx, commentUpdates, dryRun); err != nil {
+				return err
+			}
+			commentUpdates = nil
+		}
+	}
+
+	// Process remaining items
+	if len(commentUpdates) > 0 {
+		if err := ces.processBatch(ctx, commentUpdates, dryRun); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// processBatch processes a batch of comment embeddings
+func (ces *CommentEmbeddingService) processBatch(ctx context.Context, updates []CommentEmbeddingUpdate, dryRun bool) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	// Collect texts for embedding generation
+	var texts []string
+	for _, update := range updates {
+		texts = append(texts, update.Text)
+	}
+
+	fmt.Printf("   Generating embeddings for %d comments...\n", len(texts))
+
+	if dryRun {
+		fmt.Printf("   [DRY RUN] Would generate embeddings for %d comments\n", len(texts))
+		return nil
+	}
+
+	// Generate embeddings
+	embeddings, err := ces.embeddingService.GenerateBatchEmbeddings(ctx, texts)
+	if err != nil {
+		return fmt.Errorf("failed to generate embeddings: %w", err)
+	}
+
+	// Update embeddings in the updates
+	for i, embedding := range embeddings {
+		updates[i].Embedding = embedding
+	}
+
+	// Create comment nodes and relationships in Neo4j
+	return ces.createCommentNodes(ctx, updates)
+}
+
+// createCommentNodes creates comment nodes and links them to parent nodes
+func (ces *CommentEmbeddingService) createCommentNodes(ctx context.Context, updates []CommentEmbeddingUpdate) error {
+	fmt.Printf("   Creating %d comment nodes in Neo4j...\n", len(updates))
+
+	for _, update := range updates {
+		// Create comment node with embedding
+		createCommentQuery := `
+			MATCH (parent) WHERE elementId(parent) = $parentId
+			CREATE (c:Comment {
+				text: $text,
+				type: 'docstring',
+				isDocstring: true,
+				embedding: $embedding,
+				parentType: $parentType,
+				parentName: $parentName,
+				createdAt: datetime(),
+				updatedAt: datetime()
+			})
+			CREATE (parent)-[:HAS_COMMENT]->(c)
+			RETURN elementId(c) as commentId
+		`
+
+		params := map[string]any{
+			"parentId":    update.ParentNodeId,
+			"text":        update.Text,
+			"embedding":   update.Embedding,
+			"parentType":  update.ParentType,
+			"parentName":  update.ParentName,
+		}
+
+		results, err := ces.client.ExecuteQuery(ctx, createCommentQuery, params)
+		if err != nil {
+			return fmt.Errorf("failed to create comment node: %w", err)
+		}
+
+		if len(results) > 0 {
+			recordMap := results[0].AsMap()
+			commentId, _ := recordMap["commentId"].(string)
+			fmt.Printf("   Created comment node %s for %s %s\n", commentId, update.ParentType, update.ParentName)
+		}
+	}
+
+	return nil
+}
+
+// SearchFunctionsByComment searches for functions/methods/classes through their comment embeddings
+func (ces *CommentEmbeddingService) SearchFunctionsByComment(ctx context.Context, query string, limit int) (*CommentSearchResponse, error) {
+	if ces.embeddingService == nil {
+		return &CommentSearchResponse{Results: nil}, nil
+	}
+	// Generate embedding for the query
+	embedding, err := ces.embeddingService.GenerateEmbedding(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate query embedding: %w", err)
+	}
+
+	// Search comment embeddings
+	searchQuery := `
+		CALL db.index.vector.queryNodes('comment_embeddings_768', $limit, $embedding)
+		YIELD node as comment, score
+		WHERE comment:Comment AND comment.isDocstring = true
+		MATCH (parent)-[:HAS_COMMENT]->(comment)
+		RETURN parent, comment, score
+		ORDER BY score DESC
+	`
+
+	params := map[string]any{
+		"embedding": embedding,
+		"limit":     limit,
+	}
+
+	results, err := ces.client.ExecuteQuery(ctx, searchQuery, params)
+	if err != nil {
+		return nil, fmt.Errorf("comment search failed: %w", err)
+	}
+
+	var searchResults []CommentSearchResult
+	for _, result := range results {
+		resultMap := result.AsMap()
+
+		// Extract parent node data
+		parentNode := make(map[string]interface{})
+		if parent, ok := resultMap["parent"]; ok {
+			if parentMap, ok := parent.(map[string]interface{}); ok {
+				parentNode = parentMap
+			}
+		}
+
+		// Extract comment data
+		commentNode := make(map[string]interface{})
+		if comment, ok := resultMap["comment"]; ok {
+			if commentMap, ok := comment.(map[string]interface{}); ok {
+				commentNode = commentMap
+			}
+		}
+
+		score := 0.0
+		if s, ok := resultMap["score"].(float64); ok {
+			score = s
+		}
+
+		searchResults = append(searchResults, CommentSearchResult{
+			ParentNode:  parentNode,
+			CommentNode: commentNode,
+			Score:       score,
+		})
+	}
+
+	return &CommentSearchResponse{
+		Query:        query,
+		Results:      searchResults,
+		TotalResults: len(searchResults),
+		QueryVector:  embedding,
+	}, nil
+}
+
+// CommentSearchResponse represents search results based on comment embeddings
+type CommentSearchResponse struct {
+	Query        string               `json:"query"`
+	Results      []CommentSearchResult `json:"results"`
+	TotalResults int                  `json:"totalResults"`
+	QueryVector  []float64            `json:"queryVector,omitempty"`
+}
+
+// CommentSearchResult represents a single search result
+type CommentSearchResult struct {
+	ParentNode  map[string]interface{} `json:"parentNode"`  // The function/class/method
+	CommentNode map[string]interface{} `json:"commentNode"` // The comment/docstring
+	Score       float64                `json:"score"`       // Similarity score
+}
+
+// CreateCommentEmbeddingIndex creates the vector index for comment embeddings
+func (ces *CommentEmbeddingService) CreateCommentEmbeddingIndex(ctx context.Context, dimensions int) error {
+	indexName := fmt.Sprintf("comment_embeddings_%d", dimensions)
+
+	// Drop existing index if it exists
+	dropQuery := fmt.Sprintf("DROP INDEX %s IF EXISTS", indexName)
+	_, err := ces.client.ExecuteQuery(ctx, dropQuery, nil)
+	if err != nil {
+		fmt.Printf("Warning: Could not drop existing index: %v\n", err)
+	}
+
+	// Create new index
+	createQuery := fmt.Sprintf(`
+		CREATE VECTOR INDEX %s IF NOT EXISTS
+		FOR (c:Comment)
+		ON c.embedding
+		OPTIONS {
+			indexConfig: {
+				`+"`vector.dimensions`"+`: %d,
+				`+"`vector.similarity_function`"+`: 'cosine'
+			}
+		}
+	`, indexName, dimensions)
+
+	_, err = ces.client.ExecuteQuery(ctx, createQuery, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create comment embedding index: %w", err)
+	}
+
+	fmt.Printf("✅ Created comment embedding index: %s\n", indexName)
+	return nil
+}

--- a/services/retrieval-go/search/embedding_service.go
+++ b/services/retrieval-go/search/embedding_service.go
@@ -1,0 +1,385 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/genai"
+)
+
+// SimpleEmbeddingService provides embeddings using a REST API or local service
+type SimpleEmbeddingService struct {
+	BaseURL    string
+	APIKey     string
+	Model      string
+	HTTPClient *http.Client
+}
+
+// NewSimpleEmbeddingService creates a new embedding service
+func NewSimpleEmbeddingService(baseURL, apiKey, model string) *SimpleEmbeddingService {
+	return &SimpleEmbeddingService{
+		BaseURL: baseURL,
+		APIKey:  apiKey,
+		Model:   model,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// EmbeddingRequest represents a request to generate embeddings
+type EmbeddingRequest struct {
+	Input []string `json:"input"`
+	Model string   `json:"model"`
+}
+
+// EmbeddingResponse represents the response from an embedding API
+type EmbeddingResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+	Model string `json:"model"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// GenerateEmbedding generates a single embedding for the given text
+func (es *SimpleEmbeddingService) GenerateEmbedding(ctx context.Context, text string) ([]float64, error) {
+	embeddings, err := es.GenerateBatchEmbeddings(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embeddings returned")
+	}
+
+	return embeddings[0], nil
+}
+
+// GenerateBatchEmbeddings generates embeddings for multiple texts
+func (es *SimpleEmbeddingService) GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	if len(texts) == 0 {
+		return nil, fmt.Errorf("no texts provided")
+	}
+
+	// If no API key provided, return error
+	if es.APIKey == "" || es.BaseURL == "" {
+		return nil, fmt.Errorf("API key and base URL are required for embedding service")
+	}
+
+	// Call actual API
+	response, err := es.callEmbeddingAPI(ctx, texts)
+	if err != nil {
+		return nil, fmt.Errorf("embedding API call failed: %w", err)
+	}
+
+	// Extract embeddings from API response
+	var embeddings [][]float64
+	for _, data := range response.Data {
+		embeddings = append(embeddings, data.Embedding)
+	}
+
+	if len(embeddings) != len(texts) {
+		return nil, fmt.Errorf("expected %d embeddings, got %d", len(texts), len(embeddings))
+	}
+
+	return embeddings, nil
+}
+
+// generateMockEmbeddings creates mock embeddings for testing purposes
+func (es *SimpleEmbeddingService) generateMockEmbeddings(texts []string) [][]float64 {
+	var embeddings [][]float64
+
+	for _, text := range texts {
+		// Generate a mock embedding based on text content and semantic meaning
+		embedding := make([]float64, 384) // sentence-transformers/all-MiniLM-L6-v2 dimensions
+
+		// Create hash of the content for consistency
+		hash := es.simpleHash(text)
+
+		// Analyze text characteristics for more meaningful embeddings
+		wordCount := float64(len(strings.Fields(text)))
+		charCount := float64(len(text))
+
+		// Create base pattern based on text content
+		for j := 0; j < 384; j++ {
+			// Create deterministic values based on text content and position
+			baseValue := float64((hash+int64(j*13))%2000)/1000.0 - 1.0 // Range: -1.0 to 1.0
+
+			// Add semantic variations based on text characteristics
+			if strings.Contains(strings.ToLower(text), "function") {
+				baseValue += 0.1 * float64(j%10) / 10.0
+			}
+			if strings.Contains(strings.ToLower(text), "class") {
+				baseValue += 0.15 * float64(j%7) / 7.0
+			}
+			if strings.Contains(strings.ToLower(text), "index") {
+				baseValue += 0.12 * float64(j%5) / 5.0
+			}
+
+			// Incorporate word and character count for diversity
+			baseValue += (wordCount / 100.0) * 0.05 * float64(j%3) / 3.0
+			baseValue += (charCount / 1000.0) * 0.03 * float64(j%4) / 4.0
+
+			// Keep in valid range
+			if baseValue > 1.0 {
+				baseValue = 1.0
+			} else if baseValue < -1.0 {
+				baseValue = -1.0
+			}
+
+			embedding[j] = baseValue
+		}
+
+		// Normalize the vector for proper cosine similarity
+		embedding = es.normalizeVector(embedding)
+		embeddings = append(embeddings, embedding)
+	}
+
+	return embeddings
+}
+
+// simpleHash creates a simple hash of a string for mock embedding generation
+func (es *SimpleEmbeddingService) simpleHash(s string) int64 {
+	var hash int64 = 5381
+	for _, c := range s {
+		hash = ((hash << 5) + hash) + int64(c)
+	}
+	return hash
+}
+
+// normalizeVector normalizes a vector to unit length for cosine similarity
+func (es *SimpleEmbeddingService) normalizeVector(vec []float64) []float64 {
+	var sum float64
+	for _, v := range vec {
+		sum += v * v
+	}
+
+	if sum == 0 {
+		return vec
+	}
+
+	magnitude := math.Sqrt(sum) // Proper L2 norm: sqrt(sum of squares)
+	if magnitude == 0 {
+		return vec
+	}
+
+	normalized := make([]float64, len(vec))
+	for i, v := range vec {
+		normalized[i] = v / magnitude
+	}
+
+	return normalized
+}
+
+// CallEmbeddingAPI makes an actual API call to an embedding service
+func (es *SimpleEmbeddingService) callEmbeddingAPI(ctx context.Context, texts []string) (*EmbeddingResponse, error) {
+	request := EmbeddingRequest{
+		Input: texts,
+		Model: es.Model,
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", es.BaseURL+"/embeddings", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if es.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+es.APIKey)
+	}
+
+	resp, err := es.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var embeddingResponse EmbeddingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embeddingResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &embeddingResponse, nil
+}
+
+
+// GeminiEmbeddingService provides embeddings using Google's Gemini API
+type GeminiEmbeddingService struct {
+	APIKey string
+	Model  string
+}
+
+// NewGeminiEmbeddingService creates a new Gemini embedding service
+func NewGeminiEmbeddingService(apiKey, model string) *GeminiEmbeddingService {
+	if model == "" {
+		model = "gemini-embedding-001" // Stable Gemini embedding model
+	}
+
+	return &GeminiEmbeddingService{
+		APIKey: apiKey,
+		Model:  model,
+	}
+}
+
+// GenerateEmbedding generates a single embedding for the given text using Gemini
+func (ges *GeminiEmbeddingService) GenerateEmbedding(ctx context.Context, text string) ([]float64, error) {
+	embeddings, err := ges.GenerateBatchEmbeddings(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embeddings returned")
+	}
+
+	return embeddings[0], nil
+}
+
+// GenerateBatchEmbeddings generates embeddings for multiple texts using Gemini.
+// It uses the batch EmbedContent API (up to 100 texts per call) for efficient
+// quota usage, with automatic retry and backoff on rate limit (429) errors.
+func (ges *GeminiEmbeddingService) GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	if len(texts) == 0 {
+		return nil, fmt.Errorf("no texts provided")
+	}
+
+	if ges.APIKey == "" {
+		return nil, fmt.Errorf("Google API key is required for Gemini embedding service")
+	}
+
+	clientConfig := &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		APIKey:  ges.APIKey,
+	}
+	client, err := genai.NewClient(ctx, clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Gemini client: %w", err)
+	}
+
+	embedConfig := &genai.EmbedContentConfig{
+		TaskType:             "SEMANTIC_SIMILARITY",
+		OutputDimensionality: genai.Ptr(int32(768)),
+	}
+
+	allEmbeddings := make([][]float64, 0, len(texts))
+
+	// Process in chunks of up to 100 texts per API call (Gemini batch limit).
+	// Each batch call counts as 1 API request against the daily quota.
+	const maxBatchSize = 100
+	for batchStart := 0; batchStart < len(texts); batchStart += maxBatchSize {
+		batchEnd := batchStart + maxBatchSize
+		if batchEnd > len(texts) {
+			batchEnd = len(texts)
+		}
+		batchTexts := texts[batchStart:batchEnd]
+
+		// Build multi-content batch: each text becomes a *genai.Content
+		contents := make([]*genai.Content, len(batchTexts))
+		for i, text := range batchTexts {
+			trimmedText := strings.TrimSpace(text)
+			if len(trimmedText) < 3 {
+				trimmedText = trimmedText + " code element"
+			}
+			contents[i] = genai.NewContentFromText(trimmedText, genai.RoleUser)
+		}
+
+		var result *genai.EmbedContentResponse
+		maxRetries := 5
+		for attempt := 0; attempt <= maxRetries; attempt++ {
+			result, err = client.Models.EmbedContent(ctx, ges.Model, contents, embedConfig)
+			if err == nil {
+				break
+			}
+
+			// Check for rate limit error (429) and retry with backoff
+			errMsg := err.Error()
+			if strings.Contains(errMsg, "429") || strings.Contains(errMsg, "RESOURCE_EXHAUSTED") {
+				if attempt == maxRetries {
+					return nil, fmt.Errorf("Gemini rate limit exceeded after %d retries for batch %d-%d: %w",
+						maxRetries, batchStart+1, batchEnd, err)
+				}
+				// Exponential backoff: 10s, 20s, 40s, 60s, 60s
+				backoff := time.Duration(10*(1<<attempt)) * time.Second
+				if backoff > 60*time.Second {
+					backoff = 60 * time.Second
+				}
+				log.Printf("⏳ Rate limited, waiting %s before retry (%d/%d)...", backoff, attempt+1, maxRetries)
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				continue
+			}
+
+			// Non-retryable error
+			return nil, fmt.Errorf("Gemini embedding failed for batch %d-%d: %w", batchStart+1, batchEnd, err)
+		}
+
+		if result == nil || result.Embeddings == nil {
+			return nil, fmt.Errorf("no embeddings returned for batch %d-%d", batchStart+1, batchEnd)
+		}
+
+		if len(result.Embeddings) != len(batchTexts) {
+			return nil, fmt.Errorf("expected %d embeddings for batch %d-%d, got %d",
+				len(batchTexts), batchStart+1, batchEnd, len(result.Embeddings))
+		}
+
+		for i, embedding := range result.Embeddings {
+			if len(embedding.Values) == 0 {
+				return nil, fmt.Errorf("empty embedding values for text %d in batch %d-%d",
+					i, batchStart+1, batchEnd)
+			}
+			embeddingVec := make([]float64, len(embedding.Values))
+			for j, v := range embedding.Values {
+				embeddingVec[j] = float64(v)
+			}
+			allEmbeddings = append(allEmbeddings, embeddingVec)
+		}
+
+		log.Printf("✓ Batch %d-%d: generated %d embeddings (1 API call)", batchStart+1, batchEnd, len(result.Embeddings))
+
+		// Brief pause between batch calls to respect rate limits (100 RPM)
+		if batchEnd < len(texts) {
+			select {
+			case <-time.After(700 * time.Millisecond):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+
+	log.Printf("✓ Generated %d total embeddings using Gemini %s", len(allEmbeddings), ges.Model)
+	return allEmbeddings, nil
+}
+
+// Helper function for min
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/services/retrieval-go/search/feature_linker.go
+++ b/services/retrieval-go/search/feature_linker.go
@@ -1,0 +1,411 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// FeatureLinker implements the RFC-002 specification for semantic linking of features to code
+type FeatureLinker struct {
+	client              *neo4j.Client
+	embeddingService    EmbeddingService
+	llmService          LLMService
+	codeSummarizer      *CodeSubgraphSummarizer
+	llmValidator        *LLMValidator
+	vectorStore         VectorStore
+	minConfidence       float64
+	maxCandidates       int
+}
+
+// NewFeatureLinker creates a new feature linker according to RFC-002
+func NewFeatureLinker(client *neo4j.Client, embeddingService EmbeddingService, vectorStore VectorStore) *FeatureLinker {
+	return &FeatureLinker{
+		client:              client,
+		embeddingService:    embeddingService,
+		llmService:          nil, // Optional LLM service
+		codeSummarizer:      NewCodeSubgraphSummarizer(client, embeddingService),
+		llmValidator:        NewLLMValidator(embeddingService),
+		vectorStore:         vectorStore,
+		minConfidence:       0.6,  // Minimum confidence to create IMPLEMENTS relationship
+		maxCandidates:       10,   // Maximum candidates to validate per feature
+	}
+}
+
+// WithLLMService sets the LLM service for text generation and validation
+func (fl *FeatureLinker) WithLLMService(llmService LLMService) *FeatureLinker {
+	fl.llmService = llmService
+	fl.codeSummarizer.WithLLMService(llmService)
+	fl.llmValidator.WithLLMService(llmService)
+	return fl
+}
+
+// FeatureLinkingResult contains the results of feature linking process
+type FeatureLinkingResult struct {
+	FeatureID           string                  `json:"featureId"`
+	FeatureName         string                  `json:"featureName"`
+	FeatureDescription  string                  `json:"featureDescription"`
+	CandidatesFound     int                     `json:"candidatesFound"`
+	CandidatesValidated int                     `json:"candidatesValidated"`
+	ImplementsLinks     []*ImplementsLink       `json:"implementsLinks"`
+	ProcessingTime      string                  `json:"processingTime"`
+}
+
+// ImplementsLink represents a validated IMPLEMENTS relationship
+type ImplementsLink struct {
+	FunctionID       string  `json:"functionId"`
+	FunctionName     string  `json:"functionName"`
+	Confidence       float64 `json:"confidence"`
+	ValidationMethod string  `json:"validationMethod"`
+	CodeSummary      string  `json:"codeSummary"`
+	SubgraphSize     int     `json:"subgraphSize"`
+	RelationshipID   string  `json:"relationshipId"`
+}
+
+// LinkAllFeatures processes all features in the database and creates IMPLEMENTS relationships
+func (fl *FeatureLinker) LinkAllFeatures(ctx context.Context) ([]*FeatureLinkingResult, error) {
+	log.Println("Starting feature linking process for all features...")
+
+	// Step 1: Get all Feature nodes with embeddings
+	features, err := fl.getAllFeatures(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get features: %w", err)
+	}
+
+	log.Printf("Found %d features to process", len(features))
+
+	var results []*FeatureLinkingResult
+
+	// Step 2: Process each feature
+	for _, feature := range features {
+		result, err := fl.LinkFeatureToCode(ctx, feature.ID, feature.Name, feature.Description)
+		if err != nil {
+			log.Printf("Warning: failed to link feature %s: %v", feature.Name, err)
+			continue
+		}
+
+		results = append(results, result)
+		log.Printf("Processed feature %s: %d links created", feature.Name, len(result.ImplementsLinks))
+	}
+
+	return results, nil
+}
+
+// LinkFeatureToCode implements the full RFC-002 process for a single feature
+func (fl *FeatureLinker) LinkFeatureToCode(ctx context.Context, featureID, featureName, featureDescription string) (*FeatureLinkingResult, error) {
+	log.Printf("Linking feature to code: %s", featureName)
+
+	result := &FeatureLinkingResult{
+		FeatureID:          featureID,
+		FeatureName:        featureName,
+		FeatureDescription: featureDescription,
+	}
+
+	// Step 1: Generate or get feature embedding
+	featureEmbedding, err := fl.embeddingService.GenerateEmbedding(ctx, featureDescription)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate feature embedding: %w", err)
+	}
+
+	// Step 2: Find candidate code entry points using vector search
+	candidates, err := fl.findCandidateEntryPoints(ctx, featureEmbedding)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find candidates: %w", err)
+	}
+
+	result.CandidatesFound = len(candidates)
+	log.Printf("Found %d candidate entry points for feature %s", len(candidates), featureName)
+
+	// Step 3: For each candidate, extract subgraph and generate summary
+	var matches []*FeatureCodeMatch
+	for _, candidate := range candidates {
+		match, err := fl.analyzeCandidate(ctx, featureID, featureName, featureDescription, candidate)
+		if err != nil {
+			log.Printf("Warning: failed to analyze candidate %s: %v", candidate.FunctionID, err)
+			continue
+		}
+
+		matches = append(matches, match)
+	}
+
+	result.CandidatesValidated = len(matches)
+
+	// Step 4: LLM validation of matches
+	err = fl.llmValidator.ValidateBatch(ctx, matches)
+	if err != nil {
+		return nil, fmt.Errorf("LLM validation failed: %w", err)
+	}
+
+	// Step 5: Create IMPLEMENTS relationships for validated matches
+	for _, match := range matches {
+		if match.ValidationResult != nil && match.ValidationResult.IsMatch && match.ValidationResult.Confidence >= fl.minConfidence {
+			link, err := fl.createImplementsRelationship(ctx, match)
+			if err != nil {
+				log.Printf("Warning: failed to create IMPLEMENTS relationship: %v", err)
+				continue
+			}
+
+			result.ImplementsLinks = append(result.ImplementsLinks, link)
+		}
+	}
+
+	log.Printf("Created %d IMPLEMENTS relationships for feature %s", len(result.ImplementsLinks), featureName)
+
+	return result, nil
+}
+
+// getAllFeatures retrieves all Feature nodes from the database
+func (fl *FeatureLinker) getAllFeatures(ctx context.Context) ([]FeatureNode, error) {
+	cypher := `
+		MATCH (f:Feature)
+		RETURN f.id AS id, f.name AS name, f.description AS description,
+			   f.status AS status, f.priority AS priority
+		ORDER BY f.priority DESC, f.name
+	`
+
+	results, err := fl.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var features []FeatureNode
+	for _, record := range results {
+		recordMap := record.AsMap()
+		features = append(features, FeatureNode{
+			ID:          getStringValue(recordMap, "id"),
+			Name:        getStringValue(recordMap, "name"),
+			Description: getStringValue(recordMap, "description"),
+			Status:      getStringValue(recordMap, "status"),
+			Priority:    getStringValue(recordMap, "priority"),
+		})
+	}
+
+	return features, nil
+}
+
+// FeatureNode represents a feature in the database
+type FeatureNode struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Priority    string `json:"priority"`
+}
+
+// CandidateEntryPoint represents a potential code entry point for implementing a feature
+type CandidateEntryPoint struct {
+	FunctionID  string  `json:"functionId"`
+	FunctionName string  `json:"functionName"`
+	Signature   string  `json:"signature"`
+	FilePath    string  `json:"filePath"`
+	Confidence  float64 `json:"confidence"`
+	Source      string  `json:"source"` // "vector", "keyword", "hybrid"
+}
+
+// findCandidateEntryPoints finds potential entry points using vector search and keyword matching
+func (fl *FeatureLinker) findCandidateEntryPoints(ctx context.Context, featureEmbedding []float64) ([]*CandidateEntryPoint, error) {
+	var candidates []*CandidateEntryPoint
+
+	// Strategy 1: Vector search using vector store
+	if fl.vectorStore != nil {
+		vectorResults, err := fl.vectorStore.Query(ctx, VectorQuery{
+			Vector:     featureEmbedding,
+			Limit:      fl.maxCandidates,
+			NodeLabels: []string{"Function", "Method"},
+		})
+		if err == nil {
+			for _, result := range vectorResults {
+				nodeType, _ := result.Metadata["nodeLabel"].(string)
+				if nodeType == "Function" || nodeType == "Method" {
+					name, _ := result.Metadata["name"].(string)
+					sig, _ := result.Metadata["signature"].(string)
+					fp, _ := result.Metadata["filePath"].(string)
+					candidates = append(candidates, &CandidateEntryPoint{
+						FunctionID:   result.ID,
+						FunctionName: name,
+						Signature:    sig,
+						FilePath:     fp,
+						Confidence:   result.Score,
+						Source:       "vector",
+					})
+				}
+			}
+		}
+	}
+
+	// Strategy 2: Keyword-based search for functions with meaningful names
+	// This bootstraps the search as mentioned in the RFC
+	keywordCandidates, err := fl.findKeywordCandidates(ctx)
+	if err == nil {
+		for _, candidate := range keywordCandidates {
+			// Check if not already found by vector search
+			found := false
+			for _, existing := range candidates {
+				if existing.FunctionID == candidate.FunctionID {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				candidates = append(candidates, candidate)
+			}
+		}
+	}
+
+	// Sort by confidence and limit results
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Confidence > candidates[j].Confidence
+	})
+
+	if len(candidates) > fl.maxCandidates {
+		candidates = candidates[:fl.maxCandidates]
+	}
+
+	return candidates, nil
+}
+
+// findKeywordCandidates finds functions with meaningful names that could be entry points
+func (fl *FeatureLinker) findKeywordCandidates(ctx context.Context) ([]*CandidateEntryPoint, error) {
+	// Look for functions with names that suggest they are entry points
+	cypher := `
+		MATCH (f:Function)
+		WHERE f.name =~ '(?i).*(handler|controller|service|process|execute|run|handle|create|generate|calculate|compute|validate|authenticate|authorize).*'
+		AND f.signature IS NOT NULL
+		RETURN f.id AS id, f.name AS name, f.signature AS signature, f.filePath AS filePath
+		LIMIT 20
+	`
+
+	results, err := fl.client.ExecuteQuery(ctx, cypher, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []*CandidateEntryPoint
+	for _, record := range results {
+		recordMap := record.AsMap()
+		candidates = append(candidates, &CandidateEntryPoint{
+			FunctionID:   getStringValue(recordMap, "id"),
+			FunctionName: getStringValue(recordMap, "name"),
+			Signature:    getStringValue(recordMap, "signature"),
+			FilePath:     getStringValue(recordMap, "filePath"),
+			Confidence:   0.5, // Base confidence for keyword matches
+			Source:       "keyword",
+		})
+	}
+
+	return candidates, nil
+}
+
+// analyzeCandidate performs subgraph extraction and summarization for a candidate
+func (fl *FeatureLinker) analyzeCandidate(ctx context.Context, featureID, featureName, featureDescription string, candidate *CandidateEntryPoint) (*FeatureCodeMatch, error) {
+	// Extract and summarize the code subgraph
+	subgraph, err := fl.codeSummarizer.ExtractAndSummarizeSubgraph(ctx, candidate.FunctionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract subgraph: %w", err)
+	}
+
+	// Persist embedding to the entry point Function node (RFC-002 requirement)
+	if subgraph.Embedding != nil && len(subgraph.Embedding) > 0 {
+		err = fl.client.SetNodeProperty(ctx, subgraph.EntryPoint.ID, "embedding", subgraph.Embedding)
+		if err != nil {
+			log.Printf("Warning: failed to persist embedding to function node %s: %v", subgraph.EntryPoint.ID, err)
+			// Don't fail the entire operation if embedding persistence fails
+		} else {
+			log.Printf("Persisted embedding (%d dims) to function node %s", len(subgraph.Embedding), subgraph.EntryPoint.Name)
+		}
+	}
+
+	return &FeatureCodeMatch{
+		FeatureID:          featureID,
+		FeatureName:        featureName,
+		FeatureDescription: featureDescription,
+		CodeSubgraph:       subgraph,
+		InitialConfidence:  candidate.Confidence,
+	}, nil
+}
+
+// createImplementsRelationship creates an IMPLEMENTS relationship in the database
+func (fl *FeatureLinker) createImplementsRelationship(ctx context.Context, match *FeatureCodeMatch) (*ImplementsLink, error) {
+	// Prepare relationship properties according to enhanced ImplementsRelationship model
+	relProps := map[string]any{
+		"confidence":       match.ValidationResult.Confidence,
+		"validationMethod": match.ValidationResult.Explanation,
+		"codeSummary":      match.CodeSubgraph.Summary,
+		"subgraphSize":     len(match.CodeSubgraph.Functions),
+	}
+
+	// Create the IMPLEMENTS relationship from function to feature
+	relationshipID, err := fl.client.CreateRelationship(
+		ctx,
+		match.CodeSubgraph.EntryPoint.ID, // Function implements Feature
+		match.FeatureID,
+		string(models.ImplementsRel),
+		relProps,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create IMPLEMENTS relationship: %w", err)
+	}
+
+	return &ImplementsLink{
+		FunctionID:       match.CodeSubgraph.EntryPoint.ID,
+		FunctionName:     match.CodeSubgraph.EntryPoint.Name,
+		Confidence:       match.ValidationResult.Confidence,
+		ValidationMethod: match.ValidationResult.Explanation,
+		CodeSummary:      match.CodeSubgraph.Summary,
+		SubgraphSize:     len(match.CodeSubgraph.Functions),
+		RelationshipID:   relationshipID,
+	}, nil
+}
+
+// GetFeatureImplementations retrieves all code that implements a specific feature
+func (fl *FeatureLinker) GetFeatureImplementations(ctx context.Context, featureID string) ([]*ImplementsLink, error) {
+	cypher := `
+		MATCH (f:Function)-[r:IMPLEMENTS]->(feature:Feature {id: $featureId})
+		RETURN f.id AS functionId, f.name AS functionName,
+			   r.confidence AS confidence, r.validationMethod AS validationMethod,
+			   r.codeSummary AS codeSummary, r.subgraphSize AS subgraphSize,
+			   r.id AS relationshipId
+		ORDER BY r.confidence DESC
+	`
+
+	results, err := fl.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"featureId": featureID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var implementations []*ImplementsLink
+	for _, record := range results {
+		recordMap := record.AsMap()
+		implementations = append(implementations, &ImplementsLink{
+			FunctionID:       getStringValue(recordMap, "functionId"),
+			FunctionName:     getStringValue(recordMap, "functionName"),
+			Confidence:       getFloatValue(recordMap, "confidence"),
+			ValidationMethod: getStringValue(recordMap, "validationMethod"),
+			CodeSummary:      getStringValue(recordMap, "codeSummary"),
+			SubgraphSize:     getIntValue(recordMap, "subgraphSize"),
+			RelationshipID:   getStringValue(recordMap, "relationshipId"),
+		})
+	}
+
+	return implementations, nil
+}
+
+// Helper function for float conversion
+func getFloatValue(m map[string]any, key string) float64 {
+	if val, ok := m[key]; ok {
+		if f64, ok := val.(float64); ok {
+			return f64
+		}
+		if f32, ok := val.(float32); ok {
+			return float64(f32)
+		}
+	}
+	return 0.0
+}

--- a/services/retrieval-go/search/fulltext_search.go
+++ b/services/retrieval-go/search/fulltext_search.go
@@ -1,0 +1,424 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// FullTextSearchManager handles BM25-based full-text search operations
+type FullTextSearchManager struct {
+	client *neo4j.Client
+}
+
+// NewFullTextSearchManager creates a new full-text search manager
+func NewFullTextSearchManager(client *neo4j.Client) *FullTextSearchManager {
+	return &FullTextSearchManager{
+		client: client,
+	}
+}
+
+// FullTextIndexConfig represents configuration for full-text indexes
+type FullTextIndexConfig struct {
+	Name          string   `json:"name"`
+	NodeLabels    []string `json:"nodeLabels"`
+	Properties    []string `json:"properties"`
+	Analyzer      string   `json:"analyzer"`      // Optional: "standard", "english", etc.
+	EventuallyConsistent bool `json:"eventuallyConsistent"` // Optional: for performance
+}
+
+// FullTextSearchResult represents a full-text search result with BM25 score
+type FullTextSearchResult struct {
+	Node   map[string]interface{} `json:"node"`
+	Score  float64                `json:"score"`
+	Labels []string               `json:"labels"`
+}
+
+// FullTextSearchResponse contains full-text search results and metadata
+type FullTextSearchResponse struct {
+	Results   []FullTextSearchResult `json:"results"`
+	Query     string                 `json:"query"`
+	IndexUsed string                 `json:"indexUsed"`
+	Count     int                    `json:"count"`
+}
+
+// CreateFullTextIndexes creates all necessary full-text indexes for CodeGraph
+func (ftsm *FullTextSearchManager) CreateFullTextIndexes(ctx context.Context) error {
+	indexes := []FullTextIndexConfig{
+		{
+			Name:       "code_fulltext",
+			NodeLabels: []string{"Function", "Method", "Class", "Interface", "Variable"},
+			Properties: []string{"name", "signature", "description"},
+			Analyzer:   "standard",
+		},
+		{
+			Name:       "document_fulltext",
+			NodeLabels: []string{"Document", "Feature"},
+			Properties: []string{"title", "name", "description", "content"},
+			Analyzer:   "english",
+		},
+		{
+			Name:       "symbol_fulltext",
+			NodeLabels: []string{"Symbol"},
+			Properties: []string{"symbol", "displayName", "description"},
+			Analyzer:   "standard",
+		},
+		{
+			Name:       "file_fulltext",
+			NodeLabels: []string{"File"},
+			Properties: []string{"path", "name"},
+			Analyzer:   "standard",
+		},
+	}
+
+	for _, index := range indexes {
+		if err := ftsm.createFullTextIndex(ctx, index); err != nil {
+			log.Printf("Warning: failed to create full-text index %s: %v", index.Name, err)
+			// Continue with other indexes even if one fails
+		} else {
+			log.Printf("✓ Created full-text index: %s", index.Name)
+		}
+	}
+
+	return nil
+}
+
+// createFullTextIndex creates a single full-text index
+func (ftsm *FullTextSearchManager) createFullTextIndex(ctx context.Context, config FullTextIndexConfig) error {
+	// Build node labels part: (n:Label1|Label2|Label3)
+	nodeLabels := strings.Join(config.NodeLabels, "|")
+
+	// Build properties part: [n.prop1, n.prop2, n.prop3]
+	var properties []string
+	for _, prop := range config.Properties {
+		properties = append(properties, fmt.Sprintf("n.%s", prop))
+	}
+	propertiesPart := fmt.Sprintf("[%s]", strings.Join(properties, ", "))
+
+	// Build the query
+	var query string
+	if config.Analyzer != "" {
+		query = fmt.Sprintf(`
+			CREATE FULLTEXT INDEX %s IF NOT EXISTS
+			FOR (n:%s)
+			ON EACH %s
+			OPTIONS {
+				indexConfig: {
+					` + "`fulltext.analyzer`" + `: '%s',
+					` + "`fulltext.eventually_consistent`" + `: %t
+				}
+			}
+		`, config.Name, nodeLabels, propertiesPart, config.Analyzer, config.EventuallyConsistent)
+	} else {
+		query = fmt.Sprintf(`
+			CREATE FULLTEXT INDEX %s IF NOT EXISTS
+			FOR (n:%s)
+			ON EACH %s
+		`, config.Name, nodeLabels, propertiesPart)
+	}
+
+	_, err := ftsm.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create full-text index %s: %w", config.Name, err)
+	}
+
+	return nil
+}
+
+// FullTextSearch performs BM25-based full-text search
+func (ftsm *FullTextSearchManager) FullTextSearch(ctx context.Context, indexName, queryText string, limit int) (*FullTextSearchResponse, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	query := `
+		CALL db.index.fulltext.queryNodes($indexName, $queryText)
+		YIELD node, score
+		RETURN node, score, labels(node) as nodeLabels
+		ORDER BY score DESC
+		LIMIT $limit
+	`
+
+	params := map[string]any{
+		"indexName": indexName,
+		"queryText": queryText,
+		"limit":     limit,
+	}
+
+	results, err := ftsm.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform full-text search: %w", err)
+	}
+
+	var searchResults []FullTextSearchResult
+	for _, record := range results {
+		recordMap := record.AsMap()
+
+		node, ok := recordMap["node"]
+		if !ok {
+			continue
+		}
+
+		score, ok := recordMap["score"].(float64)
+		if !ok {
+			score = 0.0
+		}
+
+		labels := []string{}
+		if labelsList, ok := recordMap["nodeLabels"].([]interface{}); ok {
+			for _, label := range labelsList {
+				if labelStr, ok := label.(string); ok {
+					labels = append(labels, labelStr)
+				}
+			}
+		}
+
+		// Convert node to map for JSON serialization
+		nodeMap := make(map[string]interface{})
+		if nodeObj, ok := node.(neo4jdriver.Node); ok {
+			// Extract all properties from the Neo4j Node object
+			nodeMap = nodeObj.Props
+		} else if nodeData, ok := node.(map[string]interface{}); ok {
+			nodeMap = nodeData
+		}
+
+		searchResults = append(searchResults, FullTextSearchResult{
+			Node:   nodeMap,
+			Score:  score,
+			Labels: labels,
+		})
+	}
+
+	return &FullTextSearchResponse{
+		Results:   searchResults,
+		Query:     queryText,
+		IndexUsed: indexName,
+		Count:     len(searchResults),
+	}, nil
+}
+
+// SmartFullTextSearch automatically selects the best index based on query content
+func (ftsm *FullTextSearchManager) SmartFullTextSearch(ctx context.Context, queryText string, limit int) (*FullTextSearchResponse, error) {
+	// Analyze query to determine best index
+	indexName := ftsm.selectBestIndex(queryText)
+
+	return ftsm.FullTextSearch(ctx, indexName, queryText, limit)
+}
+
+// selectBestIndex determines the most appropriate index for a query
+func (ftsm *FullTextSearchManager) selectBestIndex(queryText string) string {
+	query := strings.ToLower(queryText)
+
+	// Code-related keywords
+	codeKeywords := []string{
+		"function", "method", "class", "interface", "variable",
+		"return", "parameter", "argument", "struct", "type",
+		"implements", "extends", "override", "private", "public",
+		"static", "const", "var", "func", "package",
+	}
+
+	// Document-related keywords
+	docKeywords := []string{
+		"documentation", "guide", "tutorial", "readme", "feature",
+		"requirement", "specification", "design", "architecture",
+		"overview", "getting started", "how to", "example",
+	}
+
+	// Symbol-related keywords
+	symbolKeywords := []string{
+		"symbol", "reference", "definition", "declaration",
+		"import", "export", "namespace", "scope",
+	}
+
+	// Check for code-related terms
+	for _, keyword := range codeKeywords {
+		if strings.Contains(query, keyword) {
+			return "code_fulltext"
+		}
+	}
+
+	// Check for document-related terms
+	for _, keyword := range docKeywords {
+		if strings.Contains(query, keyword) {
+			return "document_fulltext"
+		}
+	}
+
+	// Check for symbol-related terms
+	for _, keyword := range symbolKeywords {
+		if strings.Contains(query, keyword) {
+			return "symbol_fulltext"
+		}
+	}
+
+	// Default to document search for general queries
+	return "document_fulltext"
+}
+
+// HybridFullTextSearch searches across multiple full-text indexes
+func (ftsm *FullTextSearchManager) HybridFullTextSearch(ctx context.Context, queryText string, limit int) (*FullTextSearchResponse, error) {
+	indexes := []string{
+		"code_fulltext",
+		"document_fulltext",
+		"symbol_fulltext",
+		"file_fulltext",
+	}
+
+	var allResults []FullTextSearchResult
+	limitPerIndex := limit / len(indexes)
+	if limitPerIndex < 1 {
+		limitPerIndex = 1
+	}
+
+	// Search across all full-text indexes
+	for _, indexName := range indexes {
+		response, err := ftsm.FullTextSearch(ctx, indexName, queryText, limitPerIndex)
+		if err != nil {
+			log.Printf("Warning: full-text search failed for index %s: %v", indexName, err)
+			continue
+		}
+		allResults = append(allResults, response.Results...)
+	}
+
+	// Sort by BM25 score (descending)
+	for i := 0; i < len(allResults)-1; i++ {
+		for j := i + 1; j < len(allResults); j++ {
+			if allResults[i].Score < allResults[j].Score {
+				allResults[i], allResults[j] = allResults[j], allResults[i]
+			}
+		}
+	}
+
+	// Limit results
+	if len(allResults) > limit {
+		allResults = allResults[:limit]
+	}
+
+	return &FullTextSearchResponse{
+		Results:   allResults,
+		Query:     queryText,
+		IndexUsed: "hybrid",
+		Count:     len(allResults),
+	}, nil
+}
+
+// AdvancedFullTextSearch supports Lucene query syntax
+func (ftsm *FullTextSearchManager) AdvancedFullTextSearch(ctx context.Context, indexName, luceneQuery string, limit int) (*FullTextSearchResponse, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	// Lucene query examples:
+	// - "function AND indexing" (boolean AND)
+	// - "function OR method" (boolean OR)
+	// - "function NOT test" (boolean NOT)
+	// - "\"exact phrase\"" (exact phrase)
+	// - "name:createIndex" (field-specific search)
+	// - "func*" (wildcard)
+
+	query := `
+		CALL db.index.fulltext.queryNodes($indexName, $luceneQuery)
+		YIELD node, score
+		RETURN node, score, labels(node) as nodeLabels
+		ORDER BY score DESC
+		LIMIT $limit
+	`
+
+	params := map[string]any{
+		"indexName":   indexName,
+		"luceneQuery": luceneQuery,
+		"limit":       limit,
+	}
+
+	results, err := ftsm.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform advanced full-text search: %w", err)
+	}
+
+	var searchResults []FullTextSearchResult
+	for _, record := range results {
+		recordMap := record.AsMap()
+
+		node, ok := recordMap["node"]
+		if !ok {
+			continue
+		}
+
+		score, ok := recordMap["score"].(float64)
+		if !ok {
+			score = 0.0
+		}
+
+		labels := []string{}
+		if labelsList, ok := recordMap["nodeLabels"].([]interface{}); ok {
+			for _, label := range labelsList {
+				if labelStr, ok := label.(string); ok {
+					labels = append(labels, labelStr)
+				}
+			}
+		}
+
+		nodeMap := make(map[string]interface{})
+		if nodeData, ok := node.(map[string]interface{}); ok {
+			nodeMap = nodeData
+		}
+
+		searchResults = append(searchResults, FullTextSearchResult{
+			Node:   nodeMap,
+			Score:  score,
+			Labels: labels,
+		})
+	}
+
+	return &FullTextSearchResponse{
+		Results:   searchResults,
+		Query:     luceneQuery,
+		IndexUsed: indexName,
+		Count:     len(searchResults),
+	}, nil
+}
+
+// GetFullTextIndexInfo returns information about existing full-text indexes
+func (ftsm *FullTextSearchManager) GetFullTextIndexInfo(ctx context.Context) (map[string]interface{}, error) {
+	query := `SHOW INDEXES WHERE type = 'FULLTEXT'`
+
+	results, err := ftsm.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get full-text index info: %w", err)
+	}
+
+	info := make(map[string]interface{})
+	info["fullTextIndexes"] = make([]map[string]interface{}, 0)
+
+	for _, record := range results {
+		recordMap := record.AsMap()
+		indexInfo := make(map[string]interface{})
+
+		for key, value := range recordMap {
+			indexInfo[key] = value
+		}
+
+		if indexes, ok := info["fullTextIndexes"].([]map[string]interface{}); ok {
+			info["fullTextIndexes"] = append(indexes, indexInfo)
+		}
+	}
+
+	return info, nil
+}
+
+// DropFullTextIndex removes a full-text index
+func (ftsm *FullTextSearchManager) DropFullTextIndex(ctx context.Context, indexName string) error {
+	query := fmt.Sprintf("DROP INDEX %s IF EXISTS", indexName)
+
+	_, err := ftsm.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return fmt.Errorf("failed to drop full-text index %s: %w", indexName, err)
+	}
+
+	log.Printf("✓ Dropped full-text index: %s", indexName)
+	return nil
+}

--- a/services/retrieval-go/search/hybrid_search.go
+++ b/services/retrieval-go/search/hybrid_search.go
@@ -1,0 +1,639 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// HybridSearchManager combines vector search, BM25 full-text search, and semantic search
+type HybridSearchManager struct {
+	client              *neo4j.Client
+	vectorStore         VectorStore              // Vector store backend (e.g. Qdrant)
+	fullTextSearch      *FullTextSearchManager
+	queryBuilder        *neo4j.QueryBuilder
+	embeddingService    EmbeddingService // Interface for generating embeddings
+	commentSearch       *CommentEmbeddingService // For comment-based function discovery
+}
+
+// NewHybridSearchManager creates a comprehensive hybrid search manager.
+// The VectorStore is used for all vector similarity queries.
+func NewHybridSearchManager(client *neo4j.Client, embeddingService EmbeddingService, store VectorStore) *HybridSearchManager {
+	return &HybridSearchManager{
+		client:           client,
+		vectorStore:      store,
+		fullTextSearch:   NewFullTextSearchManager(client),
+		queryBuilder:     neo4j.NewQueryBuilder(client),
+		embeddingService: embeddingService,
+		commentSearch:    NewCommentEmbeddingService(client, embeddingService),
+	}
+}
+
+// EmbeddingService interface for generating text embeddings
+type EmbeddingService interface {
+	GenerateEmbedding(ctx context.Context, text string) ([]float64, error)
+	GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float64, error)
+}
+
+// HybridSearchResult represents a unified search result with multiple scores
+type HybridSearchResult struct {
+	Node            map[string]interface{} `json:"node"`
+	Labels          []string               `json:"labels"`
+	VectorScore     float64                `json:"vectorScore"`
+	FullTextScore   float64                `json:"fullTextScore"`
+	SemanticScore   float64                `json:"semanticScore"`
+	CommentScore    float64                `json:"commentScore"`    // Score from comment-based search
+	CombinedScore   float64                `json:"combinedScore"`
+	Source          string                 `json:"source"` // "vector", "fulltext", "semantic", "hybrid", "comment"
+	Relevance       string                 `json:"relevance"` // "high", "medium", "low"
+}
+
+// HybridSearchResponse contains comprehensive search results
+type HybridSearchResponse struct {
+	Results      []HybridSearchResult `json:"results"`
+	Query        string               `json:"query"`
+	QueryVector  []float64            `json:"queryVector,omitempty"`
+	SearchTypes  []string             `json:"searchTypes"`
+	TotalResults int                  `json:"totalResults"`
+	Metadata     SearchMetadata       `json:"metadata"`
+}
+
+// SearchMetadata provides information about the search execution
+type SearchMetadata struct {
+	VectorResults    int     `json:"vectorResults"`
+	FullTextResults  int     `json:"fullTextResults"`
+	SemanticResults  int     `json:"semanticResults"`
+	CommentResults   int     `json:"commentResults"`
+	SearchDuration   string  `json:"searchDuration"`
+	HybridWeight     Weights `json:"hybridWeight"`
+}
+
+// Weights for combining different search results
+type Weights struct {
+	Vector    float64 `json:"vector"`
+	FullText  float64 `json:"fullText"`
+	Semantic  float64 `json:"semantic"`
+}
+
+// DefaultWeights provides balanced scoring weights
+var DefaultWeights = Weights{
+	Vector:   0.4, // Semantic similarity
+	FullText: 0.4, // BM25 relevance
+	Semantic: 0.2, // Graph-based semantic search
+}
+
+// InitializeSearchIndexes creates all necessary indexes for hybrid search
+func (hsm *HybridSearchManager) InitializeSearchIndexes(ctx context.Context) error {
+	log.Println("🚀 Initializing hybrid search indexes...")
+
+	// Create full-text indexes in Neo4j
+	if err := hsm.fullTextSearch.CreateFullTextIndexes(ctx); err != nil {
+		log.Printf("Warning: failed to create full-text indexes: %v", err)
+	}
+
+	log.Println("✓ Hybrid search indexes initialization completed")
+	return nil
+}
+
+// rrfScore returns the Reciprocal Rank Fusion contribution for rank r (1-indexed).
+// k=60 is the standard constant that balances the influence of top vs. lower ranks.
+func rrfScore(r int) float64 {
+	return 1.0 / (60.0 + float64(r))
+}
+
+// UnifiedSearch performs comprehensive search using all available methods.
+// Results are merged using Reciprocal Rank Fusion (RRF), which correctly
+// combines scores from different scales (cosine 0-1, BM25 2-20, etc.).
+func (hsm *HybridSearchManager) UnifiedSearch(ctx context.Context, query string, limit int, weights ...Weights) (*HybridSearchResponse, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	// Use provided weights or defaults
+	searchWeights := DefaultWeights
+	if len(weights) > 0 {
+		searchWeights = weights[0]
+	}
+
+	var queryVector []float64
+
+	// rrfEntry accumulates per-source scores and rank contributions for a node.
+	type rrfEntry struct {
+		result HybridSearchResult
+		rrf    float64
+	}
+	byKey := make(map[string]*rrfEntry)
+
+	addEntry := func(key string, result HybridSearchResult, rank int) {
+		e, ok := byKey[key]
+		if !ok {
+			e = &rrfEntry{result: result}
+			byKey[key] = e
+		}
+		// Merge node: prefer the one with more properties.
+		if len(result.Node) > len(e.result.Node) {
+			e.result.Node = result.Node
+		}
+		// Merge labels.
+		e.result.Labels = hsm.mergeLabels(e.result.Labels, result.Labels)
+		// Keep highest raw scores per source.
+		e.result.VectorScore = math.Max(e.result.VectorScore, result.VectorScore)
+		e.result.FullTextScore = math.Max(e.result.FullTextScore, result.FullTextScore)
+		e.result.SemanticScore = math.Max(e.result.SemanticScore, result.SemanticScore)
+		e.result.CommentScore = math.Max(e.result.CommentScore, result.CommentScore)
+		// Accumulate RRF score (scale by source weight).
+		var w float64
+		switch result.Source {
+		case "vector":
+			w = searchWeights.Vector
+		case "fulltext":
+			w = searchWeights.FullText
+		case "semantic":
+			w = searchWeights.Semantic
+		default:
+			w = 0.3
+		}
+		e.rrf += rrfScore(rank) * w
+	}
+
+	// 1. Vector Search
+	var vectorResultCount int
+	if hsm.embeddingService != nil && hsm.vectorStore != nil {
+		var err error
+		queryVector, err = hsm.embeddingService.GenerateEmbedding(ctx, query)
+		if err != nil {
+			log.Printf("Warning: failed to generate query embedding: %v", err)
+		} else {
+			storeResults, err := hsm.vectorStore.Query(ctx, VectorQuery{
+				Vector: queryVector,
+				Limit:  limit,
+			})
+			if err != nil {
+				log.Printf("Warning: vector store search failed: %v", err)
+			} else {
+				vectorResultCount = len(storeResults)
+				resolvedNodes := hsm.resolveNodeKeys(ctx, storeResults)
+				for i, result := range storeResults {
+					node := resolvedNodes[i]
+					// Extract labels stored by resolveNodeKeys under "_labels".
+					var labels []string
+					if lv, ok := node["_labels"].([]string); ok {
+						labels = lv
+					}
+					hr := HybridSearchResult{
+						Node:        node,
+						Labels:      labels,
+						VectorScore: result.Score,
+						Source:      "vector",
+						Relevance:   hsm.calculateRelevance(result.Score, "vector"),
+					}
+					key := hsm.getResultKey(node)
+					addEntry(key, hr, i+1)
+				}
+			}
+		}
+	}
+
+	// 2. Full-Text Search (BM25)
+	var fullTextResults []FullTextSearchResult
+	fullTextResponse, err := hsm.fullTextSearch.HybridFullTextSearch(ctx, query, limit)
+	if err != nil {
+		log.Printf("Warning: full-text search failed: %v", err)
+	} else {
+		fullTextResults = fullTextResponse.Results
+		for i, result := range fullTextResults {
+			hr := HybridSearchResult{
+				Node:          result.Node,
+				Labels:        result.Labels,
+				FullTextScore: result.Score,
+				Source:        "fulltext",
+				Relevance:     hsm.calculateRelevance(result.Score, "fulltext"),
+			}
+			key := hsm.getResultKey(result.Node)
+			addEntry(key, hr, i+1)
+		}
+	}
+
+	// 3. Semantic Search (graph-based name/description matching)
+	semanticResults, err := hsm.queryBuilder.SearchNodes(ctx, query, []string{"Function", "Method", "Class", "Document", "Feature", "Symbol"}, limit)
+	if err != nil {
+		log.Printf("Warning: semantic search failed: %v", err)
+	} else {
+		for i, record := range semanticResults {
+			recordMap := record.AsMap()
+			node, ok := recordMap["n"]
+			if !ok {
+				continue
+			}
+			var labels []string
+			if labelsList, ok := recordMap["nodeLabels"].([]interface{}); ok {
+				for _, label := range labelsList {
+					if ls, ok := label.(string); ok {
+						labels = append(labels, ls)
+					}
+				}
+			}
+			nodeMap := make(map[string]interface{})
+			if nodeObj, ok := node.(neo4jdriver.Node); ok {
+				nodeMap = nodeObj.Props
+				nodeMap["elementId"] = nodeObj.ElementId
+			} else if nodeData, ok := node.(map[string]interface{}); ok {
+				nodeMap = nodeData
+			}
+			semanticScore := hsm.calculateSemanticRelevance(nodeMap, query)
+			hr := HybridSearchResult{
+				Node:          nodeMap,
+				Labels:        labels,
+				SemanticScore: semanticScore,
+				Source:        "semantic",
+				Relevance:     hsm.calculateRelevance(semanticScore, "semantic"),
+			}
+			key := hsm.getResultKey(nodeMap)
+			addEntry(key, hr, i+1)
+		}
+	}
+
+	// 4. Comment-Based Search
+	var commentResults []CommentSearchResult
+	if hsm.commentSearch != nil {
+		commentResponse, err := hsm.commentSearch.SearchFunctionsByComment(ctx, query, limit)
+		if err != nil {
+			log.Printf("Warning: comment search failed: %v", err)
+		} else {
+			commentResults = commentResponse.Results
+			for i, result := range commentResults {
+				hr := HybridSearchResult{
+					Node:         result.ParentNode,
+					Labels:       []string{getStringFromMap(result.CommentNode, "parentType")},
+					CommentScore: result.Score,
+					Source:       "comment",
+					Relevance:    hsm.calculateRelevance(result.Score, "comment"),
+				}
+				key := hsm.getResultKey(result.ParentNode)
+				addEntry(key, hr, i+1)
+			}
+		}
+	}
+
+	// 5. Build final result slice from RRF scores.
+	mergedResults := make([]HybridSearchResult, 0, len(byKey))
+	for _, e := range byKey {
+		e.result.CombinedScore = e.rrf
+		// Determine source label.
+		sourceCount := 0
+		for _, s := range []float64{e.result.VectorScore, e.result.FullTextScore, e.result.SemanticScore, e.result.CommentScore} {
+			if s > 0 {
+				sourceCount++
+			}
+		}
+		if sourceCount > 1 {
+			e.result.Source = "hybrid"
+		}
+		e.result.Relevance = hsm.calculateRelevance(e.rrf, "rrf")
+		mergedResults = append(mergedResults, e.result)
+	}
+
+	// 6. Sort by RRF combined score descending.
+	sort.Slice(mergedResults, func(i, j int) bool {
+		return mergedResults[i].CombinedScore > mergedResults[j].CombinedScore
+	})
+
+	// 7. Limit results.
+	if len(mergedResults) > limit {
+		mergedResults = mergedResults[:limit]
+	}
+
+	response := &HybridSearchResponse{
+		Results:      mergedResults,
+		Query:        query,
+		QueryVector:  queryVector,
+		SearchTypes:  []string{"vector", "fulltext", "semantic", "comment"},
+		TotalResults: len(mergedResults),
+		Metadata: SearchMetadata{
+			VectorResults:   vectorResultCount,
+			FullTextResults: len(fullTextResults),
+			SemanticResults: len(semanticResults),
+			CommentResults:  len(commentResults),
+			HybridWeight:    searchWeights,
+		},
+	}
+
+	return response, nil
+}
+
+// getResultKey generates a stable unique key for result deduplication.
+// Priority: nodeKey (most stable) > elementId > name+type fallback.
+func (hsm *HybridSearchManager) getResultKey(node map[string]interface{}) string {
+	if nk, ok := node["nodeKey"].(string); ok && nk != "" {
+		return nk
+	}
+	if id, ok := node["elementId"].(string); ok && id != "" {
+		return id
+	}
+
+	name, _ := node["name"].(string)
+	nodeType := "unknown"
+	if _, ok := node["signature"]; ok {
+		nodeType = "function"
+	} else if _, ok := node["content"]; ok {
+		nodeType = "document"
+	} else if _, ok := node["path"]; ok {
+		nodeType = "file"
+	}
+	return fmt.Sprintf("%s_%s", nodeType, name)
+}
+
+// mergeLabels combines label arrays, removing duplicates
+func (hsm *HybridSearchManager) mergeLabels(labels1, labels2 []string) []string {
+	labelSet := make(map[string]bool)
+	for _, label := range labels1 {
+		labelSet[label] = true
+	}
+	for _, label := range labels2 {
+		labelSet[label] = true
+	}
+
+	var merged []string
+	for label := range labelSet {
+		merged = append(merged, label)
+	}
+
+	return merged
+}
+
+// calculateRelevance determines relevance level based on score and source.
+// RRF scores top out around 1/(60+1) ≈ 0.016 per source; three sources ≈ 0.048.
+func (hsm *HybridSearchManager) calculateRelevance(score float64, source string) string {
+	switch source {
+	case "vector":
+		if score > 0.85 {
+			return "high"
+		} else if score > 0.65 {
+			return "medium"
+		}
+		return "low"
+	case "fulltext":
+		if score > 5.0 {
+			return "high"
+		} else if score > 2.0 {
+			return "medium"
+		}
+		return "low"
+	case "semantic":
+		if score > 0.7 {
+			return "high"
+		} else if score > 0.4 {
+			return "medium"
+		}
+		return "low"
+	case "rrf", "hybrid":
+		// RRF: single-source max ≈ 0.016, dual ≈ 0.032, triple ≈ 0.048 (unweighted).
+		// With weights 0.4/0.4/0.2 these scale accordingly.
+		if score > 0.010 {
+			return "high"
+		} else if score > 0.006 {
+			return "medium"
+		}
+		return "low"
+	default:
+		return "low"
+	}
+}
+
+// calculateSemanticRelevance calculates a simple relevance score for semantic search
+func (hsm *HybridSearchManager) calculateSemanticRelevance(node map[string]interface{}, query string) float64 {
+	query = strings.ToLower(query)
+	score := 0.0
+
+	// Check name field
+	if name, ok := node["name"].(string); ok {
+		if strings.Contains(strings.ToLower(name), query) {
+			score += 1.0
+		}
+	}
+
+	// Check description field
+	if description, ok := node["description"].(string); ok {
+		if strings.Contains(strings.ToLower(description), query) {
+			score += 0.5
+		}
+	}
+
+	// Check signature field
+	if signature, ok := node["signature"].(string); ok {
+		if strings.Contains(strings.ToLower(signature), query) {
+			score += 0.3
+		}
+	}
+
+	// Check content field (for documents)
+	if content, ok := node["content"].(string); ok {
+		if strings.Contains(strings.ToLower(content), query) {
+			score += 0.4
+		}
+	}
+
+	return math.Min(score, 1.0) // Cap at 1.0
+}
+
+// SmartSearch automatically selects the best search strategy based on query characteristics
+func (hsm *HybridSearchManager) SmartSearch(ctx context.Context, query string, limit int) (*HybridSearchResponse, error) {
+	// Analyze query to determine optimal search strategy
+	strategy := hsm.analyzeQuery(query)
+
+	switch strategy {
+	case "code-focused":
+		return hsm.UnifiedSearch(ctx, query, limit, Weights{Vector: 0.3, FullText: 0.5, Semantic: 0.2})
+	case "concept-focused":
+		return hsm.UnifiedSearch(ctx, query, limit, Weights{Vector: 0.6, FullText: 0.3, Semantic: 0.1})
+	case "document-focused":
+		return hsm.UnifiedSearch(ctx, query, limit, Weights{Vector: 0.5, FullText: 0.4, Semantic: 0.1})
+	default:
+		return hsm.UnifiedSearch(ctx, query, limit)
+	}
+}
+
+// analyzeQuery determines the optimal search strategy based on query content
+func (hsm *HybridSearchManager) analyzeQuery(query string) string {
+	query = strings.ToLower(query)
+
+	// Code-specific keywords
+	codeKeywords := []string{
+		"function", "method", "class", "variable", "struct", "interface",
+		"return", "parameter", "implements", "extends", "private", "public",
+	}
+
+	// Conceptual keywords
+	conceptKeywords := []string{
+		"how to", "what is", "why", "when", "where", "concept", "idea",
+		"approach", "strategy", "pattern", "best practice",
+	}
+
+	// Document keywords
+	docKeywords := []string{
+		"documentation", "guide", "tutorial", "example", "readme",
+		"specification", "requirements", "design", "architecture",
+	}
+
+	codeScore := 0
+	conceptScore := 0
+	docScore := 0
+
+	for _, keyword := range codeKeywords {
+		if strings.Contains(query, keyword) {
+			codeScore++
+		}
+	}
+
+	for _, keyword := range conceptKeywords {
+		if strings.Contains(query, keyword) {
+			conceptScore++
+		}
+	}
+
+	for _, keyword := range docKeywords {
+		if strings.Contains(query, keyword) {
+			docScore++
+		}
+	}
+
+	if codeScore > conceptScore && codeScore > docScore {
+		return "code-focused"
+	} else if conceptScore > docScore {
+		return "concept-focused"
+	} else if docScore > 0 {
+		return "document-focused"
+	}
+
+	return "balanced"
+}
+
+// GetSearchCapabilities returns information about available search capabilities
+func (hsm *HybridSearchManager) GetSearchCapabilities(ctx context.Context) (map[string]interface{}, error) {
+	capabilities := make(map[string]interface{})
+
+	capabilities["vectorSearch"] = map[string]interface{}{
+		"backend":    "qdrant",
+		"vectorStore": hsm.vectorStore != nil,
+	}
+
+	// Get full-text index info
+	fullTextInfo, err := hsm.fullTextSearch.GetFullTextIndexInfo(ctx)
+	if err != nil {
+		log.Printf("Warning: failed to get full-text index info: %v", err)
+	} else {
+		capabilities["fullTextSearch"] = fullTextInfo
+	}
+
+	capabilities["hybridSearch"] = map[string]interface{}{
+		"supportedMethods": []string{"vector", "fulltext", "semantic", "hybrid"},
+		"defaultWeights":   DefaultWeights,
+		"smartSearch":      true,
+		"embeddingService": hsm.embeddingService != nil,
+	}
+
+	return capabilities, nil
+}
+
+// resolveNodeKeys takes Qdrant vector results and resolves their nodeKeys
+// back to full Neo4j node properties (filePath, sourceCode, startLine, etc.).
+// Returns a slice of node maps in the same order as the input results.
+func (hsm *HybridSearchManager) resolveNodeKeys(ctx context.Context, results []VectorResult) []map[string]interface{} {
+	nodes := make([]map[string]interface{}, len(results))
+
+	// Collect nodeKeys for batch lookup.
+	var nodeKeys []string
+	keyIndex := make(map[string][]int) // nodeKey -> indices in results
+	for i, r := range results {
+		nk, _ := r.Metadata["nodeKey"].(string)
+		if nk == "" {
+			nk = r.ID
+		}
+		if nk != "" {
+			keyIndex[nk] = append(keyIndex[nk], i)
+			nodeKeys = append(nodeKeys, nk)
+		}
+		// Initialize with Qdrant metadata as fallback.
+		node := make(map[string]interface{})
+		for k, v := range r.Metadata {
+			node[k] = v
+		}
+		nodes[i] = node
+	}
+
+	if len(nodeKeys) == 0 {
+		return nodes
+	}
+
+	// Batch-resolve from Neo4j.
+	resolveQuery := `
+		UNWIND $keys AS key
+		MATCH (n)
+		WHERE n.nodeKey = key
+		RETURN n.nodeKey AS nodeKey, n, labels(n) AS labels
+	`
+	records, err := hsm.client.ExecuteQuery(ctx, resolveQuery, map[string]any{"keys": nodeKeys})
+	if err != nil {
+		log.Printf("Warning: failed to resolve nodeKeys from Neo4j: %v", err)
+		return nodes
+	}
+
+	for _, record := range records {
+		rm := record.AsMap()
+		nk, _ := rm["nodeKey"].(string)
+		indices, ok := keyIndex[nk]
+		if !ok {
+			continue
+		}
+
+		// Extract node properties.
+		props := make(map[string]interface{})
+		if nodeObj, ok := rm["n"].(neo4jdriver.Node); ok {
+			for k, v := range nodeObj.Props {
+				if k == "embedding" || k == "embeddedAt" {
+					continue // Don't copy large/internal fields.
+				}
+				props[k] = v
+			}
+			props["elementId"] = nodeObj.ElementId
+		}
+
+		// Extract labels.
+		var labels []string
+		if labelsList, ok := rm["labels"].([]interface{}); ok {
+			for _, l := range labelsList {
+				if ls, ok := l.(string); ok {
+					labels = append(labels, ls)
+				}
+			}
+		}
+
+		// Overwrite the Qdrant-only metadata with the full Neo4j properties.
+		for _, idx := range indices {
+			enriched := make(map[string]interface{})
+			for k, v := range props {
+				enriched[k] = v
+			}
+			enriched["_labels"] = labels
+			nodes[idx] = enriched
+		}
+	}
+
+	return nodes
+}
+
+// Helper function to safely extract string values from maps
+func getStringFromMap(data map[string]interface{}, key string) string {
+	if val, ok := data[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}

--- a/services/retrieval-go/search/intelligent_linker.go
+++ b/services/retrieval-go/search/intelligent_linker.go
@@ -1,0 +1,523 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+)
+
+// IntelligentDocumentLinker creates semantic relationships between documents and code
+type IntelligentDocumentLinker struct {
+	client           *neo4j.Client
+	semanticAnalyzer *SemanticDocumentAnalyzer
+	vectorStore      VectorStore
+	hybridSearch     *HybridSearchManager
+}
+
+// NewIntelligentDocumentLinker creates a new intelligent document linker
+func NewIntelligentDocumentLinker(client *neo4j.Client, embeddingService EmbeddingService, vectorStore VectorStore) *IntelligentDocumentLinker {
+	return &IntelligentDocumentLinker{
+		client:           client,
+		semanticAnalyzer: NewSemanticDocumentAnalyzer(embeddingService),
+		vectorStore:      vectorStore,
+		hybridSearch:     NewHybridSearchManager(client, embeddingService, vectorStore),
+	}
+}
+
+// CodeMatch represents a potential match between document and code
+type CodeMatch struct {
+	NodeID         string   `json:"nodeId"`
+	NodeType       string   `json:"nodeType"`
+	Name           string   `json:"name"`
+	Signature      string   `json:"signature,omitempty"`
+	FilePath       string   `json:"filePath"`
+	Confidence     float64  `json:"confidence"`
+	MatchReasons   []string `json:"matchReasons"`
+	CallGraphDepth int      `json:"callGraphDepth"`
+}
+
+// LinkingResult contains the results of intelligent document linking
+type LinkingResult struct {
+	DocumentID    string      `json:"documentId"`
+	DirectMatches []CodeMatch `json:"directMatches"`
+	SemanticMatches []CodeMatch `json:"semanticMatches"`
+	CallGraphMatches []CodeMatch `json:"callGraphMatches"`
+	CreatedLinks  int         `json:"createdLinks"`
+}
+
+// LinkDocumentToCode performs intelligent linking between a document and code
+func (idl *IntelligentDocumentLinker) LinkDocumentToCode(ctx context.Context, documentID string, content string) (*LinkingResult, error) {
+	log.Printf("Starting intelligent linking for document: %s", documentID)
+
+	result := &LinkingResult{
+		DocumentID: documentID,
+	}
+
+	// Step 1: Analyze document semantically
+	searchQueries, concepts, err := idl.semanticAnalyzer.AnalyzeForCodeMapping(ctx, content)
+	if err != nil {
+		return nil, fmt.Errorf("semantic analysis failed: %w", err)
+	}
+
+	log.Printf("Found %d search queries and %d technical concepts", len(searchQueries), len(concepts))
+
+	// Step 2: Find direct matches (existing backtick references)
+	directMatches := idl.findDirectMatches(ctx, content)
+	result.DirectMatches = directMatches
+
+	// Step 3: Find semantic matches using embeddings
+	semanticMatches, err := idl.findSemanticMatches(ctx, content, searchQueries)
+	if err != nil {
+		log.Printf("Warning: semantic matching failed: %v", err)
+	} else {
+		result.SemanticMatches = semanticMatches
+	}
+
+	// Step 4: Expand matches using call graph analysis
+	callGraphMatches, err := idl.expandWithCallGraph(ctx, append(directMatches, semanticMatches...))
+	if err != nil {
+		log.Printf("Warning: call graph expansion failed: %v", err)
+	} else {
+		result.CallGraphMatches = callGraphMatches
+	}
+
+	// Step 5: Create relationships in the database
+	allMatches := idl.consolidateMatches(directMatches, semanticMatches, callGraphMatches)
+	createdLinks, err := idl.createMentionsRelationships(ctx, documentID, allMatches)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create relationships: %w", err)
+	}
+
+	result.CreatedLinks = createdLinks
+
+	log.Printf("Intelligent linking complete: %d direct, %d semantic, %d call graph matches, %d links created",
+		len(directMatches), len(semanticMatches), len(callGraphMatches), createdLinks)
+
+	return result, nil
+}
+
+// findDirectMatches finds functions/classes explicitly mentioned in backticks
+func (idl *IntelligentDocumentLinker) findDirectMatches(ctx context.Context, content string) []CodeMatch {
+	var matches []CodeMatch
+
+	// Extract code symbols from content
+	symbols := idl.extractCodeSymbols(content)
+
+	for _, symbol := range symbols {
+		cypher := `
+			MATCH (n:Function|Method|Class)
+			WHERE n.name = $symbol OR n.displayName = $symbol
+			RETURN n.id AS id, labels(n)[0] AS type, n.name AS name,
+				   n.signature AS signature, n.filePath AS filePath
+			LIMIT 5
+		`
+
+		results, err := idl.client.ExecuteQuery(ctx, cypher, map[string]any{
+			"symbol": symbol,
+		})
+		if err != nil {
+			continue
+		}
+
+		for _, record := range results {
+			recordMap := record.AsMap()
+			matches = append(matches, CodeMatch{
+				NodeID:       recordMap["id"].(string),
+				NodeType:     recordMap["type"].(string),
+				Name:         recordMap["name"].(string),
+				Signature:    getStringValue(recordMap, "signature"),
+				FilePath:     getStringValue(recordMap, "filePath"),
+				Confidence:   1.0, // Direct matches have highest confidence
+				MatchReasons: []string{"direct_reference"},
+				CallGraphDepth: 0,
+			})
+		}
+	}
+
+	return matches
+}
+
+// findSemanticMatches finds code using semantic similarity
+func (idl *IntelligentDocumentLinker) findSemanticMatches(ctx context.Context, content string, searchQueries []string) ([]CodeMatch, error) {
+	var allMatches []CodeMatch
+
+	// Generate embedding for the document content
+	docEmbedding, err := idl.semanticAnalyzer.GenerateSemanticEmbedding(ctx, content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate document embedding: %w", err)
+	}
+
+	// Search for similar functions using vector store
+	if idl.vectorStore != nil {
+		vectorResults, err := idl.vectorStore.Query(ctx, VectorQuery{
+			Vector: docEmbedding,
+			Limit:  20,
+		})
+		if err == nil {
+			for _, result := range vectorResults {
+				confidence := idl.calculateSemanticConfidence(result.Score)
+				if confidence > 0.3 {
+					name, _ := result.Metadata["name"].(string)
+					sig, _ := result.Metadata["signature"].(string)
+					fp, _ := result.Metadata["filePath"].(string)
+					nl, _ := result.Metadata["nodeLabel"].(string)
+					allMatches = append(allMatches, CodeMatch{
+						NodeID:         result.ID,
+						NodeType:       nl,
+						Name:           name,
+						Signature:      sig,
+						FilePath:       fp,
+						Confidence:     confidence,
+						MatchReasons:   []string{"vector_similarity"},
+						CallGraphDepth: 0,
+					})
+				}
+			}
+		}
+	}
+
+	// Also search using hybrid search for each query
+	for _, query := range searchQueries[:minInt(5, len(searchQueries))] { // Limit to first 5 queries
+		hybridResults, err := idl.hybridSearch.UnifiedSearch(ctx, query, 10)
+		if err != nil {
+			continue
+		}
+
+		for _, result := range hybridResults.Results {
+			confidence := idl.calculateHybridConfidence(result.CombinedScore, query, getStringValue(result.Node, "name"))
+			if confidence > 0.2 {
+				allMatches = append(allMatches, CodeMatch{
+					NodeID:       getStringValue(result.Node, "id"),
+					NodeType:     strings.Join(result.Labels, ","),
+					Name:         getStringValue(result.Node, "name"),
+					Signature:    getStringValue(result.Node, "signature"),
+					FilePath:     getStringValue(result.Node, "filePath"),
+					Confidence:   confidence,
+					MatchReasons: []string{"hybrid_search", "query:" + query},
+					CallGraphDepth: 0,
+				})
+			}
+		}
+	}
+
+	// Remove duplicates and sort by confidence
+	uniqueMatches := idl.deduplicateMatches(allMatches)
+	sort.Slice(uniqueMatches, func(i, j int) bool {
+		return uniqueMatches[i].Confidence > uniqueMatches[j].Confidence
+	})
+
+	// Return top matches
+	maxResults := 15
+	if len(uniqueMatches) < maxResults {
+		maxResults = len(uniqueMatches)
+	}
+
+	return uniqueMatches[:maxResults], nil
+}
+
+// expandWithCallGraph expands matches using call graph relationships
+func (idl *IntelligentDocumentLinker) expandWithCallGraph(ctx context.Context, baseMatches []CodeMatch) ([]CodeMatch, error) {
+	var expandedMatches []CodeMatch
+
+	for _, match := range baseMatches {
+		if match.Confidence < 0.4 { // Only expand high-confidence matches
+			continue
+		}
+
+		// Find functions called by this function (callees)
+		callees, err := idl.findCallees(ctx, match.NodeID, 2) // Max depth of 2
+		if err == nil {
+			for _, callee := range callees {
+				confidence := match.Confidence * 0.7 * math.Pow(0.8, float64(callee.CallGraphDepth)) // Decay with depth
+				if confidence > 0.2 {
+					callee.Confidence = confidence
+					callee.MatchReasons = append([]string{"call_graph_callee"}, match.MatchReasons...)
+					expandedMatches = append(expandedMatches, callee)
+				}
+			}
+		}
+
+		// Find functions that call this function (callers)
+		callers, err := idl.findCallers(ctx, match.NodeID, 2) // Max depth of 2
+		if err == nil {
+			for _, caller := range callers {
+				confidence := match.Confidence * 0.6 * math.Pow(0.8, float64(caller.CallGraphDepth)) // Slightly lower confidence for callers
+				if confidence > 0.2 {
+					caller.Confidence = confidence
+					caller.MatchReasons = append([]string{"call_graph_caller"}, match.MatchReasons...)
+					expandedMatches = append(expandedMatches, caller)
+				}
+			}
+		}
+	}
+
+	return expandedMatches, nil
+}
+
+// findCallees finds functions called by the given function
+func (idl *IntelligentDocumentLinker) findCallees(ctx context.Context, functionID string, maxDepth int) ([]CodeMatch, error) {
+	cypher := `
+		MATCH (f:Function {id: $functionId})-[:CALLS*1..` + fmt.Sprintf("%d", maxDepth) + `]->(callee:Function)
+		RETURN callee.id AS id, labels(callee)[0] AS type, callee.name AS name,
+			   callee.signature AS signature, callee.filePath AS filePath,
+			   length(()-[:CALLS*]->(callee)) AS depth
+		LIMIT 20
+	`
+
+	results, err := idl.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"functionId": functionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []CodeMatch
+	for _, record := range results {
+		recordMap := record.AsMap()
+		depth := 0
+		if d, ok := recordMap["depth"].(int64); ok {
+			depth = int(d)
+		}
+
+		matches = append(matches, CodeMatch{
+			NodeID:         recordMap["id"].(string),
+			NodeType:       recordMap["type"].(string),
+			Name:           recordMap["name"].(string),
+			Signature:      getStringValue(recordMap, "signature"),
+			FilePath:       getStringValue(recordMap, "filePath"),
+			CallGraphDepth: depth,
+		})
+	}
+
+	return matches, nil
+}
+
+// findCallers finds functions that call the given function
+func (idl *IntelligentDocumentLinker) findCallers(ctx context.Context, functionID string, maxDepth int) ([]CodeMatch, error) {
+	cypher := `
+		MATCH (caller:Function)-[:CALLS*1..` + fmt.Sprintf("%d", maxDepth) + `]->(f:Function {id: $functionId})
+		RETURN caller.id AS id, labels(caller)[0] AS type, caller.name AS name,
+			   caller.signature AS signature, caller.filePath AS filePath,
+			   length((caller)-[:CALLS*]->()) AS depth
+		LIMIT 20
+	`
+
+	results, err := idl.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"functionId": functionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []CodeMatch
+	for _, record := range results {
+		recordMap := record.AsMap()
+		depth := 0
+		if d, ok := recordMap["depth"].(int64); ok {
+			depth = int(d)
+		}
+
+		matches = append(matches, CodeMatch{
+			NodeID:         recordMap["id"].(string),
+			NodeType:       recordMap["type"].(string),
+			Name:           recordMap["name"].(string),
+			Signature:      getStringValue(recordMap, "signature"),
+			FilePath:       getStringValue(recordMap, "filePath"),
+			CallGraphDepth: depth,
+		})
+	}
+
+	return matches, nil
+}
+
+// consolidateMatches removes duplicates and combines matches
+func (idl *IntelligentDocumentLinker) consolidateMatches(directMatches, semanticMatches, callGraphMatches []CodeMatch) []CodeMatch {
+	seen := make(map[string]*CodeMatch)
+
+	// Add all matches, combining reasons for duplicates
+	allMatches := [][]CodeMatch{directMatches, semanticMatches, callGraphMatches}
+	for _, matchGroup := range allMatches {
+		for _, match := range matchGroup {
+			if existing, exists := seen[match.NodeID]; exists {
+				// Combine confidence scores (take the higher one)
+				if match.Confidence > existing.Confidence {
+					existing.Confidence = match.Confidence
+				}
+				// Combine match reasons
+				existing.MatchReasons = append(existing.MatchReasons, match.MatchReasons...)
+			} else {
+				// Create copy to avoid modifying original
+				matchCopy := match
+				seen[match.NodeID] = &matchCopy
+			}
+		}
+	}
+
+	// Convert back to slice
+	var result []CodeMatch
+	for _, match := range seen {
+		result = append(result, *match)
+	}
+
+	// Sort by confidence
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Confidence > result[j].Confidence
+	})
+
+	return result
+}
+
+// createMentionsRelationships creates MENTIONS relationships in the database
+func (idl *IntelligentDocumentLinker) createMentionsRelationships(ctx context.Context, documentID string, matches []CodeMatch) (int, error) {
+	createdLinks := 0
+
+	for _, match := range matches {
+		if match.Confidence < 0.15 { // Skip very low confidence matches
+			continue
+		}
+
+		relProps := map[string]any{
+			"confidence":   match.Confidence,
+			"reasons":      match.MatchReasons,
+			"contextType":  "intelligent_linking",
+			"callGraphDepth": match.CallGraphDepth,
+		}
+
+		_, err := idl.client.CreateRelationship(ctx, documentID, match.NodeID, string(models.MentionsRel), relProps)
+		if err != nil {
+			log.Printf("Warning: failed to create MENTIONS relationship: %v", err)
+			continue
+		}
+
+		createdLinks++
+	}
+
+	return createdLinks, nil
+}
+
+// Helper functions
+
+func (idl *IntelligentDocumentLinker) calculateSemanticConfidence(similarity float64) float64 {
+	// Convert similarity score to confidence (normalize and apply threshold)
+	return math.Max(0, (similarity-0.5)*2) // Convert 0.5-1.0 to 0-1.0
+}
+
+func (idl *IntelligentDocumentLinker) calculateHybridConfidence(score float64, query, functionName string) float64 {
+	// Base confidence from search score
+	confidence := math.Min(score/100.0, 1.0) // Normalize score
+
+	// Boost if query appears in function name
+	if len(query) > 2 && contains(functionName, query) {
+		confidence *= 1.5
+	}
+
+	return math.Min(confidence, 1.0)
+}
+
+func (idl *IntelligentDocumentLinker) deduplicateMatches(matches []CodeMatch) []CodeMatch {
+	seen := make(map[string]bool)
+	var unique []CodeMatch
+
+	for _, match := range matches {
+		if !seen[match.NodeID] {
+			seen[match.NodeID] = true
+			unique = append(unique, match)
+		}
+	}
+
+	return unique
+}
+
+func getStringValue(m map[string]any, key string) string {
+	if val, ok := m[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+func contains(s, substr string) bool {
+	return len(substr) > 0 && len(s) >= len(substr) &&
+		(s == substr ||
+		 (len(s) > len(substr) &&
+		  (s[:len(substr)] == substr ||
+		   s[len(s)-len(substr):] == substr ||
+		   findSubstring(s, substr))))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// extractCodeSymbols finds references to code symbols in the document
+func (idl *IntelligentDocumentLinker) extractCodeSymbols(content string) []string {
+	var symbols []string
+
+	// Pattern for code references in backticks
+	codePattern := regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*(?:\\(\\))?)`")
+	matches := codePattern.FindAllStringSubmatch(content, -1)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			symbol := match[1]
+			// Filter out common words that aren't likely to be code symbols
+			if idl.isLikelyCodeSymbol(symbol) {
+				symbols = append(symbols, symbol)
+			}
+		}
+	}
+
+	return symbols
+}
+
+// isLikelyCodeSymbol determines if a string is likely a code symbol
+func (idl *IntelligentDocumentLinker) isLikelyCodeSymbol(symbol string) bool {
+	// Skip common English words
+	commonWords := []string{"the", "and", "or", "but", "if", "then", "else", "for", "while", "when", "where", "what", "how", "why", "who", "which"}
+	lowerSymbol := strings.ToLower(symbol)
+
+	for _, word := range commonWords {
+		if word == lowerSymbol {
+			return false
+		}
+	}
+
+	// Must start with letter or underscore
+	if len(symbol) == 0 || (!((symbol[0] >= 'A' && symbol[0] <= 'Z') || (symbol[0] >= 'a' && symbol[0] <= 'z') || symbol[0] == '_')) {
+		return false
+	}
+
+	// Should have at least one capital letter (camelCase/PascalCase) or underscore
+	hasCapital := false
+	hasUnderscore := false
+	for _, char := range symbol {
+		if char >= 'A' && char <= 'Z' {
+			hasCapital = true
+		}
+		if char == '_' {
+			hasUnderscore = true
+		}
+	}
+
+	return hasCapital || hasUnderscore || strings.Contains(symbol, ".")
+}

--- a/services/retrieval-go/search/llm_service.go
+++ b/services/retrieval-go/search/llm_service.go
@@ -1,0 +1,180 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// LLMService defines the interface for text generation using LLMs
+type LLMService interface {
+	GenerateText(ctx context.Context, prompt string) (string, error)
+	GenerateTextWithSystemPrompt(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+}
+
+// GeminiLLMService implements LLM text generation using Google's Gemini API
+type GeminiLLMService struct {
+	apiKey     string
+	model      string
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewGeminiLLMService creates a new Gemini LLM service for text generation
+func NewGeminiLLMService(apiKey string) *GeminiLLMService {
+	return &GeminiLLMService{
+		apiKey:  apiKey,
+		model:   "gemini-1.5-flash", // Fast model for code analysis
+		baseURL: "https://generativelanguage.googleapis.com/v1beta/models",
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// WithModel sets a custom Gemini model (e.g., gemini-pro, gemini-1.5-flash)
+func (g *GeminiLLMService) WithModel(model string) *GeminiLLMService {
+	g.model = model
+	return g
+}
+
+// GenerateText generates text from a prompt using Gemini
+func (g *GeminiLLMService) GenerateText(ctx context.Context, prompt string) (string, error) {
+	return g.GenerateTextWithSystemPrompt(ctx, "", prompt)
+}
+
+// GenerateTextWithSystemPrompt generates text with a system prompt and user prompt
+func (g *GeminiLLMService) GenerateTextWithSystemPrompt(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	// Construct the full prompt
+	fullPrompt := userPrompt
+	if systemPrompt != "" {
+		fullPrompt = systemPrompt + "\n\n" + userPrompt
+	}
+
+	// Build the request
+	requestBody := GeminiTextRequest{
+		Contents: []GeminiContent{
+			{
+				Parts: []GeminiPart{
+					{Text: fullPrompt},
+				},
+			},
+		},
+		GenerationConfig: GeminiGenerationConfig{
+			Temperature:     0.2, // Lower temperature for more deterministic outputs
+			TopK:            40,
+			TopP:            0.95,
+			MaxOutputTokens: 1024,
+		},
+		SafetySettings: []GeminiSafetySetting{
+			{
+				Category:  "HARM_CATEGORY_HARASSMENT",
+				Threshold: "BLOCK_MEDIUM_AND_ABOVE",
+			},
+			{
+				Category:  "HARM_CATEGORY_HATE_SPEECH",
+				Threshold: "BLOCK_MEDIUM_AND_ABOVE",
+			},
+			{
+				Category:  "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+				Threshold: "BLOCK_MEDIUM_AND_ABOVE",
+			},
+			{
+				Category:  "HARM_CATEGORY_DANGEROUS_CONTENT",
+				Threshold: "BLOCK_MEDIUM_AND_ABOVE",
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Make the API request
+	url := fmt.Sprintf("%s/%s:generateContent?key=%s", g.baseURL, g.model, g.apiKey)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse the response
+	var response GeminiTextResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Extract the generated text
+	if len(response.Candidates) == 0 {
+		return "", fmt.Errorf("no candidates in response")
+	}
+
+	if len(response.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("no parts in response")
+	}
+
+	return response.Candidates[0].Content.Parts[0].Text, nil
+}
+
+// Gemini API request/response structures
+
+type GeminiTextRequest struct {
+	Contents         []GeminiContent          `json:"contents"`
+	GenerationConfig GeminiGenerationConfig   `json:"generationConfig"`
+	SafetySettings   []GeminiSafetySetting    `json:"safetySettings"`
+}
+
+type GeminiContent struct {
+	Parts []GeminiPart `json:"parts"`
+	Role  string       `json:"role,omitempty"`
+}
+
+type GeminiPart struct {
+	Text string `json:"text"`
+}
+
+type GeminiGenerationConfig struct {
+	Temperature     float64 `json:"temperature"`
+	TopK            int     `json:"topK"`
+	TopP            float64 `json:"topP"`
+	MaxOutputTokens int     `json:"maxOutputTokens"`
+}
+
+type GeminiSafetySetting struct {
+	Category  string `json:"category"`
+	Threshold string `json:"threshold"`
+}
+
+type GeminiTextResponse struct {
+	Candidates []GeminiCandidate `json:"candidates"`
+}
+
+type GeminiCandidate struct {
+	Content       GeminiContent `json:"content"`
+	FinishReason  string        `json:"finishReason"`
+	SafetyRatings []struct {
+		Category    string `json:"category"`
+		Probability string `json:"probability"`
+	} `json:"safetyRatings"`
+}

--- a/services/retrieval-go/search/llm_validator.go
+++ b/services/retrieval-go/search/llm_validator.go
@@ -1,0 +1,518 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ValidationResult represents the result of LLM validation
+type ValidationResult struct {
+	IsMatch     bool    `json:"isMatch"`
+	Confidence  float64 `json:"confidence"`
+	Reasoning   string  `json:"reasoning"`
+	Explanation string  `json:"explanation"`
+}
+
+// FeatureCodeMatch represents a potential match between a feature and code
+type FeatureCodeMatch struct {
+	FeatureID          string         `json:"featureId"`
+	FeatureName        string         `json:"featureName"`
+	FeatureDescription string         `json:"featureDescription"`
+	CodeSubgraph       *CodeSubgraph  `json:"codeSubgraph"`
+	InitialConfidence  float64        `json:"initialConfidence"`
+	ValidationResult   *ValidationResult `json:"validationResult,omitempty"`
+}
+
+// LLMValidator uses LLM to validate whether code implements a feature
+type LLMValidator struct {
+	embeddingService EmbeddingService
+	llmService       LLMService
+}
+
+// NewLLMValidator creates a new LLM validator
+func NewLLMValidator(embeddingService EmbeddingService) *LLMValidator {
+	return &LLMValidator{
+		embeddingService: embeddingService,
+		llmService:       nil, // Optional LLM service for text generation
+	}
+}
+
+// WithLLMService sets the LLM service for validation
+func (lv *LLMValidator) WithLLMService(llmService LLMService) *LLMValidator {
+	lv.llmService = llmService
+	return lv
+}
+
+// ValidateFeatureImplementation determines if a code subgraph implements a given feature
+func (lv *LLMValidator) ValidateFeatureImplementation(ctx context.Context, match *FeatureCodeMatch) error {
+	log.Printf("Validating if code subgraph implements feature: %s", match.FeatureName)
+
+	// Create a validation prompt for the LLM
+	prompt := lv.createValidationPrompt(match)
+
+	var validation *ValidationResult
+
+	// Try to use LLM service if available
+	if lv.llmService != nil {
+		log.Println("Using LLM service for validation")
+		llmValidation, err := lv.performLLMValidation(ctx, match, prompt)
+		if err != nil {
+			log.Printf("Warning: LLM validation failed, falling back to heuristic: %v", err)
+			validation = lv.performHeuristicValidation(match)
+		} else {
+			validation = llmValidation
+		}
+	} else {
+		// Use heuristic-based validation
+		log.Println("No LLM service available, using heuristic validation")
+		validation = lv.performHeuristicValidation(match)
+
+		// Try to enhance validation using embedding similarity
+		enhancedValidation, err := lv.enhanceValidationWithEmbeddings(ctx, match, prompt)
+		if err != nil {
+			log.Printf("Warning: enhanced validation failed, using heuristic result: %v", err)
+		} else {
+			validation = enhancedValidation
+		}
+	}
+
+	match.ValidationResult = validation
+
+	log.Printf("Validation result for %s: %t (confidence: %.3f)",
+		match.FeatureName, validation.IsMatch, validation.Confidence)
+
+	return nil
+}
+
+// ValidateBatch validates multiple feature-code matches
+func (lv *LLMValidator) ValidateBatch(ctx context.Context, matches []*FeatureCodeMatch) error {
+	for _, match := range matches {
+		if err := lv.ValidateFeatureImplementation(ctx, match); err != nil {
+			return fmt.Errorf("validation failed for feature %s: %w", match.FeatureName, err)
+		}
+	}
+	return nil
+}
+
+// createValidationPrompt creates a prompt for LLM validation
+func (lv *LLMValidator) createValidationPrompt(match *FeatureCodeMatch) string {
+	var promptBuilder strings.Builder
+
+	promptBuilder.WriteString("TASK: Determine if the following code logic implements the specified feature requirement.\n\n")
+
+	// Feature information
+	promptBuilder.WriteString("FEATURE REQUIREMENT:\n")
+	promptBuilder.WriteString(fmt.Sprintf("Name: %s\n", match.FeatureName))
+	promptBuilder.WriteString(fmt.Sprintf("Description: %s\n\n", match.FeatureDescription))
+
+	// Code information
+	promptBuilder.WriteString("CODE IMPLEMENTATION:\n")
+	if match.CodeSubgraph != nil {
+		promptBuilder.WriteString(fmt.Sprintf("Entry Point: %s\n", match.CodeSubgraph.EntryPoint.Name))
+		if match.CodeSubgraph.Summary != "" {
+			promptBuilder.WriteString(fmt.Sprintf("Code Summary: %s\n", match.CodeSubgraph.Summary))
+		}
+
+		promptBuilder.WriteString(fmt.Sprintf("Functions Involved: %d\n", len(match.CodeSubgraph.Functions)))
+
+		// Include key function signatures
+		promptBuilder.WriteString("Key Functions:\n")
+		for i, fn := range match.CodeSubgraph.Functions {
+			if i >= 5 { // Limit to first 5 functions
+				promptBuilder.WriteString(fmt.Sprintf("... and %d more\n", len(match.CodeSubgraph.Functions)-i))
+				break
+			}
+			promptBuilder.WriteString(fmt.Sprintf("- %s\n", fn.Signature))
+			if fn.DocString != "" {
+				promptBuilder.WriteString(fmt.Sprintf("  Doc: %s\n", fn.DocString))
+			}
+		}
+	}
+
+	promptBuilder.WriteString("\nQUESTION: Does this code logic accurately implement the specified feature requirement?\n")
+	promptBuilder.WriteString("Consider:\n")
+	promptBuilder.WriteString("1. Does the code's purpose align with the feature's intent?\n")
+	promptBuilder.WriteString("2. Are the key behaviors described in the feature present in the code?\n")
+	promptBuilder.WriteString("3. Is this a primary implementation or just tangentially related?\n\n")
+
+	promptBuilder.WriteString("RESPOND: Yes/No with brief reasoning.\n")
+
+	return promptBuilder.String()
+}
+
+// performLLMValidation uses LLM to validate if code implements a feature
+func (lv *LLMValidator) performLLMValidation(ctx context.Context, match *FeatureCodeMatch, prompt string) (*ValidationResult, error) {
+	// Ask the LLM to validate the match
+	systemPrompt := "You are a code analysis expert. Your task is to determine if a given code implementation matches a feature requirement. " +
+		"Respond with a JSON object containing: {\"isMatch\": true/false, \"confidence\": 0.0-1.0, \"reasoning\": \"brief explanation\"}. " +
+		"Be concise and focus on semantic alignment between the feature intent and code behavior."
+
+	response, err := lv.llmService.GenerateTextWithSystemPrompt(ctx, systemPrompt, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("LLM validation request failed: %w", err)
+	}
+
+	// Parse the LLM response
+	validation, err := lv.parseLLMValidationResponse(response)
+	if err != nil {
+		log.Printf("Warning: failed to parse LLM response, using heuristic fallback: %v", err)
+		return lv.performHeuristicValidation(match), nil
+	}
+
+	// Add detailed explanation
+	validation.Explanation = fmt.Sprintf("LLM validation: %s (confidence: %.3f)", validation.Reasoning, validation.Confidence)
+
+	log.Printf("LLM validation result: isMatch=%t, confidence=%.3f, reasoning=%s",
+		validation.IsMatch, validation.Confidence, validation.Reasoning)
+
+	return validation, nil
+}
+
+// parseLLMValidationResponse parses the LLM's validation response
+func (lv *LLMValidator) parseLLMValidationResponse(response string) (*ValidationResult, error) {
+	// Try to extract JSON from the response
+	response = strings.TrimSpace(response)
+
+	// Find JSON object in response (LLM might add extra text)
+	startIdx := strings.Index(response, "{")
+	endIdx := strings.LastIndex(response, "}")
+
+	if startIdx == -1 || endIdx == -1 {
+		return nil, fmt.Errorf("no JSON object found in response")
+	}
+
+	jsonStr := response[startIdx : endIdx+1]
+
+	// Parse the JSON
+	var result struct {
+		IsMatch    bool    `json:"isMatch"`
+		Confidence float64 `json:"confidence"`
+		Reasoning  string  `json:"reasoning"`
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		// Try a more lenient parsing approach
+		return lv.parseTextualResponse(response)
+	}
+
+	// Validate confidence bounds
+	if result.Confidence < 0.0 {
+		result.Confidence = 0.0
+	} else if result.Confidence > 1.0 {
+		result.Confidence = 1.0
+	}
+
+	return &ValidationResult{
+		IsMatch:    result.IsMatch,
+		Confidence: result.Confidence,
+		Reasoning:  result.Reasoning,
+	}, nil
+}
+
+// parseTextualResponse attempts to parse non-JSON LLM responses
+func (lv *LLMValidator) parseTextualResponse(response string) (*ValidationResult, error) {
+	responseLower := strings.ToLower(response)
+
+	// Check for affirmative indicators
+	isMatch := strings.Contains(responseLower, "yes") ||
+		strings.Contains(responseLower, "match") ||
+		strings.Contains(responseLower, "implements") ||
+		strings.Contains(responseLower, "correct") ||
+		strings.Contains(responseLower, "accurate")
+
+	// Check for negative indicators
+	isNegative := strings.Contains(responseLower, "no") ||
+		strings.Contains(responseLower, "does not") ||
+		strings.Contains(responseLower, "doesn't") ||
+		strings.Contains(responseLower, "incorrect") ||
+		strings.Contains(responseLower, "unrelated")
+
+	if isNegative {
+		isMatch = false
+	}
+
+	// Extract confidence if mentioned
+	confidence := 0.7 // Default moderate confidence for textual responses
+
+	// Look for percentage or decimal confidence
+	confidencePattern := regexp.MustCompile(`(\d+)%|confidence[:\s]+([0-9.]+)`)
+	matches := confidencePattern.FindStringSubmatch(response)
+	if len(matches) > 1 {
+		if matches[1] != "" {
+			// Percentage format
+			if pct, err := strconv.Atoi(matches[1]); err == nil {
+				confidence = float64(pct) / 100.0
+			}
+		} else if matches[2] != "" {
+			// Decimal format
+			if conf, err := strconv.ParseFloat(matches[2], 64); err == nil {
+				confidence = conf
+				if confidence > 1.0 {
+					confidence = confidence / 100.0
+				}
+			}
+		}
+	}
+
+	return &ValidationResult{
+		IsMatch:    isMatch,
+		Confidence: confidence,
+		Reasoning:  strings.TrimSpace(response),
+	}, nil
+}
+
+// performHeuristicValidation uses rule-based validation when LLM is unavailable
+func (lv *LLMValidator) performHeuristicValidation(match *FeatureCodeMatch) *ValidationResult {
+	// Start with initial confidence from vector similarity
+	confidence := match.InitialConfidence
+
+	// Apply heuristic rules to adjust confidence
+	var reasons []string
+
+	if match.CodeSubgraph != nil {
+		// Rule 1: Check keyword overlap between feature and code
+		keywordOverlap := lv.calculateKeywordOverlap(match.FeatureDescription, match.CodeSubgraph)
+		if keywordOverlap > 0.3 {
+			confidence += 0.1
+			reasons = append(reasons, fmt.Sprintf("high keyword overlap (%.2f)", keywordOverlap))
+		} else if keywordOverlap < 0.1 {
+			confidence -= 0.1
+			reasons = append(reasons, "low keyword overlap")
+		}
+
+		// Rule 2: Consider subgraph size (too small might be incomplete, too large might be unfocused)
+		functionCount := len(match.CodeSubgraph.Functions)
+		if functionCount >= 3 && functionCount <= 10 {
+			confidence += 0.05
+			reasons = append(reasons, "appropriate subgraph size")
+		} else if functionCount > 15 {
+			confidence -= 0.1
+			reasons = append(reasons, "subgraph too large")
+		}
+
+		// Rule 3: Check for meaningful function names
+		meaningfulNames := lv.countMeaningfulFunctionNames(match.CodeSubgraph)
+		if meaningfulNames > 0.5 {
+			confidence += 0.05
+			reasons = append(reasons, "meaningful function names")
+		}
+
+		// Rule 4: Check for documentation alignment
+		if lv.hasAlignedDocumentation(match.FeatureDescription, match.CodeSubgraph) {
+			confidence += 0.1
+			reasons = append(reasons, "documentation alignment")
+		}
+	}
+
+	// Apply confidence bounds
+	if confidence > 1.0 {
+		confidence = 1.0
+	} else if confidence < 0.0 {
+		confidence = 0.0
+	}
+
+	// Determine if it's a match based on confidence threshold
+	isMatch := confidence >= 0.6
+
+	reasoning := strings.Join(reasons, "; ")
+	if reasoning == "" {
+		reasoning = "vector similarity analysis"
+	}
+
+	explanation := fmt.Sprintf("Heuristic validation based on %s. Confidence: %.3f", reasoning, confidence)
+
+	return &ValidationResult{
+		IsMatch:     isMatch,
+		Confidence:  confidence,
+		Reasoning:   reasoning,
+		Explanation: explanation,
+	}
+}
+
+// enhanceValidationWithEmbeddings uses embedding similarity to improve validation
+func (lv *LLMValidator) enhanceValidationWithEmbeddings(ctx context.Context, match *FeatureCodeMatch, prompt string) (*ValidationResult, error) {
+	// Generate embeddings for both feature and code summary
+	featureEmbedding, err := lv.embeddingService.GenerateEmbedding(ctx, match.FeatureDescription)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate feature embedding: %w", err)
+	}
+
+	var codeText string
+	if match.CodeSubgraph != nil && match.CodeSubgraph.Summary != "" {
+		codeText = match.CodeSubgraph.Summary
+	} else {
+		// Fallback to function names and signatures
+		var parts []string
+		if match.CodeSubgraph != nil {
+			for _, fn := range match.CodeSubgraph.Functions {
+				parts = append(parts, fn.Name+" "+fn.Signature)
+			}
+		}
+		codeText = strings.Join(parts, " ")
+	}
+
+	codeEmbedding, err := lv.embeddingService.GenerateEmbedding(ctx, codeText)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate code embedding: %w", err)
+	}
+
+	// Calculate cosine similarity
+	similarity := lv.cosineSimilarity(featureEmbedding, codeEmbedding)
+
+	// Use the higher of vector similarity or initial confidence
+	enhancedConfidence := similarity
+	if match.InitialConfidence > enhancedConfidence {
+		enhancedConfidence = match.InitialConfidence
+	}
+
+	// Apply enhancement boost
+	enhancedConfidence += 0.1
+
+	// Perform heuristic validation with enhanced confidence
+	heuristicResult := lv.performHeuristicValidation(match)
+
+	// Combine results
+	finalConfidence := (enhancedConfidence + heuristicResult.Confidence) / 2
+	isMatch := finalConfidence >= 0.6
+
+	explanation := fmt.Sprintf("Enhanced validation: vector similarity %.3f, heuristic confidence %.3f, final %.3f",
+		similarity, heuristicResult.Confidence, finalConfidence)
+
+	return &ValidationResult{
+		IsMatch:     isMatch,
+		Confidence:  finalConfidence,
+		Reasoning:   "enhanced embedding similarity + " + heuristicResult.Reasoning,
+		Explanation: explanation,
+	}, nil
+}
+
+// calculateKeywordOverlap calculates overlap between feature description and code
+func (lv *LLMValidator) calculateKeywordOverlap(featureDesc string, subgraph *CodeSubgraph) float64 {
+	featureWords := lv.extractKeywords(featureDesc)
+
+	var codeWords []string
+	for _, fn := range subgraph.Functions {
+		codeWords = append(codeWords, lv.extractKeywords(fn.Name)...)
+		codeWords = append(codeWords, lv.extractKeywords(fn.DocString)...)
+	}
+
+	if len(featureWords) == 0 || len(codeWords) == 0 {
+		return 0.0
+	}
+
+	overlap := 0
+	codeWordSet := make(map[string]bool)
+	for _, word := range codeWords {
+		codeWordSet[word] = true
+	}
+
+	for _, word := range featureWords {
+		if codeWordSet[word] {
+			overlap++
+		}
+	}
+
+	return float64(overlap) / float64(len(featureWords))
+}
+
+// extractKeywords extracts meaningful keywords from text
+func (lv *LLMValidator) extractKeywords(text string) []string {
+	text = strings.ToLower(text)
+	words := strings.Fields(text)
+
+	var keywords []string
+	stopWords := map[string]bool{
+		"the": true, "and": true, "or": true, "but": true, "in": true, "on": true,
+		"at": true, "to": true, "for": true, "of": true, "with": true, "by": true,
+		"is": true, "are": true, "was": true, "were": true, "be": true, "been": true,
+		"have": true, "has": true, "had": true, "do": true, "does": true, "did": true,
+		"will": true, "would": true, "could": true, "should": true, "can": true,
+		"this": true, "that": true, "these": true, "those": true, "a": true, "an": true,
+	}
+
+	for _, word := range words {
+		// Remove punctuation
+		word = strings.Trim(word, ".,!?;:()[]{}\"'")
+		if len(word) > 2 && !stopWords[word] {
+			keywords = append(keywords, word)
+		}
+	}
+
+	return keywords
+}
+
+// countMeaningfulFunctionNames calculates the ratio of functions with meaningful names
+func (lv *LLMValidator) countMeaningfulFunctionNames(subgraph *CodeSubgraph) float64 {
+	meaningful := 0
+	total := len(subgraph.Functions)
+
+	for _, fn := range subgraph.Functions {
+		name := strings.ToLower(fn.Name)
+		// Check if name contains meaningful words (not just generic patterns)
+		if strings.Contains(name, "get") || strings.Contains(name, "set") ||
+		   strings.Contains(name, "create") || strings.Contains(name, "update") ||
+		   strings.Contains(name, "delete") || strings.Contains(name, "process") ||
+		   strings.Contains(name, "handle") || strings.Contains(name, "validate") ||
+		   strings.Contains(name, "generate") || strings.Contains(name, "calculate") {
+			meaningful++
+		}
+	}
+
+	if total == 0 {
+		return 0.0
+	}
+
+	return float64(meaningful) / float64(total)
+}
+
+// hasAlignedDocumentation checks if function documentation aligns with feature description
+func (lv *LLMValidator) hasAlignedDocumentation(featureDesc string, subgraph *CodeSubgraph) bool {
+	featureKeywords := lv.extractKeywords(featureDesc)
+
+	for _, fn := range subgraph.Functions {
+		if fn.DocString != "" {
+			docKeywords := lv.extractKeywords(fn.DocString)
+			overlap := 0
+			for _, fkw := range featureKeywords {
+				for _, dkw := range docKeywords {
+					if fkw == dkw {
+						overlap++
+						break
+					}
+				}
+			}
+
+			// If any function has good documentation overlap, consider it aligned
+			if len(featureKeywords) > 0 && float64(overlap)/float64(len(featureKeywords)) > 0.2 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// cosineSimilarity calculates cosine similarity between two vectors
+func (lv *LLMValidator) cosineSimilarity(a, b []float64) float64 {
+	if len(a) != len(b) {
+		return 0.0
+	}
+
+	var dotProduct, normA, normB float64
+	for i := 0; i < len(a); i++ {
+		dotProduct += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+
+	if normA == 0 || normB == 0 {
+		return 0.0
+	}
+
+	return dotProduct / (normA * normB)
+}

--- a/services/retrieval-go/search/semantic_analyzer.go
+++ b/services/retrieval-go/search/semantic_analyzer.go
@@ -1,0 +1,298 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/libs/core-models-go"
+)
+
+// SemanticDocumentAnalyzer uses LLM to understand document content and extract technical concepts
+type SemanticDocumentAnalyzer struct {
+	embeddingService EmbeddingService
+}
+
+// NewSemanticDocumentAnalyzer creates a new semantic document analyzer
+func NewSemanticDocumentAnalyzer(embeddingService EmbeddingService) *SemanticDocumentAnalyzer {
+	return &SemanticDocumentAnalyzer{
+		embeddingService: embeddingService,
+	}
+}
+
+// TechnicalConcept represents a technical concept extracted from documentation
+type TechnicalConcept struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Keywords    []string `json:"keywords"`
+	Confidence  float64  `json:"confidence"`
+	Context     string   `json:"context"`
+}
+
+// SemanticAnalysisResult contains the results of analyzing a document
+type SemanticAnalysisResult struct {
+	Document         *models.Document    `json:"document"`
+	TechnicalConcepts []TechnicalConcept `json:"technicalConcepts"`
+	FunctionalAreas  []string           `json:"functionalAreas"`
+	SearchQueries    []string           `json:"searchQueries"`
+	Embedding        []float64          `json:"embedding"`
+}
+
+// AnalyzeDocument performs semantic analysis on a document
+func (sda *SemanticDocumentAnalyzer) AnalyzeDocument(ctx context.Context, doc *models.Document) (*SemanticAnalysisResult, error) {
+	log.Printf("Starting semantic analysis for document: %s", doc.Title)
+
+	// Generate embedding for the entire document
+	embedding, err := sda.embeddingService.GenerateEmbedding(ctx, doc.Content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate document embedding: %w", err)
+	}
+
+	// Extract technical concepts using heuristic analysis
+	concepts := sda.extractTechnicalConcepts(doc.Content)
+
+	// Identify functional areas
+	functionalAreas := sda.identifyFunctionalAreas(doc.Content, concepts)
+
+	// Generate search queries for finding related code
+	searchQueries := sda.generateSearchQueries(concepts, functionalAreas)
+
+	result := &SemanticAnalysisResult{
+		Document:         doc,
+		TechnicalConcepts: concepts,
+		FunctionalAreas:  functionalAreas,
+		SearchQueries:    searchQueries,
+		Embedding:        embedding,
+	}
+
+	log.Printf("Semantic analysis complete: %d concepts, %d functional areas, %d search queries",
+		len(concepts), len(functionalAreas), len(searchQueries))
+
+	return result, nil
+}
+
+// extractTechnicalConcepts identifies technical concepts from document content
+func (sda *SemanticDocumentAnalyzer) extractTechnicalConcepts(content string) []TechnicalConcept {
+	var concepts []TechnicalConcept
+
+	// Technical patterns to look for
+	patterns := map[string][]string{
+		"authentication": {"auth", "login", "token", "jwt", "oauth", "credential", "session", "verify"},
+		"database":       {"db", "sql", "query", "schema", "migration", "transaction", "index", "table"},
+		"api":           {"endpoint", "rest", "graphql", "http", "request", "response", "route", "handler"},
+		"validation":    {"validate", "check", "verify", "sanitize", "format", "rules", "constraint"},
+		"caching":       {"cache", "redis", "memcache", "ttl", "expire", "invalidate", "store"},
+		"messaging":     {"queue", "pub", "sub", "message", "event", "notification", "broker"},
+		"security":      {"encrypt", "decrypt", "hash", "secure", "permission", "access", "role"},
+		"monitoring":    {"log", "metric", "trace", "monitor", "alert", "health", "status"},
+		"storage":       {"file", "upload", "download", "s3", "blob", "storage", "bucket"},
+		"processing":    {"process", "transform", "parse", "convert", "format", "pipeline"},
+	}
+
+	contentLower := strings.ToLower(content)
+
+	for concept, keywords := range patterns {
+		matches := 0
+		foundKeywords := []string{}
+		context := ""
+
+		for _, keyword := range keywords {
+			if strings.Contains(contentLower, keyword) {
+				matches++
+				foundKeywords = append(foundKeywords, keyword)
+
+				// Extract context around the keyword
+				if context == "" {
+					context = sda.extractContextAroundKeyword(content, keyword)
+				}
+			}
+		}
+
+		if matches > 0 {
+			confidence := float64(matches) / float64(len(keywords))
+			concepts = append(concepts, TechnicalConcept{
+				Name:        concept,
+				Description: fmt.Sprintf("Technical concept related to %s", concept),
+				Keywords:    foundKeywords,
+				Confidence:  confidence,
+				Context:     context,
+			})
+		}
+	}
+
+	// Sort by confidence
+	for i := 0; i < len(concepts); i++ {
+		for j := i + 1; j < len(concepts); j++ {
+			if concepts[i].Confidence < concepts[j].Confidence {
+				concepts[i], concepts[j] = concepts[j], concepts[i]
+			}
+		}
+	}
+
+	return concepts
+}
+
+// extractContextAroundKeyword extracts surrounding text around a keyword
+func (sda *SemanticDocumentAnalyzer) extractContextAroundKeyword(content, keyword string) string {
+	contentLower := strings.ToLower(content)
+	index := strings.Index(contentLower, keyword)
+	if index == -1 {
+		return ""
+	}
+
+	// Extract 100 characters before and after
+	start := index - 50
+	if start < 0 {
+		start = 0
+	}
+	end := index + len(keyword) + 50
+	if end > len(content) {
+		end = len(content)
+	}
+
+	context := content[start:end]
+	// Clean up and return
+	return strings.TrimSpace(strings.ReplaceAll(context, "\n", " "))
+}
+
+// identifyFunctionalAreas categorizes the document into functional areas
+func (sda *SemanticDocumentAnalyzer) identifyFunctionalAreas(content string, concepts []TechnicalConcept) []string {
+	areas := make(map[string]bool)
+
+	// Map concepts to functional areas
+	conceptToArea := map[string]string{
+		"authentication": "security",
+		"security":       "security",
+		"database":       "data",
+		"storage":        "data",
+		"api":           "interface",
+		"messaging":     "communication",
+		"monitoring":    "observability",
+		"validation":    "business_logic",
+		"processing":    "business_logic",
+		"caching":       "performance",
+	}
+
+	for _, concept := range concepts {
+		if area, exists := conceptToArea[concept.Name]; exists {
+			areas[area] = true
+		}
+	}
+
+	// Convert to slice
+	var result []string
+	for area := range areas {
+		result = append(result, area)
+	}
+
+	// Add additional areas based on content analysis
+	contentLower := strings.ToLower(content)
+	if strings.Contains(contentLower, "user") || strings.Contains(contentLower, "customer") {
+		result = append(result, "user_management")
+	}
+	if strings.Contains(contentLower, "report") || strings.Contains(contentLower, "analytics") {
+		result = append(result, "reporting")
+	}
+	if strings.Contains(contentLower, "config") || strings.Contains(contentLower, "setting") {
+		result = append(result, "configuration")
+	}
+
+	return result
+}
+
+// generateSearchQueries creates search queries for finding related code
+func (sda *SemanticDocumentAnalyzer) generateSearchQueries(concepts []TechnicalConcept, functionalAreas []string) []string {
+	var queries []string
+
+	// Generate queries from concepts
+	for _, concept := range concepts {
+		if concept.Confidence > 0.3 { // Only use high-confidence concepts
+			queries = append(queries, concept.Name)
+
+			// Add specific keywords as separate queries
+			for _, keyword := range concept.Keywords {
+				if len(keyword) > 3 { // Skip very short keywords
+					queries = append(queries, keyword)
+				}
+			}
+		}
+	}
+
+	// Generate queries from functional areas
+	for _, area := range functionalAreas {
+		queries = append(queries, area)
+	}
+
+	// Add common programming patterns
+	commonPatterns := []string{"handler", "service", "manager", "client", "controller", "processor"}
+	for _, pattern := range commonPatterns {
+		queries = append(queries, pattern)
+	}
+
+	// Remove duplicates and return
+	seen := make(map[string]bool)
+	var uniqueQueries []string
+	for _, query := range queries {
+		if !seen[query] {
+			seen[query] = true
+			uniqueQueries = append(uniqueQueries, query)
+		}
+	}
+
+	return uniqueQueries
+}
+
+// AnalyzeForCodeMapping specifically analyzes a document for mapping to code symbols
+func (sda *SemanticDocumentAnalyzer) AnalyzeForCodeMapping(ctx context.Context, content string) ([]string, []TechnicalConcept, error) {
+	// Create a temporary document for analysis
+	doc := &models.Document{
+		Title:   "Analysis Target",
+		Content: content,
+	}
+
+	result, err := sda.AnalyzeDocument(ctx, doc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result.SearchQueries, result.TechnicalConcepts, nil
+}
+
+// GenerateSemanticEmbedding creates an embedding specifically for semantic search
+func (sda *SemanticDocumentAnalyzer) GenerateSemanticEmbedding(ctx context.Context, content string) ([]float64, error) {
+	// Preprocess content to focus on technical terms
+	processedContent := sda.preprocessForEmbedding(content)
+
+	return sda.embeddingService.GenerateEmbedding(ctx, processedContent)
+}
+
+// preprocessForEmbedding preprocesses text to focus on technical concepts
+func (sda *SemanticDocumentAnalyzer) preprocessForEmbedding(content string) string {
+	// Extract key technical sentences and combine them
+	sentences := strings.Split(content, ".")
+	var technicalSentences []string
+
+	technicalKeywords := []string{
+		"function", "method", "class", "interface", "service", "api", "endpoint",
+		"database", "query", "auth", "validate", "process", "handle", "manage",
+		"create", "update", "delete", "get", "post", "put", "request", "response",
+	}
+
+	for _, sentence := range sentences {
+		sentenceLower := strings.ToLower(sentence)
+		for _, keyword := range technicalKeywords {
+			if strings.Contains(sentenceLower, keyword) {
+				technicalSentences = append(technicalSentences, strings.TrimSpace(sentence))
+				break
+			}
+		}
+	}
+
+	if len(technicalSentences) == 0 {
+		// Fallback to original content if no technical sentences found
+		return content
+	}
+
+	return strings.Join(technicalSentences, ". ")
+}

--- a/services/retrieval-go/search/vector_search.go
+++ b/services/retrieval-go/search/vector_search.go
@@ -1,0 +1,356 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/context-maximiser/code-graph/libs/neo4j-client-go"
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// VectorSearchManager handles vector-based semantic search operations
+type VectorSearchManager struct {
+	client *neo4j.Client
+}
+
+// NewVectorSearchManager creates a new vector search manager
+func NewVectorSearchManager(client *neo4j.Client) *VectorSearchManager {
+	return &VectorSearchManager{
+		client: client,
+	}
+}
+
+// VectorIndexConfig represents configuration for vector indexes
+type VectorIndexConfig struct {
+	Name               string `json:"name"`
+	NodeLabel          string `json:"nodeLabel"`
+	Property           string `json:"property"`
+	Dimensions         int    `json:"dimensions"`
+	SimilarityFunction string `json:"similarityFunction"` // "cosine" or "euclidean"
+}
+
+// VectorSearchResult represents a vector search result with similarity score
+type VectorSearchResult struct {
+	Node  map[string]interface{} `json:"node"`
+	Score float64                `json:"score"`
+}
+
+// VectorSearchResponse contains vector search results and metadata
+type VectorSearchResponse struct {
+	Results     []VectorSearchResult `json:"results"`
+	QueryVector []float64            `json:"queryVector"`
+	IndexUsed   string               `json:"indexUsed"`
+	Count       int                  `json:"count"`
+}
+
+// CreateVectorIndexes creates all necessary vector indexes for CodeGraph
+func (vsm *VectorSearchManager) CreateVectorIndexes(ctx context.Context) error {
+	indexes := []VectorIndexConfig{
+		// Legacy 384-dimension indexes for existing mock embeddings
+		{
+			Name:               "function_embeddings_384",
+			NodeLabel:          "Function",
+			Property:           "embedding",
+			Dimensions:         384, // sentence-transformers/all-MiniLM-L6-v2
+			SimilarityFunction: "cosine",
+		},
+		{
+			Name:               "document_embeddings_384",
+			NodeLabel:          "Document",
+			Property:           "embedding",
+			Dimensions:         384,
+			SimilarityFunction: "cosine",
+		},
+		{
+			Name:               "feature_embeddings_384",
+			NodeLabel:          "Feature",
+			Property:           "embedding",
+			Dimensions:         384,
+			SimilarityFunction: "cosine",
+		},
+		{
+			Name:               "class_embeddings_384",
+			NodeLabel:          "Class",
+			Property:           "embedding",
+			Dimensions:         384,
+			SimilarityFunction: "cosine",
+		},
+		// New 768-dimension indexes for Gemini embeddings
+		{
+			Name:               "function_embeddings_768",
+			NodeLabel:          "Function",
+			Property:           "embedding",
+			Dimensions:         768, // Gemini embedding-001 (with dimension override)
+			SimilarityFunction: "cosine",
+		},
+		{
+			Name:               "document_embeddings_768",
+			NodeLabel:          "Document",
+			Property:           "embedding",
+			Dimensions:         768,
+			SimilarityFunction: "cosine",
+		},
+		{
+			Name:               "feature_embeddings_768",
+			NodeLabel:          "Feature",
+			Property:           "embedding",
+			Dimensions:         768,
+			SimilarityFunction: "cosine",
+		},
+		{
+			Name:               "class_embeddings_768",
+			NodeLabel:          "Class",
+			Property:           "embedding",
+			Dimensions:         768,
+			SimilarityFunction: "cosine",
+		},
+	}
+
+	for _, index := range indexes {
+		if err := vsm.createVectorIndex(ctx, index); err != nil {
+			log.Printf("Warning: failed to create vector index %s: %v", index.Name, err)
+			// Continue with other indexes even if one fails
+		} else {
+			log.Printf("✓ Created vector index: %s", index.Name)
+		}
+	}
+
+	return nil
+}
+
+// createVectorIndex creates a single vector index
+func (vsm *VectorSearchManager) createVectorIndex(ctx context.Context, config VectorIndexConfig) error {
+	query := fmt.Sprintf(`
+		CREATE VECTOR INDEX %s IF NOT EXISTS
+		FOR (n:%s)
+		ON n.%s
+		OPTIONS {
+			indexConfig: {
+				` + "`vector.dimensions`" + `: %d,
+				` + "`vector.similarity_function`" + `: '%s'
+			}
+		}
+	`, config.Name, config.NodeLabel, config.Property, config.Dimensions, config.SimilarityFunction)
+
+	_, err := vsm.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create vector index %s: %w", config.Name, err)
+	}
+
+	return nil
+}
+
+// VectorSearch performs semantic search using vector similarity
+func (vsm *VectorSearchManager) VectorSearch(ctx context.Context, indexName string, queryVector []float64, limit int) (*VectorSearchResponse, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	query := fmt.Sprintf(`
+		CALL db.index.vector.queryNodes($indexName, $limit, $queryVector)
+		YIELD node, score
+		RETURN node, score
+		ORDER BY score DESC
+	`)
+
+	params := map[string]any{
+		"indexName":   indexName,
+		"limit":       limit,
+		"queryVector": queryVector,
+	}
+
+	results, err := vsm.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform vector search: %w", err)
+	}
+
+	var searchResults []VectorSearchResult
+	for _, record := range results {
+		recordMap := record.AsMap()
+
+		node, ok := recordMap["node"]
+		if !ok {
+			continue
+		}
+
+		score, ok := recordMap["score"].(float64)
+		if !ok {
+			score = 0.0
+		}
+
+		// Convert node to map for JSON serialization
+		nodeMap := make(map[string]interface{})
+		if nodeObj, ok := node.(neo4jdriver.Node); ok {
+			// Extract all properties from the Neo4j Node object
+			nodeMap = nodeObj.Props
+		} else if nodeData, ok := node.(map[string]interface{}); ok {
+			nodeMap = nodeData
+		}
+
+		searchResults = append(searchResults, VectorSearchResult{
+			Node:  nodeMap,
+			Score: score,
+		})
+	}
+
+	return &VectorSearchResponse{
+		Results:     searchResults,
+		QueryVector: queryVector,
+		IndexUsed:   indexName,
+		Count:       len(searchResults),
+	}, nil
+}
+
+// HybridVectorSearch combines multiple vector indexes for comprehensive search
+func (vsm *VectorSearchManager) HybridVectorSearch(ctx context.Context, queryVector []float64, limit int) (*VectorSearchResponse, error) {
+	// Use 768-dimension indexes for Gemini embeddings
+	indexes := []string{
+		"function_embeddings_768",
+		"class_embeddings_768",
+		"method_embeddings_768",
+		"document_embeddings_768",
+	}
+
+	dimension := len(queryVector)
+	log.Printf("Using vector indexes for %d-dimension query", dimension)
+
+	var allResults []VectorSearchResult
+
+	// Search across all vector indexes
+	for _, indexName := range indexes {
+		response, err := vsm.VectorSearch(ctx, indexName, queryVector, limit/len(indexes)+1)
+		if err != nil {
+			log.Printf("Warning: vector search failed for index %s: %v", indexName, err)
+			continue
+		}
+		allResults = append(allResults, response.Results...)
+	}
+
+	// Sort by score and limit results
+	if len(allResults) > limit {
+		allResults = allResults[:limit]
+	}
+
+	return &VectorSearchResponse{
+		Results:     allResults,
+		QueryVector: queryVector,
+		IndexUsed:   "hybrid",
+		Count:       len(allResults),
+	}, nil
+}
+
+// GetVectorIndexInfo returns information about existing vector indexes
+func (vsm *VectorSearchManager) GetVectorIndexInfo(ctx context.Context) (map[string]interface{}, error) {
+	query := `SHOW INDEXES WHERE type = 'VECTOR'`
+
+	results, err := vsm.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vector index info: %w", err)
+	}
+
+	info := make(map[string]interface{})
+	info["vectorIndexes"] = make([]map[string]interface{}, 0)
+
+	for _, record := range results {
+		recordMap := record.AsMap()
+		indexInfo := make(map[string]interface{})
+
+		for key, value := range recordMap {
+			indexInfo[key] = value
+		}
+
+		if indexes, ok := info["vectorIndexes"].([]map[string]interface{}); ok {
+			info["vectorIndexes"] = append(indexes, indexInfo)
+		}
+	}
+
+	return info, nil
+}
+
+// UpdateNodeEmbedding updates the embedding for a specific node
+func (vsm *VectorSearchManager) UpdateNodeEmbedding(ctx context.Context, nodeId string, embedding []float64) error {
+	query := `
+		MATCH (n)
+		WHERE elementId(n) = $nodeId
+		SET n.embedding = $embedding
+		RETURN elementId(n) as id
+	`
+
+	params := map[string]any{
+		"nodeId":    nodeId,
+		"embedding": embedding,
+	}
+
+	results, err := vsm.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("failed to update node embedding: %w", err)
+	}
+
+	if len(results) == 0 {
+		return fmt.Errorf("node not found: %s", nodeId)
+	}
+
+	return nil
+}
+
+// BatchUpdateEmbeddings updates embeddings for multiple nodes efficiently
+func (vsm *VectorSearchManager) BatchUpdateEmbeddings(ctx context.Context, updates []NodeEmbeddingUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	// Convert to format Neo4j can handle
+	var updateMaps []map[string]interface{}
+	for _, update := range updates {
+		updateMaps = append(updateMaps, map[string]interface{}{
+			"nodeId":    update.NodeId,
+			"embedding": update.Embedding,
+		})
+	}
+
+	query := `
+		UNWIND $updates as update
+		MATCH (n)
+		WHERE elementId(n) = update.nodeId
+		SET n.embedding = update.embedding
+		RETURN count(n) as updated
+	`
+
+	params := map[string]any{
+		"updates": updateMaps,
+	}
+
+	results, err := vsm.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("failed to batch update embeddings: %w", err)
+	}
+
+	if len(results) > 0 {
+		recordMap := results[0].AsMap()
+		if updated, ok := recordMap["updated"].(int64); ok {
+			log.Printf("✓ Updated embeddings for %d nodes", updated)
+		}
+	}
+
+	return nil
+}
+
+// NodeEmbeddingUpdate represents a node embedding update operation
+type NodeEmbeddingUpdate struct {
+	NodeId    string    `json:"nodeId"`
+	Embedding []float64 `json:"embedding"`
+}
+
+// DropVectorIndex removes a vector index
+func (vsm *VectorSearchManager) DropVectorIndex(ctx context.Context, indexName string) error {
+	query := fmt.Sprintf("DROP INDEX %s IF EXISTS", indexName)
+
+	_, err := vsm.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return fmt.Errorf("failed to drop vector index %s: %w", indexName, err)
+	}
+
+	log.Printf("✓ Dropped vector index: %s", indexName)
+	return nil
+}

--- a/services/retrieval-go/search/vector_store.go
+++ b/services/retrieval-go/search/vector_store.go
@@ -1,0 +1,43 @@
+package search
+
+import "context"
+
+// VectorUpsert represents a single vector to upsert into the store.
+type VectorUpsert struct {
+	ID         string            // Unique identifier (e.g., nodeKey or elementId).
+	Vector     []float64         // The embedding vector.
+	Metadata   map[string]any    // Optional metadata to store alongside the vector.
+	NodeLabel  string            // The Neo4j label (for stores that support label filtering).
+}
+
+// VectorQuery represents a vector similarity query.
+type VectorQuery struct {
+	Vector     []float64         // The query vector.
+	Limit      int               // Maximum number of results.
+	Filters    map[string]any    // Optional metadata filters.
+	NodeLabels []string          // Optional label filter (for stores that support it).
+	IndexName  string            // Optional: specific index to query (store-specific).
+}
+
+// VectorResult represents a single result from a vector search.
+type VectorResult struct {
+	ID       string         // The matched vector's ID.
+	Score    float64        // Similarity score (higher = more similar for cosine).
+	Metadata map[string]any // Metadata associated with the vector.
+}
+
+// VectorStore defines the interface for storing and querying vectors.
+// Implementations may use Neo4j vector indexes, Qdrant, Pinecone, etc.
+type VectorStore interface {
+	// UpsertVectors stores or updates vectors in the store.
+	UpsertVectors(ctx context.Context, vectors []VectorUpsert) error
+
+	// Query finds the k most similar vectors to the given query.
+	Query(ctx context.Context, query VectorQuery) ([]VectorResult, error)
+
+	// DeleteVectors removes vectors by their IDs.
+	DeleteVectors(ctx context.Context, ids []string) error
+
+	// CreateIndex creates a vector index (if the store supports explicit index creation).
+	CreateIndex(ctx context.Context, name string, dimensions int, similarity string) error
+}


### PR DESCRIPTION
## Summary

Stacked on: #19 (phase2-libs)

Copies all domain service packages from `pkg/` to `services/` using the copy-forward strategy. Originals in `pkg/` retained (shim phase).

## Packages migrated

### services/indexing-go/
| Source | Destination | Import update |
|--------|-------------|---------------|
| `pkg/indexer/static/` | `services/indexing-go/static/` | Retained `pkg/neo4j` + `pkg/models` (type boundary with `pkg/search`) |
| `pkg/indexer/generated/` | `services/indexing-go/generated/` | Updated → `libs/neo4j-client-go` + `libs/core-models-go` |
| `pkg/indexer/documents/` | `services/indexing-go/documents/` | Retained `pkg/neo4j` + `pkg/models` (type boundary) |
| `pkg/schema/` | `services/indexing-go/schema/` | Updated → `libs/neo4j-client-go` |

### services/retrieval-go/
| Source | Destination | Import update |
|--------|-------------|---------------|
| `pkg/query/` | `services/retrieval-go/query/` | Updated → `libs/neo4j-client-go` + `libs/core-models-go` |
| `pkg/search/` (non-vector-client files) | `services/retrieval-go/search/` | Updated → `libs/neo4j-client-go` + `libs/core-models-go` |
| `pkg/llm/` | `services/retrieval-go/llm/` | No models/neo4j deps |

**Note on retained imports:** `static/` and `documents/` retain old `pkg/` imports because they pass types directly into `pkg/search` / `pkg/indexer/generated`. Type unification will happen in Phase 3 when all call sites migrate together.

## Nx projects added

- `services/indexing-go/project.json`
- `services/retrieval-go/project.json`

## Validation

```
go build ./...                                ✓
go test ./pkg/... ./libs/... ./services/...   ✓
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)