### PR TITLE
feat(monorepo phase2-apps): copy app entry points to apps/, add platform compose

### DIFF
--- a/apps/cli-go/main.go
+++ b/apps/cli-go/main.go
@@ -1,0 +1,2476 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/context-maximiser/code-graph/pkg/benchmarks"
+	"github.com/context-maximiser/code-graph/pkg/indexer/documents"
+	"github.com/context-maximiser/code-graph/pkg/indexer/static"
+	"github.com/context-maximiser/code-graph/pkg/llm"
+	"github.com/context-maximiser/code-graph/pkg/models"
+	_ "github.com/context-maximiser/code-graph/pkg/llm/gemini"
+	_ "github.com/context-maximiser/code-graph/pkg/llm/litellm"
+	_ "github.com/context-maximiser/code-graph/pkg/llm/openai"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/context-maximiser/code-graph/pkg/query"
+	"github.com/context-maximiser/code-graph/pkg/schema"
+	"github.com/context-maximiser/code-graph/pkg/search"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	cfgFile        string
+	verbose        bool
+	neo4jURI       string
+	neo4jUser      string
+	neo4jPass      string
+	neo4jDB        string
+	qdrantURL      string
+	qdrantAPIKey   string
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "codegraph",
+	Short: "Code Intelligence Platform CLI",
+	Long: `CodeGraph is a CLI tool for building and querying a comprehensive code intelligence platform
+using Neo4j as the backend graph database. It creates a Code Property Graph (CPG) that captures
+syntactic structure, semantic relationships, control flow, data flow, and connections to business
+requirements.`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Global flags
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.codegraph.yaml)")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().StringVar(&neo4jURI, "neo4j-uri", "bolt://localhost:7687", "Neo4j connection URI")
+	rootCmd.PersistentFlags().StringVar(&neo4jUser, "neo4j-user", "neo4j", "Neo4j username")
+	rootCmd.PersistentFlags().StringVar(&neo4jPass, "neo4j-password", "password123", "Neo4j password")
+	rootCmd.PersistentFlags().StringVar(&neo4jDB, "neo4j-database", "neo4j", "Neo4j database name")
+	rootCmd.PersistentFlags().StringVar(&qdrantURL, "qdrant-url", "localhost:6334", "Qdrant gRPC endpoint")
+	rootCmd.PersistentFlags().StringVar(&qdrantAPIKey, "qdrant-api-key", "", "Qdrant API key (optional)")
+
+	// Bind flags to viper
+	viper.BindPFlag("neo4j.uri", rootCmd.PersistentFlags().Lookup("neo4j-uri"))
+	viper.BindPFlag("neo4j.username", rootCmd.PersistentFlags().Lookup("neo4j-user"))
+	viper.BindPFlag("neo4j.password", rootCmd.PersistentFlags().Lookup("neo4j-password"))
+	viper.BindPFlag("neo4j.database", rootCmd.PersistentFlags().Lookup("neo4j-database"))
+	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	viper.BindPFlag("qdrant.url", rootCmd.PersistentFlags().Lookup("qdrant-url"))
+	viper.BindPFlag("qdrant.api_key", rootCmd.PersistentFlags().Lookup("qdrant-api-key"))
+
+	// Add subcommands
+	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(schemaCmd)
+	rootCmd.AddCommand(indexCmd)
+	rootCmd.AddCommand(queryCmd)
+	rootCmd.AddCommand(searchCmd)
+	rootCmd.AddCommand(linkCmd)
+	rootCmd.AddCommand(benchmarkCmd)
+	rootCmd.AddCommand(serverCmd)
+	rootCmd.AddCommand(indexersCmd)
+	indexersCmd.AddCommand(indexersInstallCmd)
+	indexersCmd.AddCommand(indexersStatusCmd)
+	indexersInstallCmd.Flags().String("language", "", "Comma-separated languages to install (e.g., go,typescript,python)")
+	indexersInstallCmd.Flags().String("cache-dir", "", "Custom cache directory for indexer binaries")
+}
+
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".codegraph" (without extension)
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".codegraph")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// Bind specific environment variables for Qdrant configuration.
+	viper.BindEnv("qdrant.url", "QDRANT_URL")
+	viper.BindEnv("qdrant.api_key", "QDRANT_API_KEY")
+
+	// If a config file is found, read it in
+	if err := viper.ReadInConfig(); err == nil && verbose {
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	}
+}
+
+// statusCmd checks the connection to Neo4j
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check Neo4j connection status",
+	Long:  "Check if the Neo4j database is accessible and return connection information",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		ctx := context.Background()
+		info, err := client.GetDatabaseInfo(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get database info: %w", err)
+		}
+
+		fmt.Println("Neo4j Connection Status: ✓ Connected")
+		fmt.Printf("Database: %s\n", neo4jDB)
+		fmt.Printf("URI: %s\n", neo4jURI)
+		if name, ok := info["name"]; ok {
+			fmt.Printf("Name: %s\n", name)
+		}
+		if versions, ok := info["versions"]; ok {
+			fmt.Printf("Version: %s\n", versions)
+		}
+		if edition, ok := info["edition"]; ok {
+			fmt.Printf("Edition: %s\n", edition)
+		}
+
+		return nil
+	},
+}
+
+// schemaCmd manages Neo4j schema (constraints and indexes)
+var schemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Manage Neo4j schema",
+	Long:  "Create, drop, or inspect the Neo4j schema (constraints and indexes)",
+}
+
+var schemaCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create Neo4j schema",
+	Long:  "Create all required constraints and indexes in the Neo4j database",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		schemaManager := schema.NewSchemaManager(client)
+
+		fmt.Println("Creating Neo4j schema...")
+		ctx := context.Background()
+		if err := schemaManager.CreateSchema(ctx); err != nil {
+			return fmt.Errorf("failed to create schema: %w", err)
+		}
+
+		fmt.Println("✓ Schema created successfully")
+		return nil
+	},
+}
+
+var schemaDropCmd = &cobra.Command{
+	Use:   "drop",
+	Short: "Drop Neo4j schema",
+	Long:  "Drop all constraints and indexes from the Neo4j database",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		schemaManager := schema.NewSchemaManager(client)
+
+		fmt.Println("Dropping Neo4j schema...")
+		ctx := context.Background()
+		if err := schemaManager.DropSchema(ctx); err != nil {
+			return fmt.Errorf("failed to drop schema: %w", err)
+		}
+
+		fmt.Println("✓ Schema dropped successfully")
+		return nil
+	},
+}
+
+var schemaInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Show schema information",
+	Long:  "Display information about current constraints and indexes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		schemaManager := schema.NewSchemaManager(client)
+
+		ctx := context.Background()
+		info, err := schemaManager.GetSchemaInfo(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get schema info: %w", err)
+		}
+
+		fmt.Println("Schema Information:")
+		fmt.Println("==================")
+
+		if constraints, ok := info["constraints"].([]map[string]any); ok {
+			fmt.Printf("\nConstraints (%d):\n", len(constraints))
+			for _, constraint := range constraints {
+				if name, ok := constraint["name"]; ok {
+					fmt.Printf("  - %s\n", name)
+				}
+			}
+		}
+
+		if indexes, ok := info["indexes"].([]map[string]any); ok {
+			fmt.Printf("\nIndexes (%d):\n", len(indexes))
+			for _, index := range indexes {
+				if name, ok := index["name"]; ok {
+					fmt.Printf("  - %s\n", name)
+				}
+			}
+		}
+
+		return nil
+	},
+}
+
+// indexCmd manages code indexing
+var indexCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Index source code",
+	Long:  "Index source code into the Neo4j graph database",
+}
+
+var indexProjectCmd = &cobra.Command{
+	Use:   "project [path]",
+	Short: "Index a Go project",
+	Long:  "Index all Go source files in a project directory using AST parsing",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectPath := "."
+		if len(args) > 0 {
+			projectPath = args[0]
+		}
+
+		serviceName, _ := cmd.Flags().GetString("service")
+		version, _ := cmd.Flags().GetString("version")
+		repoURL, _ := cmd.Flags().GetString("repo-url")
+		generateEmbeddings, _ := cmd.Flags().GetBool("generate-embeddings")
+		apiKey, _ := cmd.Flags().GetString("embedding-api-key")
+		baseURL, _ := cmd.Flags().GetString("embedding-base-url")
+		model, _ := cmd.Flags().GetString("embedding-model")
+		// useOpenRouter, _ := cmd.Flags().GetBool("embedding-openrouter")
+		useGemini, _ := cmd.Flags().GetBool("embedding-gemini")
+
+		if serviceName == "" {
+			serviceName = "context-maximiser" // Default service name
+		}
+		if version == "" {
+			version = "v1.0.0"
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		indexer := static.NewStaticIndexer(client, serviceName, version, repoURL)
+
+		// Configure embedding service if requested
+		if generateEmbeddings {
+			var embeddingService search.EmbeddingService
+			if useGemini && apiKey != "" {
+				embeddingService = search.NewGeminiEmbeddingService(apiKey, model)
+				fmt.Printf("🔗 Using Google Gemini embedding service (model: %s)\n", model)
+			} else if apiKey != "" && baseURL != "" {
+				embeddingService = search.NewSimpleEmbeddingService(baseURL, apiKey, model)
+				fmt.Printf("🔗 Using real embedding service: %s (model: %s)\n", baseURL, model)
+			} else {
+				return fmt.Errorf("embedding generation requires either --embedding-gemini with GEMINI_API_KEY or --embedding-api-key with --embedding-base-url")
+			}
+			//  else if useOpenRouter && apiKey != "" {
+			// 	embeddingService = search.NewOpenRouterEmbeddingService(apiKey, model)
+			// 	fmt.Printf("🔗 Using OpenRouter embedding service (model: %s)\n", model)
+			// }
+			indexer.SetEmbeddingService(embeddingService)
+		}
+
+		fmt.Printf("Indexing project at %s using AST parsing...\n", projectPath)
+		ctx := context.Background()
+		if err := indexer.IndexProject(ctx, projectPath); err != nil {
+			return fmt.Errorf("failed to index project: %w", err)
+		}
+
+		fmt.Println("✓ Project indexed successfully")
+		return nil
+	},
+}
+
+var indexSCIPCmd = &cobra.Command{
+	Use:   "scip [path]",
+	Short: "Index a project using SCIP",
+	Long: fmt.Sprintf(`Index a project using the SCIP (Source Code Intelligence Protocol) indexer for accurate code intelligence.
+
+Supported languages: %s
+
+The language will be auto-detected from the project structure, or you can specify it explicitly with --language.`, static.FormatLanguageList()),
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectPath := "."
+		if len(args) > 0 {
+			projectPath = args[0]
+		}
+
+		serviceName, _ := cmd.Flags().GetString("service")
+		version, _ := cmd.Flags().GetString("version")
+		repoURL, _ := cmd.Flags().GetString("repo-url")
+		languageFlag, _ := cmd.Flags().GetString("language")
+
+		if serviceName == "" {
+			serviceName = "context-maximiser" // Default service name
+		}
+		if version == "" {
+			version = "v1.0.0"
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		// Determine language
+		var language static.Language
+		if languageFlag != "" {
+			// Use explicitly specified language
+			language = static.Language(strings.ToLower(languageFlag))
+			if _, err := static.GetLanguageConfig(language); err != nil {
+				return fmt.Errorf("unsupported language: %s. Supported languages: %s",
+					languageFlag, static.FormatLanguageList())
+			}
+			fmt.Printf("Using explicitly specified language: %s\n", languageFlag)
+		} else {
+			// Auto-detect language
+			detectedLang, err := static.DetectLanguage(projectPath)
+			if err != nil {
+				return fmt.Errorf("failed to detect language: %w\nPlease specify language explicitly with --language flag", err)
+			}
+			language = detectedLang
+			langConfig, _ := static.GetLanguageConfig(language)
+			fmt.Printf("Auto-detected language: %s\n", langConfig.DisplayName)
+		}
+
+		scipIndexer := static.NewSCIPIndexerWithLanguage(client, serviceName, version, repoURL, language)
+
+		// Set scope if provided
+		scopeFlag, _ := cmd.Flags().GetString("scope")
+		scopeIDFlag, _ := cmd.Flags().GetString("scope-id")
+		if scopeFlag == "pr" {
+			prID := scopeIDFlag
+			if prID == "" {
+				return fmt.Errorf("--scope-id is required when --scope=pr")
+			}
+			// Strip "pr-" prefix if user included it
+			if strings.HasPrefix(prID, "pr-") {
+				prID = prID[3:]
+			}
+			scipIndexer.SetScope(models.NewPRScope(prID))
+			fmt.Printf("Indexing into PR scope: pr-%s\n", prID)
+		} else if scopeIDFlag != "" && scopeIDFlag != "main" {
+			return fmt.Errorf("--scope-id should only be used with --scope=pr")
+		}
+
+		// Validate environment (with optional auto-install)
+		noAutoInstall, _ := cmd.Flags().GetBool("no-auto-install")
+		if noAutoInstall {
+			if err := scipIndexer.ValidateEnvironmentNoInstall(); err != nil {
+				return fmt.Errorf("environment validation failed: %w", err)
+			}
+		} else {
+			if err := scipIndexer.ValidateEnvironment(); err != nil {
+				return fmt.Errorf("environment validation failed: %w", err)
+			}
+		}
+
+		fmt.Printf("Indexing project at %s using SCIP...\n", projectPath)
+		ctx := context.Background()
+		if err := scipIndexer.IndexProject(ctx, projectPath); err != nil {
+			return fmt.Errorf("failed to index project with SCIP: %w", err)
+		}
+
+		fmt.Println("✓ Project indexed successfully using SCIP")
+		return nil
+	},
+}
+
+// indexDocsCmd handles indexing documents
+var indexIncrementalCmd = &cobra.Command{
+	Use:   "incremental [path]",
+	Short: "Incrementally index a Go project",
+	Long:  "Incrementally index Go source files by only updating changed files based on content hash comparison",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectPath := "."
+		if len(args) > 0 {
+			projectPath = args[0]
+		}
+
+		serviceName, _ := cmd.Flags().GetString("service")
+		version, _ := cmd.Flags().GetString("version")
+		repoURL, _ := cmd.Flags().GetString("repo-url")
+
+		if serviceName == "" {
+			serviceName = "context-maximiser" // Default service name
+		}
+		if version == "" {
+			version = "v1.0.0"
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		indexer := static.NewStaticIndexer(client, serviceName, version, repoURL)
+
+		fmt.Printf("Performing incremental indexing for project at %s...\n", projectPath)
+		ctx := context.Background()
+		if err := indexer.IndexProjectIncremental(ctx, projectPath); err != nil {
+			return fmt.Errorf("failed to perform incremental indexing: %w", err)
+		}
+
+		fmt.Println("✓ Incremental indexing completed successfully")
+		return nil
+	},
+}
+
+var indexDocsCmd = &cobra.Command{
+	Use:   "docs [path]",
+	Short: "Index documents for feature extraction",
+	Long:  "Index markdown and text documents to extract features and link them to code",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		docPath := args[0]
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		indexer := documents.NewDocumentIndexer(client)
+
+		// Set scope if provided
+		docScopeFlag, _ := cmd.Flags().GetString("scope")
+		docScopeIDFlag, _ := cmd.Flags().GetString("scope-id")
+		if docScopeFlag == "pr" {
+			prID := docScopeIDFlag
+			if prID == "" {
+				return fmt.Errorf("--scope-id is required when --scope=pr")
+			}
+			if strings.HasPrefix(prID, "pr-") {
+				prID = prID[3:]
+			}
+			indexer.SetScope(models.NewPRScope(prID))
+			fmt.Printf("Indexing docs into PR scope: pr-%s\n", prID)
+		}
+
+		ctx := context.Background()
+
+		// Check if path is a file or directory
+		info, err := os.Stat(docPath)
+		if err != nil {
+			return fmt.Errorf("failed to access path %s: %w", docPath, err)
+		}
+
+		if info.IsDir() {
+			fmt.Printf("Indexing documents in directory: %s\n", docPath)
+			err = indexer.IndexDirectory(ctx, docPath)
+		} else {
+			fmt.Printf("Indexing document file: %s\n", docPath)
+			err = indexer.IndexDocument(ctx, docPath)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to index documents: %w", err)
+		}
+
+		// Get and display stats
+		stats, err := indexer.GetDocumentStats(ctx)
+		if err != nil {
+			fmt.Printf("Warning: failed to get document stats: %v\n", err)
+		} else {
+			fmt.Printf("\n📊 Document Indexing Summary:\n")
+			if docCount, ok := stats["documentCount"]; ok {
+				fmt.Printf("  Documents: %v\n", docCount)
+			}
+			if featureCount, ok := stats["featureCount"]; ok {
+				fmt.Printf("  Features extracted: %v\n", featureCount)
+			}
+			if symbolCount, ok := stats["mentionedSymbolCount"]; ok {
+				fmt.Printf("  Code symbols linked: %v\n", symbolCount)
+			}
+		}
+
+		fmt.Println("✓ Documents indexed successfully")
+		return nil
+	},
+}
+
+// docsSyncCmd syncs documents from an external source (Confluence, etc.)
+var docsSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync documents from an external source",
+	Long:  "Fetch documents from Confluence or other external sources and index them into the graph",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		source, _ := cmd.Flags().GetString("source")
+		space, _ := cmd.Flags().GetString("space")
+		docURL, _ := cmd.Flags().GetString("url")
+		docID, _ := cmd.Flags().GetString("doc-id")
+		baseURL, _ := cmd.Flags().GetString("base-url")
+		username, _ := cmd.Flags().GetString("username")
+		apiToken, _ := cmd.Flags().GetString("api-token")
+
+		if source == "" {
+			return fmt.Errorf("--source is required (e.g., 'confluence')")
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		indexer := documents.NewDocumentIndexer(client)
+
+		// Set scope if provided.
+		syncScopeFlag, _ := cmd.Flags().GetString("scope")
+		syncScopeIDFlag, _ := cmd.Flags().GetString("scope-id")
+		if syncScopeFlag == "pr" {
+			prID := syncScopeIDFlag
+			if prID == "" {
+				return fmt.Errorf("--scope-id is required when --scope=pr")
+			}
+			if strings.HasPrefix(prID, "pr-") {
+				prID = prID[3:]
+			}
+			indexer.SetScope(models.NewPRScope(prID))
+		}
+
+		ctx := context.Background()
+
+		var connector documents.DocConnector
+		switch strings.ToLower(source) {
+		case "confluence":
+			if baseURL == "" {
+				return fmt.Errorf("--base-url is required for Confluence (e.g., 'https://your-domain.atlassian.net/wiki')")
+			}
+			if username == "" || apiToken == "" {
+				return fmt.Errorf("--username and --api-token are required for Confluence")
+			}
+			connector = documents.NewConfluenceConnector(documents.ConfluenceConfig{
+				BaseURL:  baseURL,
+				Username: username,
+				APIToken: apiToken,
+			})
+		default:
+			return fmt.Errorf("unsupported source: %s (supported: confluence)", source)
+		}
+
+		// Single document sync (by URL or doc ID).
+		if docURL != "" || docID != "" {
+			id := docID
+			if id == "" {
+				id = docURL
+			}
+			fmt.Printf("Syncing single document: %s\n", id)
+			if err := indexer.SyncExternalDocument(ctx, connector, id); err != nil {
+				return fmt.Errorf("failed to sync document: %w", err)
+			}
+			fmt.Println("✓ Document synced successfully")
+			return nil
+		}
+
+		// Space sync.
+		if space != "" {
+			fmt.Printf("Syncing space: %s from %s\n", space, source)
+			synced, err := indexer.SyncExternalSpace(ctx, connector, space)
+			if err != nil {
+				return fmt.Errorf("failed to sync space: %w", err)
+			}
+			fmt.Printf("✓ Synced %d documents from space %s\n", synced, space)
+			return nil
+		}
+
+		return fmt.Errorf("provide either --space (to sync all docs) or --url/--doc-id (to sync one doc)")
+	},
+}
+
+// indexTombstoneCmd creates tombstones for deleted files/symbols in a PR overlay
+var indexTombstoneCmd = &cobra.Command{
+	Use:   "tombstone [file_paths...]",
+	Short: "Create tombstones for deleted files in a PR overlay",
+	Long:  "Create Tombstone nodes that hide main-scope nodes from queries in a PR scope",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		scopeFlag, _ := cmd.Flags().GetString("scope")
+		scopeIDFlag, _ := cmd.Flags().GetString("scope-id")
+
+		if scopeFlag != "pr" {
+			return fmt.Errorf("tombstones can only be created in PR scope (use --scope=pr --scope-id=pr-<id>)")
+		}
+		if scopeIDFlag == "" {
+			return fmt.Errorf("--scope-id is required for tombstone creation")
+		}
+
+		prID := scopeIDFlag
+		if strings.HasPrefix(prID, "pr-") {
+			prID = prID[3:]
+		}
+		scopeCtx := models.NewPRScope(prID)
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		creator := static.NewTombstoneCreator(client, scopeCtx)
+
+		fmt.Printf("Creating tombstones in scope %s for %d file(s)...\n", scopeCtx.ScopeID, len(args))
+		ctx := context.Background()
+
+		created, err := creator.CreateFileDeletedTombstones(ctx, args)
+		if err != nil {
+			return fmt.Errorf("failed to create tombstones: %w", err)
+		}
+
+		fmt.Printf("Created %d tombstone(s) in scope %s\n", created, scopeCtx.ScopeID)
+		return nil
+	},
+}
+
+// queryCmd handles querying the graph
+var queryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "Query the code graph",
+	Long:  "Execute queries against the code graph database",
+}
+
+var querySearchCmd = &cobra.Command{
+	Use:   "search [term]",
+	Short: "Search for code symbols",
+	Long:  "Search for functions, classes, variables, and other code symbols",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		searchTerm := args[0]
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		queryBuilder := neo4j.NewQueryBuilder(client)
+
+		// Get limit from flags, 0 means no limit
+		limit, _ := cmd.Flags().GetInt("limit")
+		scopeID, _ := cmd.Flags().GetString("scope-id")
+
+		ctx := context.Background()
+		nodeTypes := []string{"Function", "Method", "Class", "Variable", "File", "Symbol", "Document", "Feature"}
+
+		// Use overlay-aware search when scope-id is provided
+		var results []*neo4jdriver.Record
+		if scopeID != "" {
+			results, err = queryBuilder.SearchNodesScoped(ctx, searchTerm, nodeTypes, limit, scopeID)
+		} else {
+			results, err = queryBuilder.SearchNodes(ctx, searchTerm, nodeTypes, limit)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to search: %w", err)
+		}
+
+		fmt.Printf("Search results for '%s':\n", searchTerm)
+		fmt.Println("========================")
+
+		for _, record := range results {
+			recordMap := record.AsMap()
+			if nodeObj, ok := recordMap["n"]; ok {
+				// Handle Neo4j Node object
+				if node, ok := nodeObj.(dbtype.Node); ok {
+					props := node.Props
+					if labels, ok := recordMap["nodeLabels"].([]interface{}); ok {
+						// Handle different node types
+						var displayName string
+						var details []string
+
+						switch labels[0].(string) {
+						case "File":
+							if path, ok := props["path"]; ok {
+								displayName = fmt.Sprintf("%s", path)
+								if lang, ok := props["language"]; ok {
+									details = append(details, fmt.Sprintf("Language: %s", lang))
+								}
+							}
+						case "Symbol":
+							if symbol, ok := props["symbol"]; ok {
+								displayName = fmt.Sprintf("%s", symbol)
+								if kind, ok := props["kind"]; ok {
+									details = append(details, fmt.Sprintf("Kind: %s", kind))
+								}
+							}
+						case "Document":
+							if title, ok := props["title"]; ok {
+								displayName = fmt.Sprintf("%s", title)
+								if docType, ok := props["type"]; ok {
+									details = append(details, fmt.Sprintf("Type: %s", docType))
+								}
+								if sourceUrl, ok := props["sourceUrl"]; ok {
+									details = append(details, fmt.Sprintf("Source: %s", sourceUrl))
+								}
+							}
+						case "Feature":
+							if name, ok := props["name"]; ok {
+								displayName = fmt.Sprintf("%s", name)
+								if desc, ok := props["description"]; ok && desc != "" {
+									details = append(details, fmt.Sprintf("Description: %s", desc))
+								}
+								if status, ok := props["status"]; ok {
+									details = append(details, fmt.Sprintf("Status: %s", status))
+								}
+							}
+						default:
+							if name, ok := props["name"]; ok {
+								displayName = fmt.Sprintf("%s", name)
+								if filePath, ok := props["filePath"]; ok {
+									details = append(details, fmt.Sprintf("File: %s", filePath))
+								}
+								if signature, ok := props["signature"]; ok && signature != "" {
+									details = append(details, fmt.Sprintf("Signature: %s", signature))
+								}
+							}
+						}
+
+						if displayName != "" {
+							fmt.Printf("- %s (%s)\n", displayName, labels[0])
+							for _, detail := range details {
+								fmt.Printf("  %s\n", detail)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return nil
+	},
+}
+
+var querySourceCmd = &cobra.Command{
+	Use:   "source [function_name]",
+	Short: "Get source code for a function",
+	Long:  "Retrieve the exact source code for a function or method using stored location metadata",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		functionName := args[0]
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		queryBuilder := neo4j.NewQueryBuilder(client)
+
+		ctx := context.Background()
+		sourceCode, err := queryBuilder.GetFunctionSourceCode(ctx, functionName)
+		if err != nil {
+			return fmt.Errorf("failed to get source code: %w", err)
+		}
+
+		fmt.Printf("Source code for function '%s':\n", functionName)
+		fmt.Println("=" + strings.Repeat("=", len(functionName)+25))
+		fmt.Println(sourceCode)
+		fmt.Println("=" + strings.Repeat("=", len(functionName)+25))
+
+		return nil
+	},
+}
+
+// queryDepsCmd queries service-level dependencies
+var queryDepsCmd = &cobra.Command{
+	Use:   "deps",
+	Short: "Query service dependencies",
+	Long:  "Show inter-service dependencies (CALLS_SERVICE relationships)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		serviceName, _ := cmd.Flags().GetString("service")
+		scopeID, _ := cmd.Flags().GetString("scope-id")
+
+		if serviceName == "" {
+			return fmt.Errorf("--service is required")
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		depsQuery := query.NewServiceDepsQuery(client)
+		ctx := context.Background()
+
+		deps, err := depsQuery.GetDependencies(ctx, serviceName, scopeID)
+		if err != nil {
+			return fmt.Errorf("failed to query dependencies: %w", err)
+		}
+
+		if len(deps) == 0 {
+			fmt.Printf("No dependencies found for service '%s'\n", serviceName)
+			return nil
+		}
+
+		fmt.Printf("Dependencies for service '%s':\n", serviceName)
+		for _, dep := range deps {
+			direction := "→"
+			peer := dep.ToService
+			if dep.ToService == serviceName {
+				direction = "←"
+				peer = dep.FromService
+			}
+			fmt.Printf("  %s %s %s (confidence: %.2f, source: %s)\n",
+				serviceName, direction, peer, dep.Confidence, dep.Source)
+			for _, ev := range dep.Evidence {
+				fmt.Printf("    evidence: %s\n", ev)
+			}
+		}
+
+		return nil
+	},
+}
+
+// queryFlowsCmd lists or generates flow spines
+var queryFlowsCmd = &cobra.Command{
+	Use:   "flows",
+	Short: "List or generate flow spines",
+	Long:  "List existing flow spines or generate new ones from API endpoints",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		generate, _ := cmd.Flags().GetBool("generate")
+		maxDepth, _ := cmd.Flags().GetInt("max-depth")
+		flowType, _ := cmd.Flags().GetString("type")
+		scopeID, _ := cmd.Flags().GetString("scope-id")
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		gen := query.NewFlowSpineGenerator(client)
+		if scopeID != "" {
+			gen.SetScope(models.NewPRScope(scopeID))
+		}
+		ctx := context.Background()
+
+		if generate {
+			results, err := gen.GenerateFromAPIEndpoints(ctx, maxDepth)
+			if err != nil {
+				return fmt.Errorf("failed to generate flows: %w", err)
+			}
+			fmt.Printf("Generated %d flow spines\n", len(results))
+			for _, r := range results {
+				fmt.Printf("  %s (%s) — %d steps\n", r.FlowName, r.FlowType, len(r.Steps))
+				for _, s := range r.Steps {
+					fmt.Printf("    [%d] %s (%s)\n", s.Order, s.Name, s.Label)
+				}
+			}
+			return nil
+		}
+
+		// List existing flows.
+		flows, err := gen.ListFlows(ctx, flowType)
+		if err != nil {
+			return fmt.Errorf("failed to list flows: %w", err)
+		}
+
+		if len(flows) == 0 {
+			fmt.Println("No flow spines found. Use --generate to create them from API endpoints.")
+			return nil
+		}
+
+		fmt.Printf("Found %d flow spines:\n", len(flows))
+		for _, f := range flows {
+			fmt.Printf("  %s [%s] (%s)\n", f.FlowName, f.FlowType, f.FlowNodeKey)
+		}
+		return nil
+	},
+}
+
+// indexersCmd is the parent command for indexer management.
+var indexersCmd = &cobra.Command{
+	Use:   "indexers",
+	Short: "Manage SCIP indexer binaries",
+	Long:  "Download, cache, and manage SCIP indexer binaries for supported languages",
+}
+
+// indexersInstallCmd installs SCIP indexer binaries.
+var indexersInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install SCIP indexer binaries",
+	Long:  "Download and cache SCIP indexer binaries for specified languages",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		langStr, _ := cmd.Flags().GetString("language")
+		cacheDir, _ := cmd.Flags().GetString("cache-dir")
+
+		mgr := static.NewIndexerManager(cacheDir)
+
+		var languages []static.Language
+		if langStr != "" {
+			for _, l := range strings.Split(langStr, ",") {
+				languages = append(languages, static.Language(strings.TrimSpace(l)))
+			}
+		} else {
+			// Install all known languages
+			languages = []static.Language{
+				static.LanguageGo,
+				static.LanguageTypeScript,
+				static.LanguagePython,
+				static.LanguageJava,
+			}
+		}
+
+		installed, failed := mgr.InstallAll(languages)
+		if len(installed) > 0 {
+			fmt.Printf("Installed/verified: %d indexers\n", len(installed))
+			for _, lang := range installed {
+				fmt.Printf("  %s: %s\n", lang, mgr.ResolveBinary(lang))
+			}
+		}
+		if len(failed) > 0 {
+			fmt.Printf("Failed: %d indexers\n", len(failed))
+			for lang, err := range failed {
+				fmt.Printf("  %s: %v\n", lang, err)
+			}
+		}
+		return nil
+	},
+}
+
+// indexersStatusCmd shows the status of installed SCIP indexer binaries.
+var indexersStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show indexer installation status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr := static.NewIndexerManager("")
+		statuses := mgr.Status()
+
+		fmt.Println("SCIP Indexer Status:")
+		fmt.Println("====================")
+		for _, s := range statuses {
+			status := "NOT INSTALLED"
+			if s.Installed {
+				status = fmt.Sprintf("installed (%s)", s.Path)
+			}
+			fmt.Printf("  %-12s %-20s %s %s\n", s.Language, s.Binary, s.Version, status)
+		}
+		return nil
+	},
+}
+
+// serverCmd starts the API server
+var serverCmd = &cobra.Command{
+	Use:   "server",
+	Short: "Start the API server",
+	Long:  "Start the REST API server for querying the code graph",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, _ := cmd.Flags().GetInt("port")
+
+		fmt.Printf("Starting API server on port %d...\n", port)
+		fmt.Println("API server functionality not yet implemented")
+
+		// Set up signal handling for graceful shutdown
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Handle shutdown signals
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+		go func() {
+			<-sigChan
+			fmt.Println("\nShutting down server...")
+			cancel()
+		}()
+
+		// Wait for shutdown signal
+		<-ctx.Done()
+		return nil
+	},
+}
+
+// benchmarkCmd handles performance and memory benchmarking
+var benchmarkCmd = &cobra.Command{
+	Use:   "benchmark",
+	Short: "Performance and memory benchmarking",
+	Long:  "Run comprehensive benchmarks to analyze performance and memory usage of indexing operations",
+}
+
+var benchmarkMemoryCmd = &cobra.Command{
+	Use:   "memory [path]",
+	Short: "Benchmark memory usage of indexing operations",
+	Long:  "Compare memory usage between full and incremental indexing to analyze performance impact",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectPath := "."
+		if len(args) > 0 {
+			projectPath = args[0]
+		}
+
+		serviceName, _ := cmd.Flags().GetString("service")
+		version, _ := cmd.Flags().GetString("version")
+		repoURL, _ := cmd.Flags().GetString("repo-url")
+		sampleInterval, _ := cmd.Flags().GetDuration("sample-interval")
+
+		if serviceName == "" {
+			serviceName = "benchmark-test"
+		}
+		if version == "" {
+			version = "v1.0.0"
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		config := benchmarks.BenchmarkConfig{
+			ProjectPath:    projectPath,
+			ServiceName:    serviceName,
+			Version:        version,
+			RepoURL:        repoURL,
+			SampleInterval: sampleInterval,
+		}
+
+		benchmark := benchmarks.NewIndexingBenchmark(client, config)
+		ctx := context.Background()
+
+		fmt.Printf("🔬 Starting Memory Impact Benchmark for project at %s...\n", projectPath)
+		comparison := benchmark.BenchmarkMemoryImpact(ctx)
+
+		// Print detailed comparison report
+		comparison.PrintComparison()
+
+		return nil
+	},
+}
+
+var benchmarkFullCmd = &cobra.Command{
+	Use:   "full [path]",
+	Short: "Benchmark full indexing performance",
+	Long:  "Run comprehensive benchmark of full project indexing with detailed memory monitoring",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectPath := "."
+		if len(args) > 0 {
+			projectPath = args[0]
+		}
+
+		serviceName, _ := cmd.Flags().GetString("service")
+		version, _ := cmd.Flags().GetString("version")
+		repoURL, _ := cmd.Flags().GetString("repo-url")
+		sampleInterval, _ := cmd.Flags().GetDuration("sample-interval")
+
+		if serviceName == "" {
+			serviceName = "benchmark-full"
+		}
+		if version == "" {
+			version = "v1.0.0"
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		config := benchmarks.BenchmarkConfig{
+			ProjectPath:    projectPath,
+			ServiceName:    serviceName,
+			Version:        version,
+			RepoURL:        repoURL,
+			SampleInterval: sampleInterval,
+		}
+
+		benchmark := benchmarks.NewIndexingBenchmark(client, config)
+		ctx := context.Background()
+
+		fmt.Printf("🚀 Starting Full Indexing Benchmark for project at %s...\n", projectPath)
+		result := benchmark.BenchmarkFullIndexing(ctx)
+
+		// Print detailed results
+		fmt.Printf("\n📊 Full Indexing Results:\n")
+		fmt.Printf("   Duration: %v\n", result.Duration)
+		fmt.Printf("   Files Processed: %d\n", result.FilesProcessed)
+		fmt.Printf("   Success: %t\n", result.Success)
+
+		if result.Error != "" {
+			fmt.Printf("   Error: %s\n", result.Error)
+		}
+
+		if result.MemoryReport != nil {
+			result.MemoryReport.PrintReport()
+		}
+
+		return nil
+	},
+}
+
+var benchmarkIncrementalCmd = &cobra.Command{
+	Use:   "incremental [path]",
+	Short: "Benchmark incremental indexing performance",
+	Long:  "Run comprehensive benchmark of incremental project indexing with detailed memory monitoring",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectPath := "."
+		if len(args) > 0 {
+			projectPath = args[0]
+		}
+
+		serviceName, _ := cmd.Flags().GetString("service")
+		version, _ := cmd.Flags().GetString("version")
+		repoURL, _ := cmd.Flags().GetString("repo-url")
+		sampleInterval, _ := cmd.Flags().GetDuration("sample-interval")
+
+		if serviceName == "" {
+			serviceName = "benchmark-incremental"
+		}
+		if version == "" {
+			version = "v1.0.0"
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		config := benchmarks.BenchmarkConfig{
+			ProjectPath:    projectPath,
+			ServiceName:    serviceName,
+			Version:        version,
+			RepoURL:        repoURL,
+			SampleInterval: sampleInterval,
+		}
+
+		benchmark := benchmarks.NewIndexingBenchmark(client, config)
+		ctx := context.Background()
+
+		fmt.Printf("⚡ Starting Incremental Indexing Benchmark for project at %s...\n", projectPath)
+		result := benchmark.BenchmarkIncrementalIndexing(ctx)
+
+		// Print detailed results
+		fmt.Printf("\n📊 Incremental Indexing Results:\n")
+		fmt.Printf("   Duration: %v\n", result.Duration)
+		fmt.Printf("   Files Processed: %d\n", result.FilesProcessed)
+		fmt.Printf("   Success: %t\n", result.Success)
+
+		if result.Error != "" {
+			fmt.Printf("   Error: %s\n", result.Error)
+		}
+
+		if result.MemoryReport != nil {
+			result.MemoryReport.PrintReport()
+		}
+
+		return nil
+	},
+}
+
+var benchmarkPipelineCmd = &cobra.Command{
+	Use:   "pipeline [path]",
+	Short: "Benchmark SCIP indexing pipeline phases",
+	Long:  "Profile each phase of the SCIP indexing pipeline and identify bottlenecks",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectPath := "."
+		if len(args) > 0 {
+			projectPath = args[0]
+		}
+
+		serviceName, _ := cmd.Flags().GetString("service")
+		version, _ := cmd.Flags().GetString("version")
+		repoURL, _ := cmd.Flags().GetString("repo-url")
+		languageFlag, _ := cmd.Flags().GetString("language")
+		pprofFlag, _ := cmd.Flags().GetBool("pprof")
+		jsonFlag, _ := cmd.Flags().GetBool("json")
+
+		if serviceName == "" {
+			serviceName = "benchmark-pipeline"
+		}
+		if version == "" {
+			version = "v1.0.0"
+		}
+
+		// Start CPU profiling if requested
+		if pprofFlag {
+			f, err := os.Create("cpu.prof")
+			if err != nil {
+				return fmt.Errorf("failed to create CPU profile: %w", err)
+			}
+			defer f.Close()
+			if err := pprof.StartCPUProfile(f); err != nil {
+				return fmt.Errorf("failed to start CPU profile: %w", err)
+			}
+			defer pprof.StopCPUProfile()
+			fmt.Println("CPU profiling enabled, will write to cpu.prof")
+		}
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		ctx := context.Background()
+
+		// Wipe database
+		fmt.Println("Wiping database...")
+		_, err = client.ExecuteQuery(ctx, "MATCH (n) DETACH DELETE n", nil)
+		if err != nil {
+			return fmt.Errorf("failed to wipe database: %w", err)
+		}
+
+		// Create schema
+		fmt.Println("Creating schema...")
+		schemaManager := schema.NewSchemaManager(client)
+		if err := schemaManager.CreateSchema(ctx); err != nil {
+			return fmt.Errorf("failed to create schema: %w", err)
+		}
+
+		// Determine language
+		var language static.Language
+		if languageFlag != "" {
+			language = static.Language(strings.ToLower(languageFlag))
+			if _, err := static.GetLanguageConfig(language); err != nil {
+				return fmt.Errorf("unsupported language: %s", languageFlag)
+			}
+		} else {
+			detectedLang, err := static.DetectLanguage(projectPath)
+			if err != nil {
+				return fmt.Errorf("failed to detect language: %w", err)
+			}
+			language = detectedLang
+		}
+
+		// Create indexer with timer
+		timer := benchmarks.NewPhaseTimer()
+		scipIndexer := static.NewSCIPIndexerWithLanguage(client, serviceName, version, repoURL, language)
+		scipIndexer.SetBenchmarkTimer(timer)
+
+		fmt.Printf("Benchmarking SCIP pipeline for %s project at %s...\n\n", language, projectPath)
+
+		if err := scipIndexer.IndexProject(ctx, projectPath); err != nil {
+			return fmt.Errorf("indexing failed: %w", err)
+		}
+
+		// Output results
+		if jsonFlag {
+			if err := timer.PrintJSON(os.Stdout); err != nil {
+				return fmt.Errorf("failed to write JSON: %w", err)
+			}
+		} else {
+			timer.PrintTable(os.Stdout)
+		}
+
+		if pprofFlag {
+			fmt.Println("CPU profile written to cpu.prof")
+			fmt.Println("Analyze with: go tool pprof cpu.prof")
+		}
+
+		return nil
+	},
+}
+
+// searchCmd manages advanced search capabilities
+var searchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Advanced search management",
+	Long:  "Manage vector search, full-text search (BM25), and hybrid search capabilities",
+}
+
+var searchInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize search indexes",
+	Long:  "Create vector and full-text indexes required for advanced search",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		ctx := context.Background()
+
+		// Always create full-text indexes in Neo4j.
+		fullTextSearch := search.NewFullTextSearchManager(client)
+		fmt.Println("🚀 Initializing full-text search indexes...")
+		if err := fullTextSearch.CreateFullTextIndexes(ctx); err != nil {
+			fmt.Printf("Warning: failed to create full-text indexes: %v\n", err)
+		}
+
+		// Create vector collections in Qdrant.
+		vectorStore, err := createVectorStore()
+		if err != nil {
+			return err
+		}
+		defer vectorStore.(*search.QdrantVectorStore).Close()
+
+		fmt.Println("🚀 Initializing Qdrant vector collections...")
+		collections := []string{
+			"function_embeddings_768",
+			"method_embeddings_768",
+			"class_embeddings_768",
+			"document_embeddings_768",
+			"feature_embeddings_768",
+		}
+		for _, col := range collections {
+			if err := vectorStore.CreateIndex(ctx, col, 768, "cosine"); err != nil {
+				fmt.Printf("Warning: failed to create collection %s: %v\n", col, err)
+			} else {
+				fmt.Printf("   ✓ Collection %s ready\n", col)
+			}
+		}
+
+		fmt.Println("✅ Advanced search indexes initialized successfully")
+		return nil
+	},
+}
+
+var searchTestCmd = &cobra.Command{
+	Use:   "test [query]",
+	Short: "Test hybrid search capabilities",
+	Long:  "Test vector search, full-text search, and hybrid search with a query.\nUse --fulltext-only to skip vector search (no API key required).",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		query := args[0]
+		limit, _ := cmd.Flags().GetInt("limit")
+		fulltextOnly, _ := cmd.Flags().GetBool("fulltext-only")
+
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		// Create embedding service based on flags
+		apiKey, _ := cmd.Flags().GetString("api-key")
+		model, _ := cmd.Flags().GetString("model")
+		useGemini, _ := cmd.Flags().GetBool("gemini")
+
+		var embeddingService search.EmbeddingService
+		if fulltextOnly {
+			fmt.Println("📝 Running in fulltext-only mode (BM25 + semantic graph search, no vector search)")
+		} else if useGemini && apiKey != "" {
+			embeddingService = search.NewGeminiEmbeddingService(apiKey, model)
+			fmt.Printf("🔗 Using Google Gemini embedding service (model: %s) for search\n", model)
+		} else {
+			return fmt.Errorf("search testing requires --gemini --api-key=<key>, or use --fulltext-only to skip vector search")
+		}
+
+		// Create hybrid search manager with Qdrant vector store.
+		vectorStore, err := createVectorStore()
+		if err != nil {
+			return err
+		}
+		defer vectorStore.(*search.QdrantVectorStore).Close()
+		fmt.Println("📦 Using Qdrant vector backend")
+
+		hybridSearch := search.NewHybridSearchManager(client, embeddingService, vectorStore)
+
+		fmt.Printf("🔍 Testing hybrid search for: '%s'\n", query)
+		fmt.Println("=" + strings.Repeat("=", len(query)+35))
+
+		ctx := context.Background()
+
+		// Perform hybrid search
+		response, err := hybridSearch.UnifiedSearch(ctx, query, limit)
+		if err != nil {
+			return fmt.Errorf("hybrid search failed: %w", err)
+		}
+
+		// Display results
+		fmt.Printf("\n📊 Search Results (%d total):\n", response.TotalResults)
+		fmt.Printf("Search Types: %v\n", response.SearchTypes)
+		fmt.Printf("Vector Results: %d | Full-Text Results: %d | Semantic Results: %d\n",
+			response.Metadata.VectorResults,
+			response.Metadata.FullTextResults,
+			response.Metadata.SemanticResults)
+
+		fmt.Println("\nResults:")
+		fmt.Println("---------")
+
+		for i, result := range response.Results {
+			fmt.Printf("\n%d. ", i+1)
+
+			name := ""
+			for _, field := range []string{"name", "title", "displayName", "signature", "symbol", "path"} {
+				if v, ok := result.Node[field].(string); ok && v != "" {
+					name = v
+					break
+				}
+			}
+			if name == "" {
+				name = "Unknown"
+			}
+			if len(name) > 80 {
+				name = name[:77] + "..."
+			}
+			fmt.Printf("**%s**", name)
+
+			if len(result.Labels) > 0 {
+				fmt.Printf(" (%s)", strings.Join(result.Labels, ", "))
+			}
+			fmt.Printf("\n   RRF Score: %.5f | Source: %s | Relevance: %s\n",
+				result.CombinedScore, result.Source, result.Relevance)
+
+			// Raw scores
+			var scores []string
+			if result.VectorScore > 0 {
+				scores = append(scores, fmt.Sprintf("Vector: %.4f", result.VectorScore))
+			}
+			if result.FullTextScore > 0 {
+				scores = append(scores, fmt.Sprintf("BM25: %.2f", result.FullTextScore))
+			}
+			if result.SemanticScore > 0 {
+				scores = append(scores, fmt.Sprintf("Semantic: %.4f", result.SemanticScore))
+			}
+			if len(scores) > 0 {
+				fmt.Printf("   Raw scores: %s\n", strings.Join(scores, " | "))
+			}
+
+			// Location info
+			if fp, ok := result.Node["filePath"].(string); ok && fp != "" {
+				loc := fp
+				if sl, ok := result.Node["startLine"]; ok {
+					loc = fmt.Sprintf("%s:%v", fp, sl)
+				}
+				fmt.Printf("   Location: %s\n", loc)
+			}
+
+			// Description or content snippet
+			if description, ok := result.Node["description"].(string); ok && description != "" {
+				if len(description) > 120 {
+					description = description[:117] + "..."
+				}
+				fmt.Printf("   Description: %s\n", description)
+			} else if content, ok := result.Node["content"].(string); ok && content != "" {
+				if len(content) > 120 {
+					content = content[:117] + "..."
+				}
+				fmt.Printf("   Content: %s\n", content)
+			}
+		}
+
+		return nil
+	},
+}
+
+var searchInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Show search capabilities and index status",
+	Long:  "Display information about available search methods and index status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		// For info command, we don't need embedding service, just to check capabilities
+		vectorStore, err := createVectorStore()
+		if err != nil {
+			return err
+		}
+		defer vectorStore.(*search.QdrantVectorStore).Close()
+		hybridSearch := search.NewHybridSearchManager(client, nil, vectorStore)
+
+		fmt.Println("🔍 CodeGraph Search Capabilities")
+		fmt.Println("=================================")
+
+		ctx := context.Background()
+		capabilities, err := hybridSearch.GetSearchCapabilities(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get search capabilities: %w", err)
+		}
+
+		// Display vector search info
+		if vectorInfo, ok := capabilities["vectorSearch"].(map[string]interface{}); ok {
+			fmt.Println("\n📊 Vector Search:")
+			if indexes, ok := vectorInfo["vectorIndexes"].([]map[string]interface{}); ok {
+				fmt.Printf("   Indexes: %d\n", len(indexes))
+				for _, index := range indexes {
+					if name, ok := index["name"].(string); ok {
+						fmt.Printf("   - %s", name)
+						if state, ok := index["state"].(string); ok {
+							fmt.Printf(" (%s)", state)
+						}
+						fmt.Println()
+					}
+				}
+			}
+		}
+
+		// Display full-text search info
+		if fullTextInfo, ok := capabilities["fullTextSearch"].(map[string]interface{}); ok {
+			fmt.Println("\n📝 Full-Text Search (BM25):")
+			if indexes, ok := fullTextInfo["fullTextIndexes"].([]map[string]interface{}); ok {
+				fmt.Printf("   Indexes: %d\n", len(indexes))
+				for _, index := range indexes {
+					if name, ok := index["name"].(string); ok {
+						fmt.Printf("   - %s", name)
+						if state, ok := index["state"].(string); ok {
+							fmt.Printf(" (%s)", state)
+						}
+						fmt.Println()
+					}
+				}
+			}
+		}
+
+		// Display hybrid search info
+		if hybridInfo, ok := capabilities["hybridSearch"].(map[string]interface{}); ok {
+			fmt.Println("\n🔬 Hybrid Search:")
+			if methods, ok := hybridInfo["supportedMethods"].([]string); ok {
+				fmt.Printf("   Methods: %v\n", methods)
+			}
+			if weights, ok := hybridInfo["defaultWeights"]; ok {
+				fmt.Printf("   Default Weights: %+v\n", weights)
+			}
+			if smartSearch, ok := hybridInfo["smartSearch"].(bool); ok {
+				fmt.Printf("   Smart Search: %t\n", smartSearch)
+			}
+			if embeddingService, ok := hybridInfo["embeddingService"].(bool); ok {
+				fmt.Printf("   Embedding Service: %t\n", embeddingService)
+			}
+		}
+
+		fmt.Println("\n✨ Available Commands:")
+		fmt.Println("   codegraph search init          # Initialize search indexes")
+		fmt.Println("   codegraph search test 'query'  # Test hybrid search")
+		fmt.Println("   codegraph search info          # Show this information")
+
+		return nil
+	},
+}
+
+// searchEnrichCmd enriches Qdrant point payloads with filePath/startLine/endLine
+// from Neo4j without re-generating embeddings.
+var searchEnrichCmd = &cobra.Command{
+	Use:   "enrich",
+	Short: "Enrich Qdrant payloads with file location metadata from Neo4j",
+	Long: `Reads all points from Qdrant, looks up their nodeKeys in Neo4j,
+and updates each point's payload with filePath, startLine, and endLine.
+No re-embedding is required — only metadata is updated.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		qdrantStore, err := createVectorStore()
+		if err != nil {
+			return err
+		}
+		qs := qdrantStore.(*search.QdrantVectorStore)
+		defer qs.Close()
+
+		ctx := context.Background()
+		collections := []string{
+			"function_embeddings_768",
+			"method_embeddings_768",
+			"class_embeddings_768",
+			"document_embeddings_768",
+			"feature_embeddings_768",
+		}
+
+		totalUpdated := 0
+		for _, col := range collections {
+			fmt.Printf("🔍 Scrolling collection %s...\n", col)
+			points, err := qs.ScrollPoints(ctx, col)
+			if err != nil {
+				fmt.Printf("   ⚠️  Failed to scroll %s: %v\n", col, err)
+				continue
+			}
+			if len(points) == 0 {
+				fmt.Printf("   (empty)\n")
+				continue
+			}
+
+			// Collect nodeKeys that lack filePath in their payload.
+			var needsEnrich []search.ScrolledPoint
+			for _, pt := range points {
+				if pt.Payload["filePath"] == "" {
+					needsEnrich = append(needsEnrich, pt)
+				}
+			}
+			fmt.Printf("   Found %d points, %d need filePath enrichment\n", len(points), len(needsEnrich))
+			if len(needsEnrich) == 0 {
+				continue
+			}
+
+			// Batch-resolve nodeKeys from Neo4j.
+			nodeKeys := make([]string, len(needsEnrich))
+			for i, pt := range needsEnrich {
+				nodeKeys[i] = pt.Payload["nodeKey"]
+			}
+
+			records, err := client.ExecuteQuery(ctx,
+				`UNWIND $keys AS key
+				 MATCH (n) WHERE n.nodeKey = key
+				 RETURN n.nodeKey AS nodeKey,
+				        coalesce(n.filePath, '') AS filePath,
+				        coalesce(toString(n.startLine), '') AS startLine,
+				        coalesce(toString(n.endLine), '') AS endLine`,
+				map[string]any{"keys": nodeKeys})
+			if err != nil {
+				fmt.Printf("   ⚠️  Neo4j lookup failed: %v\n", err)
+				continue
+			}
+
+			// Build nodeKey → location map.
+			locMap := make(map[string]map[string]string, len(records))
+			for _, rec := range records {
+				rm := rec.AsMap()
+				nk, _ := rm["nodeKey"].(string)
+				locMap[nk] = map[string]string{
+					"filePath":  fmt.Sprintf("%v", rm["filePath"]),
+					"startLine": fmt.Sprintf("%v", rm["startLine"]),
+					"endLine":   fmt.Sprintf("%v", rm["endLine"]),
+				}
+			}
+
+			// Apply updates.
+			var uuids []string
+			var payloads []map[string]string
+			for _, pt := range needsEnrich {
+				loc, ok := locMap[pt.Payload["nodeKey"]]
+				if !ok || loc["filePath"] == "" {
+					continue // No data in Neo4j for this point.
+				}
+				uuids = append(uuids, pt.UUID)
+				payloads = append(payloads, loc)
+			}
+
+			if len(uuids) > 0 {
+				if err := qs.SetPayloadFields(ctx, col, uuids, payloads); err != nil {
+					fmt.Printf("   ⚠️  SetPayload failed: %v\n", err)
+				} else {
+					fmt.Printf("   ✓ Enriched %d points in %s\n", len(uuids), col)
+					totalUpdated += len(uuids)
+				}
+			}
+		}
+
+		fmt.Printf("\n🎉 Enrichment complete. Updated %d points total.\n", totalUpdated)
+		return nil
+	},
+}
+
+var searchEmbedCmd = &cobra.Command{
+	Use:   "embed",
+	Short: "Generate and populate embeddings for existing nodes",
+	Long:  "Generate embeddings for Functions, Documents, Features, and Classes that don't have embeddings yet",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		batchSize, _ := cmd.Flags().GetInt("batch-size")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		apiKey, _ := cmd.Flags().GetString("api-key")
+		baseURL, _ := cmd.Flags().GetString("base-url")
+		model, _ := cmd.Flags().GetString("model")
+		// useOpenRouter, _ := cmd.Flags().GetBool("openrouter")
+		useGemini, _ := cmd.Flags().GetBool("gemini")
+
+		// Create embedding service
+		var embeddingService search.EmbeddingService
+		if useGemini && apiKey != "" {
+			embeddingService = search.NewGeminiEmbeddingService(apiKey, model)
+			fmt.Printf("🔗 Using Google Gemini embedding service (model: %s)\n", model)
+		} else if apiKey != "" && baseURL != "" {
+			embeddingService = search.NewSimpleEmbeddingService(baseURL, apiKey, model)
+			fmt.Printf("🔗 Using real embedding service: %s (model: %s)\n", baseURL, model)
+		} else {
+			return fmt.Errorf("embedding generation requires either --gemini with GEMINI_API_KEY or --api-key with --base-url")
+		}
+		// else if useOpenRouter && apiKey != "" {
+		// 	embeddingService = search.NewOpenRouterEmbeddingService(apiKey, model)
+		// 	fmt.Printf("🔗 Using OpenRouter embedding service (model: %s)\n", model)
+		// }
+
+		ctx := context.Background()
+
+		// Create Qdrant vector store.
+		vectorStore, err := createVectorStore()
+		if err != nil {
+			return err
+		}
+		defer vectorStore.(*search.QdrantVectorStore).Close()
+		fmt.Println("📦 Using Qdrant vector backend for embedding storage")
+
+		fmt.Printf("🚀 Starting embedding population (batch size: %d, dry-run: %t)...\n", batchSize, dryRun)
+
+		// Process each node type
+		nodeTypes := []string{"Function", "Method", "Class", "Document", "Feature"}
+		totalProcessed := 0
+
+		for _, nodeType := range nodeTypes {
+			fmt.Printf("\n📊 Processing %s nodes...\n", nodeType)
+
+			processed, err := populateEmbeddingsForNodeType(ctx, client, embeddingService, vectorStore, nodeType, batchSize, dryRun)
+			if err != nil {
+				fmt.Printf("⚠️  Error processing %s nodes: %v\n", nodeType, err)
+				continue
+			}
+
+			totalProcessed += processed
+			fmt.Printf("✓ Processed %d %s nodes\n", processed, nodeType)
+		}
+
+		fmt.Printf("\n🎉 Embedding population completed! Processed %d nodes total.\n", totalProcessed)
+		return nil
+	},
+}
+
+// searchCommentCmd handles comment/docstring-based embedding generation
+var searchCommentCmd = &cobra.Command{
+	Use:   "comments",
+	Short: "Generate embeddings for docstrings and comments only",
+	Long:  "Extract docstrings and comments from functions/methods/classes and create embeddings for semantic search",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to create Neo4j client: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		batchSize, _ := cmd.Flags().GetInt("batch-size")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		apiKey, _ := cmd.Flags().GetString("api-key")
+		baseURL, _ := cmd.Flags().GetString("base-url")
+		model, _ := cmd.Flags().GetString("model")
+		useGemini, _ := cmd.Flags().GetBool("gemini")
+		dimensions, _ := cmd.Flags().GetInt("dimensions")
+		force, _ := cmd.Flags().GetBool("force")
+
+		// Create embedding service
+		var embeddingService search.EmbeddingService
+		if useGemini && apiKey != "" {
+			embeddingService = search.NewGeminiEmbeddingService(apiKey, model)
+			fmt.Printf("🔗 Using Google Gemini embedding service (model: %s)\n", model)
+		} else if apiKey != "" && baseURL != "" {
+			embeddingService = search.NewSimpleEmbeddingService(baseURL, apiKey, model)
+			fmt.Printf("🔗 Using real embedding service: %s (model: %s)\n", baseURL, model)
+		} else {
+			return fmt.Errorf("comment embedding generation requires either --gemini with GEMINI_API_KEY or --api-key with --base-url")
+		}
+
+		// Create comment embedding service
+		commentService := search.NewCommentEmbeddingService(client, embeddingService)
+
+		// Clear existing comment embeddings if force flag is set
+		if force {
+			fmt.Printf("🧹 Clearing existing comment embeddings...\n")
+			clearQuery := `
+				MATCH (n)-[r:HAS_COMMENT]->(c:Comment)
+				WHERE c.isDocstring = true
+				DELETE r, c
+			`
+			_, err := client.ExecuteQuery(context.Background(), clearQuery, nil)
+			if err != nil {
+				fmt.Printf("Warning: failed to clear existing comment embeddings: %v\n", err)
+			} else {
+				fmt.Printf("✅ Cleared existing comment embeddings\n")
+			}
+		}
+
+		// Create comment embedding index
+		fmt.Printf("📊 Creating comment embedding index...\n")
+		if err := commentService.CreateCommentEmbeddingIndex(context.Background(), dimensions); err != nil {
+			return fmt.Errorf("failed to create comment embedding index: %w", err)
+		}
+
+		// Extract and embed docstrings
+		fmt.Printf("🚀 Starting comment embedding extraction (batch size: %d, dry-run: %t)...\n", batchSize, dryRun)
+
+		if err := commentService.ExtractAndEmbedDocstrings(context.Background(), batchSize, dryRun); err != nil {
+			return fmt.Errorf("failed to extract and embed docstrings: %w", err)
+		}
+
+		fmt.Printf("\n🎉 Comment embedding extraction completed!\n")
+
+		// Test search functionality
+		if !dryRun {
+			fmt.Printf("\n🧪 Testing comment-based search...\n")
+			testQueries := []string{
+				"authentication",
+				"database connection",
+				"error handling",
+				"HTTP request",
+			}
+
+			for _, query := range testQueries {
+				fmt.Printf("   Testing query: '%s'\n", query)
+				results, err := commentService.SearchFunctionsByComment(context.Background(), query, 3)
+				if err != nil {
+					fmt.Printf("   ❌ Search failed: %v\n", err)
+					continue
+				}
+
+				if len(results.Results) == 0 {
+					fmt.Printf("   📭 No results found\n")
+				} else {
+					fmt.Printf("   📋 Found %d results:\n", len(results.Results))
+					for i, result := range results.Results {
+						parentName := getStringFromInterface(result.ParentNode, "name")
+						parentType := getStringFromInterface(result.CommentNode, "parentType")
+						fmt.Printf("     %d. %s %s (similarity: %.3f)\n", i+1, parentType, parentName, result.Score)
+					}
+				}
+				fmt.Printf("\n")
+			}
+		}
+
+		return nil
+	},
+}
+
+// linkCmd handles linking features to code implementations
+var linkCmd = &cobra.Command{
+	Use:   "link",
+	Short: "Link features to code implementations",
+	Long:  "Create semantic links between features and code implementations using LLM analysis",
+}
+
+var linkFeaturesCmd = &cobra.Command{
+	Use:   "features",
+	Short: "Link all features to their code implementations",
+	Long: `Link all features in the database to their code implementations using RFC-002 semantic analysis.
+
+This command implements the full RFC-002 specification:
+1. Generate embeddings for feature descriptions
+2. Find candidate code entry points using vector search
+3. Extract and summarize code subgraphs using LLM
+4. Validate feature-code matches using LLM analysis
+5. Create IMPLEMENTS relationships for validated matches
+
+The process uses advanced semantic understanding to connect high-level business requirements
+to the specific code functions that implement them.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Printf("🚀 Starting RFC-002 Feature Linking Process...\n\n")
+
+		// Create Neo4j client
+		client, err := createNeo4jClient()
+		if err != nil {
+			return fmt.Errorf("failed to connect to Neo4j: %w", err)
+		}
+		defer client.Close(context.Background())
+
+		// Create LLM provider using new abstraction
+		providerWrapper, err := createLLMProvider(cmd)
+		if err != nil {
+			return fmt.Errorf("failed to create LLM provider: %w", err)
+		}
+		defer providerWrapper.Provider.Close()
+
+		// Get command flags
+		minConfidence, _ := cmd.Flags().GetFloat64("min-confidence")
+		maxCandidates, _ := cmd.Flags().GetInt("max-candidates")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		// Display provider information
+		fmt.Printf("🔗 LLM Provider: %s\n", providerWrapper.Provider.Name())
+		if providerWrapper.Provider.SupportsEmbeddings() {
+			fmt.Printf("🧠 Embeddings: Enabled\n")
+		}
+		if providerWrapper.Provider.SupportsTextGeneration() {
+			fmt.Printf("🤖 Text Generation: Enabled\n")
+		}
+
+		// Create feature linker with provider adapters
+		vectorStore, err := createVectorStore()
+		if err != nil {
+			return err
+		}
+		defer vectorStore.(*search.QdrantVectorStore).Close()
+		featureLinker := search.NewFeatureLinker(client, providerWrapper.EmbeddingService, vectorStore)
+
+		// Enable LLM service if available
+		if providerWrapper.Provider.SupportsTextGeneration() {
+			featureLinker = featureLinker.WithLLMService(providerWrapper.LLMService)
+		} else {
+			fmt.Printf("⚠️  Text generation not available - will use heuristic validation\n")
+		}
+
+		// Configure confidence threshold
+		if minConfidence > 0 {
+			fmt.Printf("📊 Using minimum confidence threshold: %.2f\n", minConfidence)
+		}
+
+		fmt.Printf("🎯 Maximum candidates per feature: %d\n", maxCandidates)
+
+		if dryRun {
+			fmt.Printf("🧪 DRY RUN MODE - No relationships will be created\n")
+		}
+
+		fmt.Printf("\n")
+
+		// Link all features
+		results, err := featureLinker.LinkAllFeatures(context.Background())
+		if err != nil {
+			return fmt.Errorf("feature linking failed: %w", err)
+		}
+
+		// Display results
+		fmt.Printf("\n📊 FEATURE LINKING RESULTS\n")
+		fmt.Println("=" + strings.Repeat("=", 50) + "\n")
+
+		totalFeatures := len(results)
+		totalLinks := 0
+		totalCandidates := 0
+
+		for _, result := range results {
+			totalCandidates += result.CandidatesFound
+			totalLinks += len(result.ImplementsLinks)
+
+			fmt.Printf("🎯 FEATURE: %s\n", result.FeatureName)
+			if result.FeatureDescription != "" {
+				fmt.Printf("   Description: %s\n", result.FeatureDescription)
+			}
+			fmt.Printf("   Candidates Found: %d\n", result.CandidatesFound)
+			fmt.Printf("   Candidates Validated: %d\n", result.CandidatesValidated)
+			fmt.Printf("   IMPLEMENTS Links Created: %d\n", len(result.ImplementsLinks))
+
+			if len(result.ImplementsLinks) > 0 {
+				fmt.Printf("   📝 IMPLEMENTATIONS:\n")
+				for i, link := range result.ImplementsLinks {
+					fmt.Printf("      %d. %s (confidence: %.3f)\n", i+1, link.FunctionName, link.Confidence)
+					if link.CodeSummary != "" {
+						fmt.Printf("         Summary: %s\n", link.CodeSummary)
+					}
+					fmt.Printf("         Subgraph Size: %d functions\n", link.SubgraphSize)
+					fmt.Printf("         Validation: %s\n", link.ValidationMethod)
+				}
+			}
+			fmt.Printf("\n")
+		}
+
+		// Summary statistics
+		fmt.Printf("🎉 SUMMARY\n")
+		fmt.Println("=" + strings.Repeat("=", 30))
+		fmt.Printf("Features Processed: %d\n", totalFeatures)
+		fmt.Printf("Total Candidates Evaluated: %d\n", totalCandidates)
+		fmt.Printf("Total IMPLEMENTS Links Created: %d\n", totalLinks)
+
+		if totalFeatures > 0 {
+			fmt.Printf("Average Links per Feature: %.2f\n", float64(totalLinks)/float64(totalFeatures))
+		}
+
+		if !dryRun {
+			fmt.Printf("\n✅ Feature linking completed successfully!\n")
+			fmt.Printf("💡 Use 'codegraph query feature-implementations <featureId>' to explore specific implementations\n")
+		} else {
+			fmt.Printf("\n🧪 Dry run completed - no changes made to database\n")
+		}
+
+		return nil
+	},
+}
+
+func populateEmbeddingsForNodeType(ctx context.Context, client *neo4j.Client, embeddingService search.EmbeddingService, vectorStore search.VectorStore, nodeType string, batchSize int, dryRun bool) (int, error) {
+	// Query nodes that haven't been embedded into Qdrant yet.
+	// We use the embeddedAt timestamp to track which nodes are already in the vector store.
+	query := fmt.Sprintf(`
+		MATCH (n:%s)
+		WHERE n.embeddedAt IS NULL
+		RETURN elementId(n) as nodeId, n.name as name, n.nodeKey as nodeKey, n.signature as signature, n.description as description, n.content as content, n.title as title, n.filePath as filePath, n.startLine as startLine, n.endLine as endLine
+		LIMIT 1000
+	`, nodeType)
+
+	results, err := client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query %s nodes: %w", nodeType, err)
+	}
+
+	if len(results) == 0 {
+		fmt.Printf("   No %s nodes need embeddings\n", nodeType)
+		return 0, nil
+	}
+
+	fmt.Printf("   Found %d %s nodes without embeddings\n", len(results), nodeType)
+
+	if dryRun {
+		return len(results), nil
+	}
+
+	// Process in batches
+	processed := 0
+	for i := 0; i < len(results); i += batchSize {
+		end := i + batchSize
+		if end > len(results) {
+			end = len(results)
+		}
+
+		batch := results[i:end]
+		var texts []string
+
+		type nodeInfo struct {
+			nodeId      string
+			nodeKey     string
+			name        string
+			signature   string
+			description string
+			filePath    string
+			startLine   int64
+			endLine     int64
+		}
+		var nodeInfos []nodeInfo
+
+		// Prepare texts for embedding
+		for _, record := range batch {
+			recordMap := record.AsMap()
+			nodeId, _ := recordMap["nodeId"].(string)
+			nodeKey, _ := recordMap["nodeKey"].(string)
+
+			// Build text for embedding based on available fields
+			var textParts []string
+			name, _ := recordMap["name"].(string)
+			if name != "" {
+				textParts = append(textParts, name)
+			}
+			if title, ok := recordMap["title"].(string); ok && title != "" {
+				textParts = append(textParts, title)
+			}
+			signature, _ := recordMap["signature"].(string)
+			if signature != "" {
+				textParts = append(textParts, signature)
+			}
+			description, _ := recordMap["description"].(string)
+			if description != "" {
+				textParts = append(textParts, description)
+			}
+			if content, ok := recordMap["content"].(string); ok && content != "" {
+				if len(content) > 500 {
+					content = content[:500] + "..."
+				}
+				textParts = append(textParts, content)
+			}
+
+			text := strings.Join(textParts, " | ")
+			if text == "" {
+				text = fmt.Sprintf("%s node", nodeType)
+			}
+
+			filePath, _ := recordMap["filePath"].(string)
+			startLine, _ := recordMap["startLine"].(int64)
+			endLine, _ := recordMap["endLine"].(int64)
+
+			texts = append(texts, text)
+			nodeInfos = append(nodeInfos, nodeInfo{
+				nodeId:      nodeId,
+				nodeKey:     nodeKey,
+				name:        name,
+				signature:   signature,
+				description: description,
+				filePath:    filePath,
+				startLine:   startLine,
+				endLine:     endLine,
+			})
+		}
+
+		// Generate embeddings
+		fmt.Printf("   Generating embeddings for batch %d-%d...\n", i+1, end)
+		embeddings, err := embeddingService.GenerateBatchEmbeddings(ctx, texts)
+		if err != nil {
+			return processed, fmt.Errorf("failed to generate embeddings: %w", err)
+		}
+
+		// Upsert to Qdrant vector store.
+		var upserts []search.VectorUpsert
+		var embeddedNodeIds []string
+		for j, embedding := range embeddings {
+			info := nodeInfos[j]
+			id := info.nodeKey
+			if id == "" {
+				id = info.nodeId
+			}
+			upserts = append(upserts, search.VectorUpsert{
+				ID:        id,
+				Vector:    embedding,
+				NodeLabel: nodeType,
+				Metadata: map[string]any{
+					"name":        info.name,
+					"signature":   info.signature,
+					"description": info.description,
+					"filePath":    info.filePath,
+					"startLine":   fmt.Sprintf("%d", info.startLine),
+					"endLine":     fmt.Sprintf("%d", info.endLine),
+				},
+			})
+			embeddedNodeIds = append(embeddedNodeIds, info.nodeId)
+		}
+		fmt.Printf("   Upserting %d vectors to Qdrant...\n", len(upserts))
+		if err := vectorStore.UpsertVectors(ctx, upserts); err != nil {
+			return processed, fmt.Errorf("failed to upsert vectors: %w", err)
+		}
+
+		// Mark nodes as embedded in Neo4j so they're skipped on re-runs.
+		stampQuery := `
+			UNWIND $ids AS id
+			MATCH (n) WHERE elementId(n) = id
+			SET n.embeddedAt = datetime()
+		`
+		if _, err := client.ExecuteQuery(ctx, stampQuery, map[string]any{"ids": embeddedNodeIds}); err != nil {
+			fmt.Printf("   Warning: failed to stamp embeddedAt: %v\n", err)
+		}
+
+		processed += len(batch)
+	}
+
+	return processed, nil
+}
+
+func init() {
+	// Schema subcommands
+	schemaCmd.AddCommand(schemaCreateCmd)
+	schemaCmd.AddCommand(schemaDropCmd)
+	schemaCmd.AddCommand(schemaInfoCmd)
+
+	// Index subcommands
+	indexCmd.AddCommand(indexProjectCmd)
+	indexCmd.AddCommand(indexSCIPCmd)
+	indexCmd.AddCommand(indexIncrementalCmd)
+	indexCmd.AddCommand(indexDocsCmd)
+	indexDocsCmd.AddCommand(docsSyncCmd)
+	indexCmd.AddCommand(indexTombstoneCmd)
+
+	// Flags for project command
+	indexProjectCmd.Flags().StringP("service", "s", "", "Service name")
+	indexProjectCmd.Flags().StringP("version", "", "v1.0.0", "Service version")
+	indexProjectCmd.Flags().StringP("repo-url", "r", "", "Repository URL")
+	indexProjectCmd.Flags().Bool("generate-embeddings", false, "Generate embeddings for indexed nodes")
+	indexProjectCmd.Flags().String("embedding-api-key", "", "API key for real embedding service")
+	indexProjectCmd.Flags().String("embedding-base-url", "", "Base URL for embedding API")
+	indexProjectCmd.Flags().String("embedding-model", "gemini-embedding-001", "Embedding model to use")
+	indexProjectCmd.Flags().Bool("embedding-openrouter", false, "Use OpenRouter for embeddings (requires --embedding-api-key)")
+	indexProjectCmd.Flags().Bool("embedding-gemini", false, "Use Google Gemini for embeddings (requires --embedding-api-key)")
+
+	// Flags for SCIP command
+	indexSCIPCmd.Flags().StringP("service", "s", "", "Service name")
+	indexSCIPCmd.Flags().StringP("version", "", "v1.0.0", "Service version")
+	indexSCIPCmd.Flags().StringP("repo-url", "r", "", "Repository URL")
+	indexSCIPCmd.Flags().StringP("language", "l", "", fmt.Sprintf("Language to index (supported: %s). If not specified, language will be auto-detected", static.FormatLanguageList()))
+	indexSCIPCmd.Flags().String("scope", "main", "Scope for indexing: 'main' (default) or 'pr'")
+	indexSCIPCmd.Flags().String("scope-id", "", "Scope ID (e.g., 'pr-42'). Defaults to scope value if not set.")
+	indexSCIPCmd.Flags().Bool("no-auto-install", false, "Skip automatic SCIP indexer installation (fail if not found)")
+
+	// Flags for docs command
+	indexDocsCmd.Flags().String("scope", "main", "Scope for indexing: 'main' (default) or 'pr'")
+	indexDocsCmd.Flags().String("scope-id", "", "Scope ID (e.g., 'pr-42'). Defaults to scope value if not set.")
+
+	// Flags for docs sync command
+	docsSyncCmd.Flags().String("source", "", "Document source (e.g., 'confluence')")
+	docsSyncCmd.Flags().String("space", "", "Space/collection to sync (e.g., Confluence space key)")
+	docsSyncCmd.Flags().String("url", "", "Single document URL to sync")
+	docsSyncCmd.Flags().String("doc-id", "", "Single document ID to sync")
+	docsSyncCmd.Flags().String("base-url", "", "Base URL of the document source API")
+	docsSyncCmd.Flags().String("username", "", "Username for authentication")
+	docsSyncCmd.Flags().String("api-token", "", "API token for authentication")
+	docsSyncCmd.Flags().String("scope", "main", "Scope for indexing: 'main' (default) or 'pr'")
+	docsSyncCmd.Flags().String("scope-id", "", "Scope ID (e.g., 'pr-42')")
+
+	// Flags for tombstone command
+	indexTombstoneCmd.Flags().String("scope", "pr", "Scope for tombstone creation (must be 'pr')")
+	indexTombstoneCmd.Flags().String("scope-id", "", "Scope ID for the PR (e.g., 'pr-42')")
+
+	// Flags for incremental command
+	indexIncrementalCmd.Flags().StringP("service", "s", "", "Service name")
+	indexIncrementalCmd.Flags().StringP("version", "", "v1.0.0", "Service version")
+	indexIncrementalCmd.Flags().StringP("repo-url", "r", "", "Repository URL")
+
+	// Query subcommands
+	queryCmd.AddCommand(querySearchCmd)
+	queryCmd.AddCommand(querySourceCmd)
+	queryCmd.AddCommand(queryDepsCmd)
+	queryCmd.AddCommand(queryFlowsCmd)
+
+	// Query flags
+	querySearchCmd.Flags().IntP("limit", "l", 0, "Limit search results (0 = no limit)")
+	querySearchCmd.Flags().String("scope-id", "", "Optional scope ID for overlay-aware search (e.g., pr-42)")
+	queryDepsCmd.Flags().String("service", "", "Service name to query dependencies for")
+	queryDepsCmd.Flags().String("scope-id", "", "Optional scope ID for overlay-aware query")
+
+	// Flow flags
+	queryFlowsCmd.Flags().Bool("generate", false, "Generate flow spines from API endpoints")
+	queryFlowsCmd.Flags().Int("max-depth", 2, "Maximum call graph traversal depth")
+	queryFlowsCmd.Flags().String("type", "", "Filter by flow type (api, consumer, cron)")
+	queryFlowsCmd.Flags().String("scope-id", "", "Optional scope ID for overlay-aware flows")
+
+	// Benchmark subcommands
+	benchmarkCmd.AddCommand(benchmarkMemoryCmd)
+	benchmarkCmd.AddCommand(benchmarkFullCmd)
+	benchmarkCmd.AddCommand(benchmarkIncrementalCmd)
+	benchmarkCmd.AddCommand(benchmarkPipelineCmd)
+
+	// Benchmark pipeline flags
+	benchmarkPipelineCmd.Flags().StringP("service", "s", "", "Service name")
+	benchmarkPipelineCmd.Flags().StringP("version", "", "v1.0.0", "Service version")
+	benchmarkPipelineCmd.Flags().StringP("repo-url", "r", "", "Repository URL")
+	benchmarkPipelineCmd.Flags().StringP("language", "l", "", "Language to index (auto-detected if not specified)")
+	benchmarkPipelineCmd.Flags().Bool("pprof", false, "Write CPU profile to cpu.prof")
+	benchmarkPipelineCmd.Flags().Bool("json", false, "Output results as JSON instead of table")
+
+	// Benchmark flags
+	benchmarkMemoryCmd.Flags().StringP("service", "s", "", "Service name")
+	benchmarkMemoryCmd.Flags().StringP("version", "", "v1.0.0", "Service version")
+	benchmarkMemoryCmd.Flags().StringP("repo-url", "r", "", "Repository URL")
+	benchmarkMemoryCmd.Flags().DurationP("sample-interval", "i", 2*time.Second, "Memory sampling interval")
+
+	benchmarkFullCmd.Flags().StringP("service", "s", "", "Service name")
+	benchmarkFullCmd.Flags().StringP("version", "", "v1.0.0", "Service version")
+	benchmarkFullCmd.Flags().StringP("repo-url", "r", "", "Repository URL")
+	benchmarkFullCmd.Flags().DurationP("sample-interval", "i", 2*time.Second, "Memory sampling interval")
+
+	benchmarkIncrementalCmd.Flags().StringP("service", "s", "", "Service name")
+	benchmarkIncrementalCmd.Flags().StringP("version", "", "v1.0.0", "Service version")
+	benchmarkIncrementalCmd.Flags().StringP("repo-url", "r", "", "Repository URL")
+	benchmarkIncrementalCmd.Flags().DurationP("sample-interval", "i", 2*time.Second, "Memory sampling interval")
+
+	// Search subcommands
+	searchCmd.AddCommand(searchInitCmd)
+	searchCmd.AddCommand(searchTestCmd)
+	searchCmd.AddCommand(searchInfoCmd)
+	searchCmd.AddCommand(searchEmbedCmd)
+	searchCmd.AddCommand(searchCommentCmd)
+	searchCmd.AddCommand(searchEnrichCmd)
+
+	// Search flags
+	searchTestCmd.Flags().IntP("limit", "l", 10, "Limit search results")
+	searchTestCmd.Flags().String("api-key", "", "Embedding API key (for real embedding service)")
+	searchTestCmd.Flags().String("model", "gemini-embedding-001", "Embedding model to use")
+	searchTestCmd.Flags().Bool("gemini", false, "Use Google Gemini API (requires --api-key)")
+	searchTestCmd.Flags().Bool("fulltext-only", false, "Skip vector search (no API key required)")
+	searchEmbedCmd.Flags().IntP("batch-size", "b", 50, "Batch size for processing embeddings")
+	searchEmbedCmd.Flags().Bool("dry-run", false, "Show what would be processed without making changes")
+	searchEmbedCmd.Flags().String("api-key", "", "Embedding API key (for real embedding service)")
+	searchEmbedCmd.Flags().String("base-url", "", "Base URL for embedding API (e.g., https://api.openai.com/v1)")
+	searchEmbedCmd.Flags().String("model", "gemini-embedding-001", "Embedding model to use")
+	searchEmbedCmd.Flags().Bool("openrouter", false, "Use OpenRouter API (requires --api-key)")
+	searchEmbedCmd.Flags().Bool("gemini", false, "Use Google Gemini API (requires --api-key)")
+	searchCommentCmd.Flags().IntP("batch-size", "b", 50, "Batch size for processing comment embeddings")
+	searchCommentCmd.Flags().Bool("dry-run", false, "Show what would be processed without making changes")
+	searchCommentCmd.Flags().String("api-key", "", "Embedding API key (for real embedding service)")
+	searchCommentCmd.Flags().String("base-url", "", "Base URL for embedding API")
+	searchCommentCmd.Flags().String("model", "gemini-embedding-001", "Embedding model to use")
+	searchCommentCmd.Flags().Bool("gemini", false, "Use Google Gemini API (requires --api-key)")
+	searchCommentCmd.Flags().Int("dimensions", 768, "Embedding dimensions to use")
+	searchCommentCmd.Flags().Bool("force", false, "Force recreate comment embeddings (remove existing ones first)")
+
+	// Link subcommands
+	linkCmd.AddCommand(linkFeaturesCmd)
+
+	// Link flags
+	linkFeaturesCmd.Flags().Float64("min-confidence", 0.6, "Minimum confidence threshold for creating IMPLEMENTS relationships")
+	linkFeaturesCmd.Flags().Int("max-candidates", 10, "Maximum number of candidate functions to analyze per feature")
+	linkFeaturesCmd.Flags().Bool("dry-run", false, "Show what would be linked without creating relationships")
+
+	// LLM Provider flags
+	linkFeaturesCmd.Flags().String("provider", "", "LLM provider: gemini, litellm, openai (default: from LLM_PROVIDER env or litellm)")
+	linkFeaturesCmd.Flags().String("api-key", "", "API key for LLM provider")
+	linkFeaturesCmd.Flags().String("llm-base-url", "", "Base URL for LiteLLM/OpenAI provider")
+	linkFeaturesCmd.Flags().String("text-model", "", "Model for text generation (e.g., openai/gpt-4)")
+	linkFeaturesCmd.Flags().String("embedding-model", "", "Model for embeddings (e.g., openai/text-embedding-3-small)")
+
+	// Deprecated flags (backward compatibility)
+	linkFeaturesCmd.Flags().String("model", "gemini-embedding-001", "Deprecated: use --embedding-model instead")
+	linkFeaturesCmd.Flags().Bool("gemini", false, "Deprecated: use --provider=gemini instead")
+
+	// Server flags
+	serverCmd.Flags().IntP("port", "p", 8080, "Server port")
+}
+
+// Helper function to extract string values from interface maps
+func getStringFromInterface(data map[string]interface{}, key string) string {
+	if val, ok := data[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+func main() {
+	Execute()
+}
+
+// createNeo4jClient creates a new Neo4j client using configuration
+func createNeo4jClient() (*neo4j.Client, error) {
+	config := neo4j.Config{
+		URI:      viper.GetString("neo4j.uri"),
+		Username: viper.GetString("neo4j.username"),
+		Password: viper.GetString("neo4j.password"),
+		Database: viper.GetString("neo4j.database"),
+	}
+
+	return neo4j.NewClient(config)
+}
+
+// createVectorStore creates a Qdrant-backed VectorStore.
+func createVectorStore() (search.VectorStore, error) {
+	url := viper.GetString("qdrant.url")
+	if url == "" {
+		url = "localhost:6334"
+	}
+	store, err := search.NewQdrantVectorStore(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Qdrant vector store at %s: %w", url, err)
+	}
+	return store, nil
+}
+
+// createLLMProvider creates an LLM provider from CLI flags and environment variables
+func createLLMProvider(cmd *cobra.Command) (*llm.ProviderWrapper, error) {
+	// Determine provider type
+	var providerType llm.ProviderType
+	var apiKey, baseURL, textModel, embModel string
+
+	// Check for --provider flag first
+	providerFlag, _ := cmd.Flags().GetString("provider")
+
+	// Check for --gemini flag (backward compatibility)
+	useGemini, _ := cmd.Flags().GetBool("gemini")
+
+	if providerFlag != "" {
+		// Explicit --provider flag takes precedence
+		providerType = llm.ProviderType(providerFlag)
+	} else if useGemini {
+		// Backward compatibility: --gemini flag
+		providerType = llm.ProviderGemini
+	} else {
+		// Check environment for provider type
+		providerStr := os.Getenv("LLM_PROVIDER")
+		if providerStr == "" {
+			// Check for GEMINI_API_KEY for backward compat
+			if os.Getenv("GEMINI_API_KEY") != "" {
+				providerStr = "gemini"
+			} else {
+				providerStr = "litellm" // Default to LiteLLM
+			}
+		}
+		providerType = llm.ProviderType(providerStr)
+	}
+
+	// Get API key (priority: flag > LLM_API_KEY env > GEMINI_API_KEY env)
+	apiKey, _ = cmd.Flags().GetString("api-key")
+	if apiKey == "" {
+		apiKey = os.Getenv("LLM_API_KEY")
+		if apiKey == "" {
+			apiKey = os.Getenv("GEMINI_API_KEY") // Backward compat
+		}
+	}
+
+	// Get base URL
+	baseURL, _ = cmd.Flags().GetString("llm-base-url")
+	if baseURL == "" {
+		baseURL = os.Getenv("LLM_BASE_URL")
+	}
+
+	// Get text model
+	textModel, _ = cmd.Flags().GetString("text-model")
+	if textModel == "" {
+		textModel = os.Getenv("LLM_TEXT_MODEL")
+		if textModel == "" {
+			// Set defaults based on provider
+			switch providerType {
+			case llm.ProviderGemini:
+				textModel = "gemini-1.5-flash"
+			case llm.ProviderLiteLLM:
+				textModel = "openai/gpt-4"
+			case llm.ProviderOpenAI:
+				textModel = "gpt-4"
+			}
+		}
+	}
+
+	// Get embedding model
+	embModel, _ = cmd.Flags().GetString("embedding-model")
+	if embModel == "" {
+		// Check deprecated --model flag for backward compat
+		embModel, _ = cmd.Flags().GetString("model")
+	}
+	if embModel == "" {
+		embModel = os.Getenv("LLM_EMBEDDING_MODEL")
+		if embModel == "" {
+			// Set defaults based on provider
+			switch providerType {
+			case llm.ProviderGemini:
+				embModel = "gemini-embedding-001"
+			case llm.ProviderLiteLLM:
+				embModel = "openai/text-embedding-3-small"
+			case llm.ProviderOpenAI:
+				embModel = "text-embedding-3-small"
+			}
+		}
+	}
+
+	// Create config
+	config := llm.Config{
+		Provider:       providerType,
+		APIKey:         apiKey,
+		BaseURL:        baseURL,
+		TextModel:      textModel,
+		EmbeddingModel: embModel,
+		Temperature:    0.2,
+		MaxTokens:      1024,
+		TopK:           40,
+		TopP:           0.95,
+	}
+
+	// Create provider
+	provider, err := llm.NewProvider(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM provider: %w", err)
+	}
+
+	// Wrap provider for backward compatibility
+	return llm.WrapProvider(provider), nil
+}

--- a/apps/cli-go/project.json
+++ b/apps/cli-go/project.json
@@ -5,28 +5,14 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "make build",
+        "command": "go build -o bin/codegraph-new ./apps/cli-go/",
         "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
       }
     },
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "make test",
-        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
-      }
-    },
-    "lint": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "make lint",
-        "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
-      }
-    },
-    "integration": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "make test-integration",
+        "command": "go test ./apps/cli-go/...",
         "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
       }
     }

--- a/apps/mcp-server-go/main.go
+++ b/apps/mcp-server-go/main.go
@@ -1,0 +1,2232 @@
+//go:build ignore
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/context-maximiser/code-graph/pkg/indexer/documents"
+	"github.com/context-maximiser/code-graph/pkg/neo4j"
+	"github.com/context-maximiser/code-graph/pkg/search"
+	"github.com/joho/godotenv"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+)
+
+// MCP Protocol Types
+type MCPRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type MCPResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *MCPError   `json:"error,omitempty"`
+}
+
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// MCP Tool Definitions
+type MCPTool struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+type ToolCallRequest struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments"`
+}
+
+type ToolCallResponse struct {
+	Content []ToolContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+type ToolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// CodeGraph MCP Server
+type CodeGraphMCPServer struct {
+	client           *neo4j.Client
+	queryBuilder     *neo4j.QueryBuilder
+	hybridSearch     *search.HybridSearchManager
+	vectorStore      search.VectorStore
+	embeddingService search.EmbeddingService
+	docIndexer       *documents.DocumentIndexer
+	commentSearch    *search.CommentEmbeddingService
+}
+
+func main() {
+	// Load environment variables from .env file
+	if err := godotenv.Load("../.env"); err != nil {
+		log.Printf("Warning: Could not load .env file: %v", err)
+		// Continue execution - environment variables might be set via other means
+	}
+
+	// Initialize Neo4j client
+	config := neo4j.Config{
+		URI:      getEnvOrDefault("NEO4J_URI", "bolt://localhost:7687"),
+		Username: getEnvOrDefault("NEO4J_USER", "neo4j"),
+		Password: getEnvOrDefault("NEO4J_PASSWORD", "password123"),
+		Database: getEnvOrDefault("NEO4J_DATABASE", "neo4j"),
+	}
+
+	client, err := neo4j.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Neo4j client: %v", err)
+	}
+	defer client.Close(context.Background())
+
+	// Initialize embedding service - optional, only required for embedding-based tools
+	var embeddingService search.EmbeddingService
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("GOOGLE_API_KEY") // fallback
+	}
+
+	if apiKey != "" {
+		embeddingService = search.NewGeminiEmbeddingService(apiKey, "gemini-embedding-001")
+		log.Printf("Using Gemini embedding service")
+	} else {
+		log.Printf("Warning: GEMINI_API_KEY not set - embedding-based tools will not be available")
+	}
+
+	// Initialize Qdrant vector store
+	qdrantURL := os.Getenv("QDRANT_URL")
+	if qdrantURL == "" {
+		qdrantURL = "localhost:6334"
+	}
+	vectorStore, err := search.NewQdrantVectorStore(qdrantURL)
+	if err != nil {
+		log.Printf("Warning: failed to connect to Qdrant at %s: %v", qdrantURL, err)
+	}
+
+	// Initialize search managers
+	hybridSearch := search.NewHybridSearchManager(client, embeddingService, vectorStore)
+
+	// Initialize document indexer and comment search
+	docIndexer := documents.NewDocumentIndexer(client)
+	commentSearch := search.NewCommentEmbeddingService(client, embeddingService)
+
+	server := &CodeGraphMCPServer{
+		client:           client,
+		queryBuilder:     neo4j.NewQueryBuilder(client),
+		hybridSearch:     hybridSearch,
+		vectorStore:      vectorStore,
+		embeddingService: embeddingService,
+		docIndexer:       docIndexer,
+		commentSearch:    commentSearch,
+	}
+
+	// Start MCP server
+	server.run()
+}
+
+func (s *CodeGraphMCPServer) run() {
+	scanner := bufio.NewScanner(os.Stdin)
+	
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var request MCPRequest
+		if err := json.Unmarshal([]byte(line), &request); err != nil {
+			s.sendError(request.ID, -32700, "Parse error")
+			continue
+		}
+
+		s.handleRequest(request)
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Printf("Error reading input: %v", err)
+	}
+}
+
+func (s *CodeGraphMCPServer) handleRequest(request MCPRequest) {
+	switch request.Method {
+	case "initialize":
+		s.handleInitialize(request)
+	case "tools/list":
+		s.handleToolsList(request)
+	case "tools/call":
+		s.handleToolCall(request)
+	default:
+		s.sendError(request.ID, -32601, "Method not found")
+	}
+}
+
+func (s *CodeGraphMCPServer) handleInitialize(request MCPRequest) {
+	result := map[string]interface{}{
+		"protocolVersion": "2024-11-05",
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    "codegraph-mcp-server",
+			"version": "1.0.0",
+		},
+	}
+
+	s.sendResponse(request.ID, result)
+}
+
+func (s *CodeGraphMCPServer) handleToolsList(request MCPRequest) {
+	tools := []MCPTool{
+		{
+			Name:        "codegraph_search",
+			Description: "Search for functions, methods, classes, and other code entities in the codebase",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "Search term to find code entities (functions, methods, classes, etc.)",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of results to return (default: 20, 0 for unlimited)",
+						"default":     20,
+					},
+					"types": map[string]interface{}{
+						"type":        "array",
+						"description": "Filter by entity types (Function, Method, Class, Variable, etc.)",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "codegraph_get_source",
+			Description: "Retrieve the exact source code for a specific function or method",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"function_name": map[string]interface{}{
+						"type":        "string",
+						"description": "Name of the function or method to retrieve source code for",
+					},
+				},
+				"required": []string{"function_name"},
+			},
+		},
+		{
+			Name:        "codegraph_find_references",
+			Description: "Find all references (usages) of a specific symbol in the codebase",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"symbol": map[string]interface{}{
+						"type":        "string",
+						"description": "Symbol to find references for",
+					},
+				},
+				"required": []string{"symbol"},
+			},
+		},
+		{
+			Name:        "codegraph_analyze_function",
+			Description: "Get detailed analysis of a function including callers, callees, and metadata",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"function_name": map[string]interface{}{
+						"type":        "string",
+						"description": "Name of the function to analyze",
+					},
+				},
+				"required": []string{"function_name"},
+			},
+		},
+		{
+			Name:        "codegraph_hybrid_search",
+			Description: "Perform hybrid semantic search combining vector similarity, full-text search, and graph queries",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "Search query for semantic understanding",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of results to return (default: 10)",
+						"default":     10,
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "codegraph_vector_search",
+			Description: "Perform pure vector similarity search using embeddings",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "Query text to convert to vector and search",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of results to return (default: 10)",
+						"default":     10,
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "codegraph_index_documents",
+			Description: "Index markdown/text documents with embeddings and create relationships to code symbols",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "Directory or file path to index (supports .md, .txt, .rst, .adoc files)",
+					},
+					"generate_embeddings": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Whether to generate embeddings for documents (default: true)",
+						"default":     true,
+					},
+				},
+				"required": []string{"path"},
+			},
+		},
+		{
+			Name:        "codegraph_search_docs",
+			Description: "Search documents using natural language queries and find related code",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "Natural language search query to find relevant documents",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of results to return (default: 10)",
+						"default":     10,
+					},
+					"include_code": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Whether to include related code symbols (default: true)",
+						"default":     true,
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "codegraph_search_by_comment",
+			Description: "Search for functions/methods by their docstrings and comments using semantic similarity",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "Natural language description to find functions by their documentation",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of results to return (default: 10)",
+						"default":     10,
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "codegraph_link_docs_to_code",
+			Description: "Create explicit relationships between documents and code symbols they reference",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"doc_path": map[string]interface{}{
+						"type":        "string",
+						"description": "Path to the document file to link to code",
+					},
+					"auto_detect": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Automatically detect code references in backticks (default: true)",
+						"default":     true,
+					},
+				},
+				"required": []string{"doc_path"},
+			},
+		},
+		{
+			Name:        "codegraph_intelligent_link",
+			Description: "Create intelligent semantic relationships between documents and code using LLM analysis and call graph traversal",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"doc_path": map[string]interface{}{
+						"type":        "string",
+						"description": "Path to the document file to analyze and link",
+					},
+					"confidence_threshold": map[string]interface{}{
+						"type":        "number",
+						"description": "Minimum confidence threshold for creating links (0.0-1.0, default: 0.2)",
+						"default":     0.2,
+						"minimum":     0.0,
+						"maximum":     1.0,
+					},
+				},
+				"required": []string{"doc_path"},
+			},
+		},
+		{
+			Name:        "codegraph_list_services",
+			Description: "List all services in the codebase with their metadata (language, package name, version)",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name_filter": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional filter to match service names (case-insensitive substring match)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "codegraph_service_dependencies",
+			Description: "Get all dependencies (DEPENDS_ON relationships) of a service, showing which packages/services it imports",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"service_name": map[string]interface{}{
+						"type":        "string",
+						"description": "Name of the service to get dependencies for",
+					},
+				},
+				"required": []string{"service_name"},
+			},
+		},
+		{
+			Name:        "codegraph_service_api_endpoints",
+			Description: "Get all API endpoints (EXPOSES_API) exposed by a service, including HTTP method, path, and framework",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"service_name": map[string]interface{}{
+						"type":        "string",
+						"description": "Name of the service to get API endpoints for",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of endpoints to return (default: 50)",
+						"default":     50,
+					},
+				},
+				"required": []string{"service_name"},
+			},
+		},
+		{
+			Name:        "codegraph_service_api_calls",
+			Description: "Get all API calls (CALLS_API) made by a service to other services or external APIs",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"service_name": map[string]interface{}{
+						"type":        "string",
+						"description": "Name of the service to get API calls for",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of calls to return (default: 50)",
+						"default":     50,
+					},
+				},
+				"required": []string{"service_name"},
+			},
+		},
+		{
+			Name:        "codegraph_cross_service_calls",
+			Description: "Get cross-service call chains showing how services communicate through API calls and SDK usage",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"from_service": map[string]interface{}{
+						"type":        "string",
+						"description": "Source service name (optional, shows all if not specified)",
+					},
+					"to_service": map[string]interface{}{
+						"type":        "string",
+						"description": "Target service name (optional, shows all if not specified)",
+					},
+					"limit": map[string]interface{}{
+						"type":        "number",
+						"description": "Maximum number of call chains to return (default: 20)",
+						"default":     20,
+					},
+				},
+			},
+		},
+		{
+			Name:        "codegraph_service_architecture",
+			Description: "Get comprehensive architecture overview showing all services and their relationships (dependencies, API calls, SDK usage)",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+	}
+
+	result := map[string]interface{}{
+		"tools": tools,
+	}
+
+	s.sendResponse(request.ID, result)
+}
+
+func (s *CodeGraphMCPServer) handleToolCall(request MCPRequest) {
+	var toolCall ToolCallRequest
+	paramsBytes, _ := json.Marshal(request.Params)
+	if err := json.Unmarshal(paramsBytes, &toolCall); err != nil {
+		s.sendError(request.ID, -32602, "Invalid params")
+		return
+	}
+
+	ctx := context.Background()
+	var response ToolCallResponse
+
+	switch toolCall.Name {
+	case "codegraph_search":
+		response = s.handleSearchTool(ctx, toolCall.Arguments)
+	case "codegraph_get_source":
+		response = s.handleGetSourceTool(ctx, toolCall.Arguments)
+	case "codegraph_find_references":
+		response = s.handleFindReferencesTool(ctx, toolCall.Arguments)
+	case "codegraph_analyze_function":
+		response = s.handleAnalyzeFunctionTool(ctx, toolCall.Arguments)
+	case "codegraph_hybrid_search":
+		response = s.handleHybridSearchTool(ctx, toolCall.Arguments)
+	case "codegraph_vector_search":
+		response = s.handleVectorSearchTool(ctx, toolCall.Arguments)
+	case "codegraph_index_documents":
+		response = s.handleIndexDocumentsTool(ctx, toolCall.Arguments)
+	case "codegraph_search_docs":
+		response = s.handleSearchDocsTool(ctx, toolCall.Arguments)
+	case "codegraph_search_by_comment":
+		response = s.handleSearchByCommentTool(ctx, toolCall.Arguments)
+	case "codegraph_link_docs_to_code":
+		response = s.handleLinkDocsToCodeTool(ctx, toolCall.Arguments)
+	case "codegraph_intelligent_link":
+		response = s.handleIntelligentLinkTool(ctx, toolCall.Arguments)
+	case "codegraph_list_services":
+		response = s.handleListServicesTool(ctx, toolCall.Arguments)
+	case "codegraph_service_dependencies":
+		response = s.handleServiceDependenciesTool(ctx, toolCall.Arguments)
+	case "codegraph_service_api_endpoints":
+		response = s.handleServiceAPIEndpointsTool(ctx, toolCall.Arguments)
+	case "codegraph_service_api_calls":
+		response = s.handleServiceAPICallsTool(ctx, toolCall.Arguments)
+	case "codegraph_cross_service_calls":
+		response = s.handleCrossServiceCallsTool(ctx, toolCall.Arguments)
+	case "codegraph_service_architecture":
+		response = s.handleServiceArchitectureTool(ctx, toolCall.Arguments)
+	default:
+		s.sendError(request.ID, -32601, "Unknown tool")
+		return
+	}
+
+	s.sendResponse(request.ID, response)
+}
+
+func (s *CodeGraphMCPServer) handleSearchTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	query, ok := args["query"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: query parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	limit := 20
+	if l, ok := args["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	var nodeTypes []string
+	if types, ok := args["types"].([]interface{}); ok {
+		for _, t := range types {
+			if typeStr, ok := t.(string); ok {
+				nodeTypes = append(nodeTypes, typeStr)
+			}
+		}
+	}
+
+	results, err := s.queryBuilder.SearchNodes(ctx, query, nodeTypes, limit)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Search error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	if len(results) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("No results found for query: %s", query)}},
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("Found %d result(s) for '%s':\n\n", len(results), query))
+
+	for i, record := range results {
+		if i >= 50 { // Limit output to prevent overwhelming
+			output.WriteString(fmt.Sprintf("... and %d more results\n", len(results)-i))
+			break
+		}
+
+		recordMap := record.AsMap()
+		if nodeObj, ok := recordMap["n"]; ok {
+			if node, ok := nodeObj.(dbtype.Node); ok {
+				props := node.Props
+				labels := node.Labels
+
+				var nodeType string
+				if len(labels) > 0 {
+					nodeType = labels[0]
+				}
+
+				name := getStringProp(props, "name")
+				filePath := getStringProp(props, "filePath")
+				signature := getStringProp(props, "signature")
+
+				output.WriteString(fmt.Sprintf("**%s** (%s)\n", name, nodeType))
+				if filePath != "" {
+					output.WriteString(fmt.Sprintf("  File: %s\n", filePath))
+				}
+				if signature != "" {
+					output.WriteString(fmt.Sprintf("  Signature: %s\n", signature))
+				}
+
+				// Add specific info based on node type
+				switch nodeType {
+				case "Function", "Method":
+					if startLine := getIntProp(props, "startLine"); startLine > 0 {
+						endLine := getIntProp(props, "endLine")
+						output.WriteString(fmt.Sprintf("  Lines: %d-%d\n", startLine, endLine))
+					}
+					if linesOfCode := getIntProp(props, "linesOfCode"); linesOfCode > 0 {
+						output.WriteString(fmt.Sprintf("  Lines of Code: %d\n", linesOfCode))
+					}
+				case "Class":
+					if fqn := getStringProp(props, "fqn"); fqn != "" {
+						output.WriteString(fmt.Sprintf("  FQN: %s\n", fqn))
+					}
+				}
+
+				output.WriteString("\n")
+			}
+		}
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleGetSourceTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	functionName, ok := args["function_name"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: function_name parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	// Get function metadata including file path
+	cypher := `
+		MATCH (f)
+		WHERE (f:Function OR f:Method) AND f.name = $functionName
+		RETURN f.filePath AS filePath
+		LIMIT 1
+	`
+
+	result, err := s.client.ExecuteQuery(ctx, cypher, map[string]any{"functionName": functionName})
+	if err != nil || len(result) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error finding function '%s': %v", functionName, err)}},
+			IsError: true,
+		}
+	}
+
+	// Detect language from file path
+	filePath := getStringFromRecord(result[0].AsMap(), "filePath")
+	language := detectLanguageFromPath(filePath)
+
+	sourceCode, err := s.queryBuilder.GetFunctionSourceCode(ctx, functionName)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error retrieving source for '%s': %v", functionName, err)}},
+			IsError: true,
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("Source code for function '%s':\n\n", functionName))
+	output.WriteString(fmt.Sprintf("```%s\n", language))
+	output.WriteString(sourceCode)
+	output.WriteString("\n```\n")
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleFindReferencesTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	symbol, ok := args["symbol"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: symbol parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	references, err := s.queryBuilder.FindAllReferences(ctx, symbol)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error finding references for '%s': %v", symbol, err)}},
+			IsError: true,
+		}
+	}
+
+	if len(references) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("No references found for symbol: %s", symbol)}},
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("Found %d reference(s) for '%s':\n\n", len(references), symbol))
+
+	for _, ref := range references {
+		output.WriteString(fmt.Sprintf("**%s**\n", ref.FilePath))
+		output.WriteString(fmt.Sprintf("  Line: %d", ref.StartLine))
+		if ref.StartColumn > 0 {
+			output.WriteString(fmt.Sprintf(", Column: %d", ref.StartColumn))
+		}
+		output.WriteString("\n")
+		if ref.Context != "" {
+			output.WriteString(fmt.Sprintf("  Context: %s\n", ref.Context))
+		}
+		output.WriteString("\n")
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleAnalyzeFunctionTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	functionName, ok := args["function_name"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: function_name parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	// Get function metadata
+	cypher := `
+		MATCH (f:Function {name: $name})
+		RETURN f.name as name, f.signature as signature, f.filePath as filePath,
+			   f.startLine as startLine, f.endLine as endLine, f.linesOfCode as linesOfCode,
+			   f.returnType as returnType, f.isExported as isExported,
+			   f.complexity as complexity, f.docstring as docstring
+		LIMIT 1
+	`
+
+	result, err := s.client.ExecuteQuery(ctx, cypher, map[string]any{"name": functionName})
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error analyzing function '%s': %v", functionName, err)}},
+			IsError: true,
+		}
+	}
+
+	if len(result) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Function not found: %s", functionName)}},
+			IsError: true,
+		}
+	}
+
+	record := result[0].AsMap()
+	var output strings.Builder
+
+	output.WriteString(fmt.Sprintf("## Analysis for function '%s'\n\n", functionName))
+
+	// Basic info
+	output.WriteString("### Basic Information\n")
+	if signature := getStringFromRecord(record, "signature"); signature != "" {
+		output.WriteString(fmt.Sprintf("- **Signature**: %s\n", signature))
+	}
+	if filePath := getStringFromRecord(record, "filePath"); filePath != "" {
+		output.WriteString(fmt.Sprintf("- **File**: %s\n", filePath))
+	}
+	if startLine := getIntFromRecord(record, "startLine"); startLine > 0 {
+		endLine := getIntFromRecord(record, "endLine")
+		output.WriteString(fmt.Sprintf("- **Location**: Lines %d-%d\n", startLine, endLine))
+	}
+	if linesOfCode := getIntFromRecord(record, "linesOfCode"); linesOfCode > 0 {
+		output.WriteString(fmt.Sprintf("- **Lines of Code**: %d\n", linesOfCode))
+	}
+	if returnType := getStringFromRecord(record, "returnType"); returnType != "" {
+		output.WriteString(fmt.Sprintf("- **Return Type**: %s\n", returnType))
+	}
+	if isExported := getBoolFromRecord(record, "isExported"); isExported {
+		output.WriteString("- **Exported**: Yes\n")
+	} else {
+		output.WriteString("- **Exported**: No\n")
+	}
+
+	output.WriteString("\n")
+
+	// Find callers (functions that call this function)
+	callersQuery := `
+		MATCH (caller)-[:CALLS]->(f:Function {name: $name})
+		RETURN caller.name as callerName, caller.filePath as callerFile
+		LIMIT 10
+	`
+	callers, _ := s.client.ExecuteQuery(ctx, callersQuery, map[string]any{"name": functionName})
+
+	output.WriteString("### Called By\n")
+	if len(callers) > 0 {
+		for _, caller := range callers {
+			callerMap := caller.AsMap()
+			callerName := getStringFromRecord(callerMap, "callerName")
+			callerFile := getStringFromRecord(callerMap, "callerFile")
+			output.WriteString(fmt.Sprintf("- **%s** (%s)\n", callerName, callerFile))
+		}
+	} else {
+		output.WriteString("- No callers found\n")
+	}
+
+	output.WriteString("\n")
+
+	// Find callees (functions this function calls)
+	calleesQuery := `
+		MATCH (f:Function {name: $name})-[:CALLS]->(callee)
+		RETURN callee.name as calleeName, callee.filePath as calleeFile
+		LIMIT 10
+	`
+	callees, _ := s.client.ExecuteQuery(ctx, calleesQuery, map[string]any{"name": functionName})
+
+	output.WriteString("### Calls\n")
+	if len(callees) > 0 {
+		for _, callee := range callees {
+			calleeMap := callee.AsMap()
+			calleeName := getStringFromRecord(calleeMap, "calleeName")
+			calleeFile := getStringFromRecord(calleeMap, "calleeFile")
+			output.WriteString(fmt.Sprintf("- **%s** (%s)\n", calleeName, calleeFile))
+		}
+	} else {
+		output.WriteString("- No function calls found\n")
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleHybridSearchTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	query, ok := args["query"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: query parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	if s.embeddingService == nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: Hybrid search requires GEMINI_API_KEY environment variable to be set for embedding generation"}},
+			IsError: true,
+		}
+	}
+
+	limit := 10
+	if l, ok := args["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	results, err := s.hybridSearch.SmartSearch(ctx, query, limit)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Hybrid search error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	if len(results.Results) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("No results found for query: %s", query)}},
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("## Hybrid Search Results for '%s'\n\n", query))
+	output.WriteString(fmt.Sprintf("**Found %d result(s) using %s**\n\n", results.TotalResults, strings.Join(results.SearchTypes, ", ")))
+
+	for i, result := range results.Results {
+		if i >= 20 { // Limit output
+			output.WriteString(fmt.Sprintf("... and %d more results\n", len(results.Results)-i))
+			break
+		}
+
+		output.WriteString(fmt.Sprintf("### Result %d (Score: %.3f)\n", i+1, result.CombinedScore))
+
+		// Handle different result types
+		if result.Node != nil {
+			name := getStringFromInterface(result.Node, "name")
+			nodeType := getStringFromInterface(result.Node, "nodeType")
+			if nodeType == "" {
+				nodeType = "Unknown"
+			}
+
+			output.WriteString(fmt.Sprintf("**%s** (%s)\n", name, nodeType))
+
+			if filePath := getStringFromInterface(result.Node, "filePath"); filePath != "" {
+				output.WriteString(fmt.Sprintf("- **File**: %s\n", filePath))
+			}
+			if signature := getStringFromInterface(result.Node, "signature"); signature != "" {
+				output.WriteString(fmt.Sprintf("- **Signature**: %s\n", signature))
+			}
+			if startLine := getIntFromInterface(result.Node, "startLine"); startLine > 0 {
+				endLine := getIntFromInterface(result.Node, "endLine")
+				if endLine > startLine {
+					output.WriteString(fmt.Sprintf("- **Lines**: %d-%d\n", startLine, endLine))
+				} else {
+					output.WriteString(fmt.Sprintf("- **Line**: %d\n", startLine))
+				}
+			}
+			if docstring := getStringFromInterface(result.Node, "docstring"); docstring != "" {
+				output.WriteString(fmt.Sprintf("- **Description**: %s\n", docstring))
+			}
+		}
+
+		if result.Source != "" {
+			output.WriteString(fmt.Sprintf("- **Match Source**: %s\n", result.Source))
+		}
+		if result.Relevance != "" {
+			output.WriteString(fmt.Sprintf("- **Relevance**: %s\n", result.Relevance))
+		}
+
+		output.WriteString("\n")
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleVectorSearchTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	query, ok := args["query"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: query parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	if s.embeddingService == nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: Vector search requires GEMINI_API_KEY environment variable to be set for embedding generation"}},
+			IsError: true,
+		}
+	}
+
+	limit := 10
+	if l, ok := args["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	// Generate embedding for the query
+	embedding, err := s.embeddingService.GenerateEmbedding(ctx, query)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error generating embedding: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	// Perform vector search via Qdrant
+	if s.vectorStore == nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: Vector store not available"}},
+			IsError: true,
+		}
+	}
+
+	results, err := s.vectorStore.Query(ctx, search.VectorQuery{
+		Vector: embedding,
+		Limit:  limit,
+	})
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Vector search error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	if len(results) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("No vector results found for query: %s", query)}},
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("## Vector Search Results for '%s'\n\n", query))
+	output.WriteString(fmt.Sprintf("**Found %d result(s)**\n", len(results)))
+	output.WriteString(fmt.Sprintf("**Embedding Dimensions**: %d\n\n", len(embedding)))
+
+	for i, result := range results {
+		if i >= 20 {
+			output.WriteString(fmt.Sprintf("... and %d more results\n", len(results)-i))
+			break
+		}
+
+		output.WriteString(fmt.Sprintf("### Result %d (Similarity: %.4f)\n", i+1, result.Score))
+
+		name, _ := result.Metadata["name"].(string)
+		signature, _ := result.Metadata["signature"].(string)
+		nodeLabel, _ := result.Metadata["nodeLabel"].(string)
+
+		output.WriteString(fmt.Sprintf("**%s** (%s)\n", name, nodeLabel))
+
+		if signature != "" {
+			output.WriteString(fmt.Sprintf("- **Signature**: %s\n", signature))
+		}
+		if description, _ := result.Metadata["description"].(string); description != "" {
+			output.WriteString(fmt.Sprintf("- **Description**: %s\n", description))
+		}
+
+		output.WriteString("\n")
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) sendResponse(id interface{}, result interface{}) {
+	response := MCPResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+
+	jsonBytes, _ := json.Marshal(response)
+	fmt.Println(string(jsonBytes))
+}
+
+func (s *CodeGraphMCPServer) sendError(id interface{}, code int, message string) {
+	response := MCPResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &MCPError{
+			Code:    code,
+			Message: message,
+		},
+	}
+
+	jsonBytes, _ := json.Marshal(response)
+	fmt.Println(string(jsonBytes))
+}
+
+// Helper functions
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getStringProp(props map[string]interface{}, key string) string {
+	if val, ok := props[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+func getIntProp(props map[string]interface{}, key string) int {
+	if val, ok := props[key]; ok {
+		switch v := val.(type) {
+		case int64:
+			return int(v)
+		case int:
+			return v
+		case float64:
+			return int(v)
+		}
+	}
+	return 0
+}
+
+func getBoolProp(props map[string]interface{}, key string) bool {
+	if val, ok := props[key]; ok {
+		if b, ok := val.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+func getStringFromRecord(record map[string]interface{}, key string) string {
+	if val, ok := record[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+func getIntFromRecord(record map[string]interface{}, key string) int {
+	if val, ok := record[key]; ok {
+		switch v := val.(type) {
+		case int64:
+			return int(v)
+		case int:
+			return v
+		case float64:
+			return int(v)
+		}
+	}
+	return 0
+}
+
+func getBoolFromRecord(record map[string]interface{}, key string) bool {
+	if val, ok := record[key]; ok {
+		if b, ok := val.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+func getStringFromInterface(data map[string]interface{}, key string) string {
+	if val, ok := data[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+func getIntFromInterface(data map[string]interface{}, key string) int {
+	if val, ok := data[key]; ok {
+		switch v := val.(type) {
+		case int64:
+			return int(v)
+		case int:
+			return v
+		case float64:
+			return int(v)
+		}
+	}
+	return 0
+}
+
+// detectLanguageFromPath detects the programming language from a file path
+func detectLanguageFromPath(filePath string) string {
+	ext := filepath.Ext(filePath)
+	switch ext {
+	case ".go":
+		return "go"
+	case ".ts":
+		return "typescript"
+	case ".tsx":
+		return "tsx"
+	case ".js":
+		return "javascript"
+	case ".jsx":
+		return "jsx"
+	case ".py":
+		return "python"
+	case ".java":
+		return "java"
+	case ".kt", ".kts":
+		return "kotlin"
+	case ".scala":
+		return "scala"
+	case ".rb":
+		return "ruby"
+	case ".php":
+		return "php"
+	case ".rs":
+		return "rust"
+	case ".c":
+		return "c"
+	case ".cpp", ".cc", ".cxx":
+		return "cpp"
+	case ".h", ".hpp":
+		return "cpp"
+	case ".cs":
+		return "csharp"
+	case ".swift":
+		return "swift"
+	default:
+		return "text"
+	}
+}
+
+// Document-related tool handlers
+
+func (s *CodeGraphMCPServer) handleIndexDocumentsTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	path, ok := args["path"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: path parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	generateEmbeddings := true
+	if gen, ok := args["generate_embeddings"].(bool); ok {
+		generateEmbeddings = gen
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("## Indexing Documents at '%s'\n\n", path))
+
+	// Check if path exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: path does not exist: %s", path)}},
+			IsError: true,
+		}
+	}
+
+	// Determine if it's a file or directory
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error accessing path: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	if fileInfo.IsDir() {
+		// Index directory
+		err = s.docIndexer.IndexDirectory(ctx, path)
+		if err != nil {
+			return ToolCallResponse{
+				Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error indexing directory: %v", err)}},
+				IsError: true,
+			}
+		}
+		output.WriteString("✓ Successfully indexed all documents in directory\n")
+	} else {
+		// Index single file
+		err = s.docIndexer.IndexDocument(ctx, path)
+		if err != nil {
+			return ToolCallResponse{
+				Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error indexing document: %v", err)}},
+				IsError: true,
+			}
+		}
+		output.WriteString("✓ Successfully indexed document\n")
+	}
+
+	// Get document stats
+	stats, err := s.docIndexer.GetDocumentStats(ctx)
+	if err != nil {
+		output.WriteString(fmt.Sprintf("Warning: failed to get document stats: %v\n", err))
+	} else {
+		output.WriteString("\n### Document Index Statistics\n")
+		if docCount, ok := stats["documentCount"].(int64); ok {
+			output.WriteString(fmt.Sprintf("- **Total Documents**: %d\n", docCount))
+		}
+		if featureCount, ok := stats["featureCount"].(int64); ok {
+			output.WriteString(fmt.Sprintf("- **Features Extracted**: %d\n", featureCount))
+		}
+		if symbolCount, ok := stats["mentionedSymbolCount"].(int64); ok {
+			output.WriteString(fmt.Sprintf("- **Code Symbols Linked**: %d\n", symbolCount))
+		}
+	}
+
+	// If embeddings are enabled, update vector indexes
+	if generateEmbeddings && s.embeddingService != nil {
+		output.WriteString("\n### Embedding Generation\n")
+
+		// Create/update vector collections in Qdrant
+		if s.vectorStore != nil {
+			collections := []string{"function_embeddings_768", "document_embeddings_768", "class_embeddings_768"}
+			for _, col := range collections {
+				if err := s.vectorStore.CreateIndex(ctx, col, 768, "cosine"); err != nil {
+					output.WriteString(fmt.Sprintf("Warning: failed to create collection %s: %v\n", col, err))
+				}
+			}
+			output.WriteString("✓ Qdrant vector collections updated\n")
+		}
+
+		output.WriteString("✓ Document embeddings generated and indexed\n")
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleSearchDocsTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	query, ok := args["query"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: query parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	limit := 10
+	if l, ok := args["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	includeCode := true
+	if include, ok := args["include_code"].(bool); ok {
+		includeCode = include
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("## Document Search Results for '%s'\n\n", query))
+
+	// Use hybrid search to find documents
+	results, err := s.hybridSearch.UnifiedSearch(ctx, query, limit)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Document search error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	if len(results.Results) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("No documents found for query: %s", query)}},
+		}
+	}
+
+	// Filter for document results and group related code
+	documentResults := []search.HybridSearchResult{}
+	codeResults := []search.HybridSearchResult{}
+
+	for _, result := range results.Results {
+		// Check if this is a document
+		isDocument := false
+		for _, label := range result.Labels {
+			if label == "Document" {
+				isDocument = true
+				break
+			}
+		}
+
+		if isDocument {
+			documentResults = append(documentResults, result)
+		} else {
+			codeResults = append(codeResults, result)
+		}
+	}
+
+	// Display document results
+	if len(documentResults) > 0 {
+		output.WriteString("### 📄 Documents\n\n")
+		for i, result := range documentResults {
+			title := getStringFromInterface(result.Node, "title")
+			if title == "" {
+				title = getStringFromInterface(result.Node, "name")
+			}
+			sourceUrl := getStringFromInterface(result.Node, "sourceUrl")
+			content := getStringFromInterface(result.Node, "content")
+
+			output.WriteString(fmt.Sprintf("**%d. %s** (Score: %.3f)\n", i+1, title, result.CombinedScore))
+			if sourceUrl != "" {
+				output.WriteString(fmt.Sprintf("   - **Source**: %s\n", sourceUrl))
+			}
+			if content != "" {
+				// Show first 200 characters of content
+				preview := content
+				if len(preview) > 200 {
+					preview = preview[:200] + "..."
+				}
+				output.WriteString(fmt.Sprintf("   - **Preview**: %s\n", preview))
+			}
+			output.WriteString(fmt.Sprintf("   - **Match Source**: %s | **Relevance**: %s\n\n", result.Source, result.Relevance))
+
+			// Find related code for this document if includeCode is true
+			if includeCode {
+				relatedCode, err := s.findRelatedCodeForDocument(ctx, result.Node, 3)
+				if err == nil && len(relatedCode) > 0 {
+					output.WriteString("   **Related Code**:\n")
+					for _, code := range relatedCode {
+						codeName := getStringFromInterface(code, "name")
+						codeType := getStringFromInterface(code, "nodeType")
+						if codeType == "" {
+							codeType = "Symbol"
+						}
+						filePath := getStringFromInterface(code, "filePath")
+						output.WriteString(fmt.Sprintf("   - %s (%s)", codeName, codeType))
+						if filePath != "" {
+							output.WriteString(fmt.Sprintf(" in %s", filePath))
+						}
+						output.WriteString("\n")
+					}
+					output.WriteString("\n")
+				}
+			}
+		}
+	}
+
+	// Display related code results if includeCode is true
+	if includeCode && len(codeResults) > 0 {
+		output.WriteString("### 💻 Related Code\n\n")
+		for i, result := range codeResults {
+			if i >= 5 { // Limit code results
+				output.WriteString(fmt.Sprintf("... and %d more code results\n", len(codeResults)-i))
+				break
+			}
+
+			name := getStringFromInterface(result.Node, "name")
+			nodeType := "Code"
+			for _, label := range result.Labels {
+				if label != "Node" {
+					nodeType = label
+					break
+				}
+			}
+			filePath := getStringFromInterface(result.Node, "filePath")
+			signature := getStringFromInterface(result.Node, "signature")
+
+			output.WriteString(fmt.Sprintf("**%d. %s** (%s, Score: %.3f)\n", i+1, name, nodeType, result.CombinedScore))
+			if filePath != "" {
+				output.WriteString(fmt.Sprintf("   - **File**: %s\n", filePath))
+			}
+			if signature != "" {
+				output.WriteString(fmt.Sprintf("   - **Signature**: %s\n", signature))
+			}
+			output.WriteString("\n")
+		}
+	}
+
+	output.WriteString(fmt.Sprintf("\n**Total Results**: %d documents", len(documentResults)))
+	if includeCode {
+		output.WriteString(fmt.Sprintf(", %d code entities", len(codeResults)))
+	}
+	output.WriteString(fmt.Sprintf(" | **Search Methods**: %s\n", strings.Join(results.SearchTypes, ", ")))
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleSearchByCommentTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	query, ok := args["query"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: query parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	if s.embeddingService == nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: Comment search requires GEMINI_API_KEY environment variable to be set for embedding generation"}},
+			IsError: true,
+		}
+	}
+
+	limit := 10
+	if l, ok := args["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("## Function Search by Comment/Docstring for '%s'\n\n", query))
+
+	// Use comment search service to find functions by their docstrings
+	results, err := s.commentSearch.SearchFunctionsByComment(ctx, query, limit)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Comment search error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	if len(results.Results) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("No functions found with comments matching: %s", query)}},
+		}
+	}
+
+	output.WriteString(fmt.Sprintf("**Found %d function(s) with matching documentation**\n\n", len(results.Results)))
+
+	for i, result := range results.Results {
+		// Extract function details from parent node
+		functionName := getStringFromInterface(result.ParentNode, "name")
+		functionType := getStringFromInterface(result.CommentNode, "parentType")
+		if functionType == "" {
+			functionType = "Function"
+		}
+		filePath := getStringFromInterface(result.ParentNode, "filePath")
+		signature := getStringFromInterface(result.ParentNode, "signature")
+		startLine := getIntFromInterface(result.ParentNode, "startLine")
+		endLine := getIntFromInterface(result.ParentNode, "endLine")
+
+		// Extract comment details
+		commentText := getStringFromInterface(result.CommentNode, "text")
+
+		output.WriteString(fmt.Sprintf("### %d. %s (%s) - Similarity: %.4f\n\n", i+1, functionName, functionType, result.Score))
+
+		if filePath != "" {
+			output.WriteString(fmt.Sprintf("**File**: %s", filePath))
+			if startLine > 0 {
+				if endLine > startLine {
+					output.WriteString(fmt.Sprintf(" (lines %d-%d)", startLine, endLine))
+				} else {
+					output.WriteString(fmt.Sprintf(" (line %d)", startLine))
+				}
+			}
+			output.WriteString("\n\n")
+		}
+
+		if signature != "" {
+			output.WriteString(fmt.Sprintf("**Signature**: `%s`\n\n", signature))
+		}
+
+		if commentText != "" {
+			output.WriteString("**Documentation**:\n")
+			output.WriteString("```\n")
+			output.WriteString(commentText)
+			output.WriteString("\n```\n\n")
+		}
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+func (s *CodeGraphMCPServer) handleLinkDocsToCodeTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	docPath, ok := args["doc_path"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: doc_path parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	autoDetect := true
+	if auto, ok := args["auto_detect"].(bool); ok {
+		autoDetect = auto
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("## Linking Document to Code: '%s'\n\n", docPath))
+
+	// Check if document exists
+	if _, err := os.Stat(docPath); os.IsNotExist(err) {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: document file does not exist: %s", docPath)}},
+			IsError: true,
+		}
+	}
+
+	if autoDetect {
+		// Re-index this specific document to create/update relationships
+		err := s.docIndexer.IndexDocument(ctx, docPath)
+		if err != nil {
+			return ToolCallResponse{
+				Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error re-indexing document: %v", err)}},
+				IsError: true,
+			}
+		}
+		output.WriteString("✓ Document re-indexed with automatic code symbol detection\n\n")
+	}
+
+	// Query for relationships from this document
+	docFileName := filepath.Base(docPath)
+	relationshipQuery := `
+		MATCH (d:Document)-[r:MENTIONS]->(s)
+		WHERE d.sourceUrl CONTAINS $docFileName OR d.title CONTAINS $docFileName
+		RETURN d.title as docTitle, s.name as symbolName, labels(s) as symbolLabels, s.filePath as symbolPath, count(r) as mentionCount
+		ORDER BY mentionCount DESC
+		LIMIT 20
+	`
+
+	results, err := s.client.ExecuteQuery(ctx, relationshipQuery, map[string]any{
+		"docFileName": docFileName,
+	})
+	if err != nil {
+		output.WriteString(fmt.Sprintf("Warning: could not query relationships: %v\n", err))
+	} else if len(results) > 0 {
+		output.WriteString("### 🔗 Code Symbols Linked to Document\n\n")
+		for i, record := range results {
+			recordMap := record.AsMap()
+			symbolName := getStringFromRecord(recordMap, "symbolName")
+			symbolPath := getStringFromRecord(recordMap, "symbolPath")
+			mentionCount := getIntFromRecord(recordMap, "mentionCount")
+
+			var symbolType string
+			if labels, ok := recordMap["symbolLabels"].([]interface{}); ok && len(labels) > 0 {
+				if label, ok := labels[0].(string); ok {
+					symbolType = label
+				}
+			}
+			if symbolType == "" {
+				symbolType = "Symbol"
+			}
+
+			output.WriteString(fmt.Sprintf("**%d. %s** (%s)\n", i+1, symbolName, symbolType))
+			if symbolPath != "" {
+				output.WriteString(fmt.Sprintf("   - **File**: %s\n", symbolPath))
+			}
+			output.WriteString(fmt.Sprintf("   - **Mentions**: %d\n\n", mentionCount))
+		}
+	} else {
+		output.WriteString("### ℹ️  No Code Symbol Links Found\n\n")
+		output.WriteString("This document doesn't appear to reference any indexed code symbols.\n")
+		output.WriteString("Make sure:\n")
+		output.WriteString("- Code symbols are referenced in backticks (e.g., `functionName`)\n")
+		output.WriteString("- The referenced code has been indexed\n")
+		output.WriteString("- Symbol names match exactly\n\n")
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+// Helper function to find code related to a document
+func (s *CodeGraphMCPServer) findRelatedCodeForDocument(ctx context.Context, docNode map[string]interface{}, limit int) ([]map[string]interface{}, error) {
+	// Try to get document ID or use title/sourceUrl for matching
+	var query string
+	var params map[string]any
+
+	if docId, ok := docNode["elementId"].(string); ok {
+		query = `
+			MATCH (d)-[:MENTIONS]->(s)
+			WHERE elementId(d) = $docId
+			RETURN s as symbol, labels(s) as nodeLabels
+			LIMIT $limit
+		`
+		params = map[string]any{"docId": docId, "limit": limit}
+	} else {
+		// Fallback to matching by title or sourceUrl
+		title := getStringFromInterface(docNode, "title")
+		sourceUrl := getStringFromInterface(docNode, "sourceUrl")
+
+		query = `
+			MATCH (d:Document)-[:MENTIONS]->(s)
+			WHERE d.title = $title OR d.sourceUrl = $sourceUrl
+			RETURN s as symbol, labels(s) as nodeLabels
+			LIMIT $limit
+		`
+		params = map[string]any{"title": title, "sourceUrl": sourceUrl, "limit": limit}
+	}
+
+	results, err := s.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var relatedCode []map[string]interface{}
+	for _, record := range results {
+		recordMap := record.AsMap()
+		if symbolObj, ok := recordMap["symbol"]; ok {
+			if symbol, ok := symbolObj.(dbtype.Node); ok {
+				symbolData := symbol.Props
+				// Add node type from labels
+				if labels, ok := recordMap["nodeLabels"].([]interface{}); ok && len(labels) > 0 {
+					if label, ok := labels[0].(string); ok {
+						symbolData["nodeType"] = label
+					}
+				}
+				relatedCode = append(relatedCode, symbolData)
+			}
+		}
+	}
+
+	return relatedCode, nil
+}
+
+func (s *CodeGraphMCPServer) handleIntelligentLinkTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	docPath, ok := args["doc_path"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: doc_path parameter is required"}},
+			IsError: true,
+		}
+	}
+
+	// Get confidence threshold
+	confidenceThreshold := 0.2
+	if ct, ok := args["confidence_threshold"].(float64); ok {
+		confidenceThreshold = ct
+	}
+
+	var output strings.Builder
+
+	// Check if file exists
+	if _, err := os.Stat(docPath); os.IsNotExist(err) {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: Document not found at path: %s", docPath)}},
+			IsError: true,
+		}
+	}
+
+	// Read document content
+	content, err := os.ReadFile(docPath)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error reading document: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	// Create intelligent linker if we have embedding service
+	if s.embeddingService == nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: Embedding service not available for intelligent linking"}},
+			IsError: true,
+		}
+	}
+
+	intelligentLinker := search.NewIntelligentDocumentLinker(s.client, s.embeddingService, s.vectorStore)
+
+	// First, create or find the document node
+	docIndexer := documents.NewDocumentIndexer(s.client)
+	err = docIndexer.IndexDocument(ctx, docPath)
+	if err != nil {
+		output.WriteString(fmt.Sprintf("Warning: Failed to index document: %v\n", err))
+	}
+
+	// Find the document ID
+	cypher := `
+		MATCH (d:Document)
+		WHERE d.sourceUrl = $docPath
+		RETURN d.id AS id
+		LIMIT 1
+	`
+
+	results, err := s.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"docPath": docPath,
+	})
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error finding document in database: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	if len(results) == 0 {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: Document not found in database after indexing"}},
+			IsError: true,
+		}
+	}
+
+	documentID := results[0].AsMap()["id"].(string)
+
+	// Perform intelligent linking
+	output.WriteString(fmt.Sprintf("## Intelligent Linking Analysis for '%s'\n\n", docPath))
+
+	linkingResult, err := intelligentLinker.LinkDocumentToCode(ctx, documentID, string(content))
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error during intelligent linking: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	// Report results
+	output.WriteString(fmt.Sprintf("✓ Intelligent linking completed with confidence threshold %.2f\n\n", confidenceThreshold))
+
+	// Direct matches
+	if len(linkingResult.DirectMatches) > 0 {
+		output.WriteString("### 🎯 Direct Matches\n\n")
+		for _, match := range linkingResult.DirectMatches {
+			output.WriteString(fmt.Sprintf("**%s** (%s, Score: %.3f)\n", match.Name, match.NodeType, match.Confidence))
+			if match.FilePath != "" {
+				output.WriteString(fmt.Sprintf("   - **File**: %s\n", match.FilePath))
+			}
+			if match.Signature != "" {
+				output.WriteString(fmt.Sprintf("   - **Signature**: %s\n", match.Signature))
+			}
+			output.WriteString(fmt.Sprintf("   - **Reasons**: %s\n\n", strings.Join(match.MatchReasons, ", ")))
+		}
+	}
+
+	// Semantic matches
+	if len(linkingResult.SemanticMatches) > 0 {
+		output.WriteString("### 🧠 Semantic Matches\n\n")
+		for _, match := range linkingResult.SemanticMatches {
+			if match.Confidence >= confidenceThreshold {
+				output.WriteString(fmt.Sprintf("**%s** (%s, Score: %.3f)\n", match.Name, match.NodeType, match.Confidence))
+				if match.FilePath != "" {
+					output.WriteString(fmt.Sprintf("   - **File**: %s\n", match.FilePath))
+				}
+				output.WriteString(fmt.Sprintf("   - **Reasons**: %s\n\n", strings.Join(match.MatchReasons, ", ")))
+			}
+		}
+	}
+
+	// Call graph matches
+	if len(linkingResult.CallGraphMatches) > 0 {
+		output.WriteString("### 🔗 Call Graph Matches\n\n")
+		for _, match := range linkingResult.CallGraphMatches {
+			if match.Confidence >= confidenceThreshold {
+				output.WriteString(fmt.Sprintf("**%s** (%s, Score: %.3f, Depth: %d)\n",
+					match.Name, match.NodeType, match.Confidence, match.CallGraphDepth))
+				if match.FilePath != "" {
+					output.WriteString(fmt.Sprintf("   - **File**: %s\n", match.FilePath))
+				}
+				output.WriteString(fmt.Sprintf("   - **Reasons**: %s\n\n", strings.Join(match.MatchReasons, ", ")))
+			}
+		}
+	}
+
+	// Summary
+	output.WriteString("### 📊 Summary\n\n")
+	output.WriteString(fmt.Sprintf("- **Direct matches**: %d\n", len(linkingResult.DirectMatches)))
+	output.WriteString(fmt.Sprintf("- **Semantic matches**: %d\n", len(linkingResult.SemanticMatches)))
+	output.WriteString(fmt.Sprintf("- **Call graph matches**: %d\n", len(linkingResult.CallGraphMatches)))
+	output.WriteString(fmt.Sprintf("- **Total relationships created**: %d\n", linkingResult.CreatedLinks))
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+// handleListServicesTool lists all services with their metadata
+func (s *CodeGraphMCPServer) handleListServicesTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	query := `
+		MATCH (s:Service)
+		OPTIONAL MATCH (s)-[:CONTAINS]->(f:File)
+		WITH s, count(DISTINCT f) AS fileCount
+		OPTIONAL MATCH (s)-[:DEPENDS_ON]->(dep:Service)
+		WITH s, fileCount, collect(DISTINCT dep.name) AS dependencies
+		RETURN s.name AS name, s.packageName AS packageName, s.version AS version,
+		       s.language AS language, fileCount, dependencies
+		ORDER BY s.name
+	`
+
+	result, err := s.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString("# Services\n\n")
+
+	if len(result) == 0 {
+		output.WriteString("No services found.\n")
+	} else {
+		for _, record := range result {
+			recordMap := record.AsMap()
+			name := getStringFromRecord(recordMap, "name")
+			packageName := getStringFromRecord(recordMap, "packageName")
+			version := getStringFromRecord(recordMap, "version")
+			language := getStringFromRecord(recordMap, "language")
+			fileCount := getIntFromRecord(recordMap, "fileCount")
+			dependencies := []interface{}{}
+			if deps, ok := recordMap["dependencies"].([]interface{}); ok {
+				dependencies = deps
+			}
+
+			output.WriteString(fmt.Sprintf("## %s\n\n", name))
+			if packageName != "" {
+				output.WriteString(fmt.Sprintf("- **Package**: %s\n", packageName))
+			}
+			if version != "" {
+				output.WriteString(fmt.Sprintf("- **Version**: %s\n", version))
+			}
+			if language != "" {
+				output.WriteString(fmt.Sprintf("- **Language**: %s\n", language))
+			}
+			output.WriteString(fmt.Sprintf("- **Files**: %d\n", fileCount))
+			if len(dependencies) > 0 {
+				output.WriteString("- **Dependencies**: ")
+				depNames := make([]string, len(dependencies))
+				for i, dep := range dependencies {
+					depNames[i] = dep.(string)
+				}
+				output.WriteString(strings.Join(depNames, ", "))
+				output.WriteString("\n")
+			}
+			output.WriteString("\n")
+		}
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+// handleServiceDependenciesTool gets dependencies of a service
+func (s *CodeGraphMCPServer) handleServiceDependenciesTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	serviceName, ok := args["service_name"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: service_name is required"}},
+			IsError: true,
+		}
+	}
+
+	query := `
+		MATCH (s:Service {name: $serviceName})-[d:DEPENDS_ON]->(target:Service)
+		RETURN target.name AS targetService, target.packageName AS packageName,
+		       d.importCount AS importCount, d.packageName AS importedPackage
+		ORDER BY importCount DESC
+	`
+
+	params := map[string]interface{}{
+		"serviceName": serviceName,
+	}
+
+	result, err := s.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("# Dependencies for %s\n\n", serviceName))
+
+	if len(result) == 0 {
+		output.WriteString("No dependencies found.\n")
+	} else {
+		output.WriteString("| Target Service | Package Name | Import Count | Imported Package |\n")
+		output.WriteString("|----------------|--------------|--------------|------------------|\n")
+		for _, record := range result {
+			recordMap := record.AsMap()
+			targetService := getStringFromRecord(recordMap, "targetService")
+			packageName := getStringFromRecord(recordMap, "packageName")
+			importCount := getIntFromRecord(recordMap, "importCount")
+			importedPackage := getStringFromRecord(recordMap, "importedPackage")
+
+			output.WriteString(fmt.Sprintf("| %s | %s | %d | %s |\n",
+				targetService, packageName, importCount, importedPackage))
+		}
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+// handleServiceAPIEndpointsTool gets API endpoints exposed by a service
+func (s *CodeGraphMCPServer) handleServiceAPIEndpointsTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	serviceName, ok := args["service_name"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: service_name is required"}},
+			IsError: true,
+		}
+	}
+
+	query := `
+		MATCH (s:Service {name: $serviceName})-[:CONTAINS*]->(f:Function)-[e:EXPOSES_API]->(api:APIRoute)
+		RETURN f.name AS functionName, api.method AS method, api.endpoint AS endpoint,
+		       api.line AS line, f.file AS filePath
+		ORDER BY api.endpoint, api.method
+	`
+
+	params := map[string]interface{}{
+		"serviceName": serviceName,
+	}
+
+	result, err := s.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("# API Endpoints for %s\n\n", serviceName))
+
+	if len(result) == 0 {
+		output.WriteString("No API endpoints found.\n")
+	} else {
+		output.WriteString("| Method | Endpoint | Function | File |\n")
+		output.WriteString("|--------|----------|----------|------|\n")
+		for _, record := range result {
+			recordMap := record.AsMap()
+			method := getStringFromRecord(recordMap, "method")
+			endpoint := getStringFromRecord(recordMap, "endpoint")
+			functionName := getStringFromRecord(recordMap, "functionName")
+			filePath := getStringFromRecord(recordMap, "filePath")
+
+			output.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+				method, endpoint, functionName, filePath))
+		}
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+// handleServiceAPICallsTool gets API calls made by a service
+func (s *CodeGraphMCPServer) handleServiceAPICallsTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	serviceName, ok := args["service_name"].(string)
+	if !ok {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: service_name is required"}},
+			IsError: true,
+		}
+	}
+
+	query := `
+		MATCH (s:Service {name: $serviceName})-[:CONTAINS*]->(f:Function)-[c:CALLS_API]->(call)
+		WHERE call:HTTPCall OR call:SDKCall
+		OPTIONAL MATCH (call)-[:TARGETS_SERVICE]->(target:Service)
+		RETURN f.name AS functionName,
+		       CASE WHEN call:HTTPCall THEN 'HTTP' ELSE 'SDK' END AS callType,
+		       call.url AS url, call.method AS method, call.target AS target,
+		       target.name AS targetService,
+		       f.file AS filePath
+		ORDER BY callType, target
+	`
+
+	params := map[string]interface{}{
+		"serviceName": serviceName,
+	}
+
+	result, err := s.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("# API Calls from %s\n\n", serviceName))
+
+	if len(result) == 0 {
+		output.WriteString("No API calls found.\n")
+	} else {
+		output.WriteString("| Type | Target | Method/SDK | URL/Call | Target Service | Function |\n")
+		output.WriteString("|------|--------|------------|----------|----------------|----------|\n")
+		for _, record := range result {
+			recordMap := record.AsMap()
+			callType := getStringFromRecord(recordMap, "callType")
+			target := getStringFromRecord(recordMap, "target")
+			method := getStringFromRecord(recordMap, "method")
+			url := getStringFromRecord(recordMap, "url")
+			targetService := getStringFromRecord(recordMap, "targetService")
+			functionName := getStringFromRecord(recordMap, "functionName")
+
+			output.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s |\n",
+				callType, target, method, url, targetService, functionName))
+		}
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+// handleCrossServiceCallsTool gets cross-service call chains
+func (s *CodeGraphMCPServer) handleCrossServiceCallsTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	sourceService, sourceOk := args["source_service"].(string)
+	targetService, targetOk := args["target_service"].(string)
+
+	if !sourceOk || !targetOk {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: "Error: source_service and target_service are required"}},
+			IsError: true,
+		}
+	}
+
+	query := `
+		MATCH (source:Service {name: $sourceService})
+		MATCH (target:Service {name: $targetService})
+		MATCH path = shortestPath((source)-[*..10]-(target))
+		RETURN [node in nodes(path) |
+		          CASE
+		            WHEN 'Service' IN labels(node) THEN node.name
+		            WHEN 'Function' IN labels(node) THEN node.name
+		            WHEN 'HTTPCall' IN labels(node) THEN node.url
+		            WHEN 'SDKCall' IN labels(node) THEN node.target
+		            ELSE ''
+		          END
+		       ] AS nodePath,
+		       [rel in relationships(path) | type(rel)] AS relPath,
+		       length(path) AS pathLength
+		LIMIT 10
+	`
+
+	params := map[string]interface{}{
+		"sourceService": sourceService,
+		"targetService": targetService,
+	}
+
+	result, err := s.client.ExecuteQuery(ctx, query, params)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("# Call Chains: %s → %s\n\n", sourceService, targetService))
+
+	if len(result) == 0 {
+		output.WriteString("No paths found between these services.\n")
+	} else {
+		for i, record := range result {
+			recordMap := record.AsMap()
+			pathLength := getIntFromRecord(recordMap, "pathLength")
+			nodePath := []interface{}{}
+			if np, ok := recordMap["nodePath"].([]interface{}); ok {
+				nodePath = np
+			}
+			relPath := []interface{}{}
+			if rp, ok := recordMap["relPath"].([]interface{}); ok {
+				relPath = rp
+			}
+
+			output.WriteString(fmt.Sprintf("## Path %d (length: %d)\n\n", i+1, pathLength))
+
+			for j := 0; j < len(nodePath); j++ {
+				node := nodePath[j].(string)
+				output.WriteString(fmt.Sprintf("%s", node))
+				if j < len(relPath) {
+					rel := relPath[j].(string)
+					output.WriteString(fmt.Sprintf(" -[%s]→ ", rel))
+				}
+			}
+			output.WriteString("\n\n")
+		}
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}
+
+// handleServiceArchitectureTool provides a complete architecture overview
+func (s *CodeGraphMCPServer) handleServiceArchitectureTool(ctx context.Context, args map[string]interface{}) ToolCallResponse {
+	query := `
+		// Get all services
+		MATCH (s:Service)
+		OPTIONAL MATCH (s)-[:DEPENDS_ON]->(dep:Service)
+		WITH s, collect(DISTINCT dep.name) AS dependencies
+
+		// Get API endpoints
+		OPTIONAL MATCH (s)-[:CONTAINS*]->(f:Function)-[:EXPOSES_API]->(api:APIRoute)
+		WITH s, dependencies, count(DISTINCT api) AS apiCount
+
+		// Get API calls
+		OPTIONAL MATCH (s)-[:CONTAINS*]->(f2:Function)-[:CALLS_API]->(call)
+		WHERE call:HTTPCall OR call:SDKCall
+		WITH s, dependencies, apiCount, count(DISTINCT call) AS callCount
+
+		RETURN s.name AS name, s.packageName AS packageName,
+		       dependencies, apiCount, callCount
+		ORDER BY s.name
+	`
+
+	result, err := s.client.ExecuteQuery(ctx, query, nil)
+	if err != nil {
+		return ToolCallResponse{
+			Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	var output strings.Builder
+	output.WriteString("# Service Architecture Overview\n\n")
+
+	if len(result) == 0 {
+		output.WriteString("No services found.\n")
+	} else {
+		// Summary
+		output.WriteString(fmt.Sprintf("**Total Services**: %d\n\n", len(result)))
+
+		// Service details
+		for _, record := range result {
+			recordMap := record.AsMap()
+			name := getStringFromRecord(recordMap, "name")
+			packageName := getStringFromRecord(recordMap, "packageName")
+			dependencies := []interface{}{}
+			if deps, ok := recordMap["dependencies"].([]interface{}); ok {
+				dependencies = deps
+			}
+			apiCount := getIntFromRecord(recordMap, "apiCount")
+			callCount := getIntFromRecord(recordMap, "callCount")
+
+			output.WriteString(fmt.Sprintf("## %s\n\n", name))
+			if packageName != "" {
+				output.WriteString(fmt.Sprintf("- **Package**: %s\n", packageName))
+			}
+			output.WriteString(fmt.Sprintf("- **API Endpoints**: %d\n", apiCount))
+			output.WriteString(fmt.Sprintf("- **API Calls**: %d\n", callCount))
+
+			if len(dependencies) > 0 {
+				output.WriteString("- **Dependencies**:\n")
+				for _, dep := range dependencies {
+					output.WriteString(fmt.Sprintf("  - %s\n", dep.(string)))
+				}
+			}
+			output.WriteString("\n")
+		}
+
+		// Relationship graph
+		output.WriteString("## Dependency Graph\n\n```mermaid\ngraph LR\n")
+		for _, record := range result {
+			recordMap := record.AsMap()
+			name := getStringFromRecord(recordMap, "name")
+			dependencies := []interface{}{}
+			if deps, ok := recordMap["dependencies"].([]interface{}); ok {
+				dependencies = deps
+			}
+
+			for _, dep := range dependencies {
+				depName := dep.(string)
+				output.WriteString(fmt.Sprintf("    %s --> %s\n", name, depName))
+			}
+		}
+		output.WriteString("```\n")
+	}
+
+	return ToolCallResponse{
+		Content: []ToolContent{{Type: "text", Text: output.String()}},
+	}
+}

--- a/apps/mcp-server-go/project.json
+++ b/apps/mcp-server-go/project.json
@@ -5,14 +5,14 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd mcp-server && go build -o ../bin/codegraph-mcp ./...",
+        "command": "go build -o bin/codegraph-mcp-new ./apps/mcp-server-go/",
         "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
       }
     },
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd mcp-server && go test ./...",
+        "command": "go test ./apps/mcp-server-go/...",
         "cwd": "/home/techsavvyash/sweatAndBlood/context/codegraph"
       }
     }

--- a/infra/docker/compose.platform.yml
+++ b/infra/docker/compose.platform.yml
@@ -1,0 +1,44 @@
+# Platform compose: neo4j + qdrant + opensearch + codegraph services
+# Usage: docker compose -f infra/docker/compose.platform.yml up
+version: "3.9"
+
+services:
+  neo4j:
+    image: neo4j:5.15-enterprise
+    environment:
+      - NEO4J_AUTH=neo4j/password123
+      - NEO4J_PLUGINS=["apoc"]
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    healthcheck:
+      test: ["CMD", "neo4j", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  qdrant:
+    image: qdrant/qdrant:v1.9.0
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/readyz"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  opensearch:
+    image: opensearchproject/opensearch:2.13.0
+    environment:
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow"]
+      interval: 10s
+      timeout: 10s
+      retries: 20

--- a/tools/scripts/bootstrap.sh
+++ b/tools/scripts/bootstrap.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== CodeGraph Platform Bootstrap ==="
+
+# Check Go
+if ! command -v go &> /dev/null; then
+  echo "ERROR: Go not found. Install Go 1.24+ from https://go.dev/dl/"
+  exit 1
+fi
+
+# Check Docker
+if ! command -v docker &> /dev/null; then
+  echo "ERROR: Docker not found. Install Docker Desktop or Docker Engine."
+  exit 1
+fi
+
+# Install pnpm/nx if needed
+if ! command -v pnpm &> /dev/null; then
+  npm install -g pnpm
+fi
+
+# Install node deps
+pnpm install
+
+# Start infrastructure
+docker compose -f infra/docker/compose.platform.yml up -d
+
+echo "Waiting for services to be healthy..."
+sleep 15
+
+# Build CLI
+make build
+
+echo ""
+echo "=== Bootstrap complete ==="
+echo "Run: ./bin/codegraph status"


### PR DESCRIPTION
## Summary

Stacked on: #20 (phase2-services)

Copies the two application entry points into `apps/`, adds the full three-store platform compose, and the developer bootstrap script.

## apps/cli-go

- Copied `cmd/codegraph/main.go` → `apps/cli-go/main.go`
- All `pkg/` imports unchanged (shim phase)
- Builds cleanly: `go build -o /tmp/codegraph-apps-test ./apps/cli-go/` ✓
- `apps/cli-go/project.json` updated to point at new location

## apps/mcp-server-go

- Copied `mcp-server/main.go` → `apps/mcp-server-go/main.go`
- Tagged `//go:build ignore` because `github.com/joho/godotenv` is only in `mcp-server/go.mod`, not root
- **Next step:** add `godotenv` to root `go.mod` and remove the ignore tag (tracked as follow-up in Phase 3)
- `apps/mcp-server-go/project.json` updated

## infra/docker/compose.platform.yml

Full three-store platform compose with health checks:
- `neo4j:5.15-enterprise` → ports 7474, 7687
- `qdrant:v1.9.0` → ports 6333, 6334
- `opensearch:2.13.0` → port 9200 (security disabled for local dev)

## tools/scripts/bootstrap.sh

One-command developer setup: checks Go + Docker, installs pnpm, starts infra, waits for health, builds CLI.

## Validation

```
go build ./...   ✓  (ignore-tagged files excluded)
make build       ✓  (bin/codegraph produced)
make test        ✓  (all unit tests pass)
```

## Test plan

- [ ] `go build ./...` passes
- [ ] `make build` produces `bin/codegraph`
- [ ] `go build ./apps/cli-go/` produces working binary
- [ ] `docker compose -f infra/docker/compose.platform.yml up` starts all three stores

🤖 Generated with [Claude Code](https://claude.ai/claude-code)