### PR TITLE
feat(monorepo phase3): GraphStore interface, Neo4j impl, and MockGraphStore

### DIFF
--- a/libs/core-models-go/store.go
+++ b/libs/core-models-go/store.go
@@ -1,0 +1,77 @@
+package models
+
+import "context"
+
+// Node is a generic graph node used by the GraphStore interface.
+// It maps directly to BaseNode and is used as the unit of storage for all
+// node types in the indexing and retrieval pipelines.
+type Node = BaseNode
+
+// Relationship is a generic graph relationship used by the GraphStore interface.
+// It maps directly to BaseRelationship and is used as the unit of storage for
+// all relationship types in the indexing and retrieval pipelines.
+type Relationship = BaseRelationship
+
+// GraphStore abstracts all graph database operations used by the indexing
+// and retrieval pipelines. Implementations: Neo4j (production), Mock (tests).
+type GraphStore interface {
+	// --- Write operations ---
+
+	// UpsertNode creates or updates a node identified by its nodeKey.
+	// The node's scope and scopeId determine which overlay it belongs to.
+	UpsertNode(ctx context.Context, node *Node) error
+
+	// UpsertNodes batch-upserts a slice of nodes.
+	UpsertNodes(ctx context.Context, nodes []*Node) error
+
+	// UpsertRelationship creates or updates a directed relationship.
+	UpsertRelationship(ctx context.Context, rel *Relationship) error
+
+	// UpsertRelationships batch-upserts a slice of relationships.
+	UpsertRelationships(ctx context.Context, rels []*Relationship) error
+
+	// ApplyTombstone marks a node as deleted in a PR overlay scope.
+	// Hides the main-scope node from that PR's view.
+	ApplyTombstone(ctx context.Context, tombstone *Tombstone) error
+
+	// --- Read operations ---
+
+	// GetNode retrieves a single node by nodeKey and scope context.
+	// Returns nil if not found.
+	GetNode(ctx context.Context, nodeKey string, scope ScopeContext) (*Node, error)
+
+	// FindNodes retrieves nodes matching the given filter.
+	FindNodes(ctx context.Context, filter NodeFilter) ([]*Node, error)
+
+	// FindRelationships retrieves relationships matching the given filter.
+	FindRelationships(ctx context.Context, filter RelFilter) ([]*Relationship, error)
+
+	// GetWithOverlay resolves a node applying overlay precedence:
+	// overlay scope wins > tombstone hides > main scope fallback.
+	GetWithOverlay(ctx context.Context, nodeKey string, scope ScopeContext) (*Node, error)
+
+	// --- Lifecycle ---
+
+	// Close releases any underlying connections.
+	Close(ctx context.Context) error
+}
+
+// NodeFilter selects nodes by various criteria.
+type NodeFilter struct {
+	TenantID  string
+	Repo      string
+	Service   string
+	NodeTypes []NodeType
+	Scope     string
+	ScopeID   string
+	Limit     int
+}
+
+// RelFilter selects relationships by various criteria.
+type RelFilter struct {
+	TenantID    string
+	FromNodeKey string
+	ToNodeKey   string
+	RelTypes    []RelationshipType
+	Limit       int
+}

--- a/libs/core-models-go/store_mock.go
+++ b/libs/core-models-go/store_mock.go
@@ -1,0 +1,264 @@
+package models
+
+import (
+	"context"
+	"sync"
+)
+
+// MockGraphStore is an in-memory GraphStore implementation for testing.
+// It does NOT require a live Neo4j instance.
+//
+// Error injection: set Errors["MethodName"] = someErr to make that method
+// return the given error on the next call.
+type MockGraphStore struct {
+	mu            sync.RWMutex
+	nodes         map[string]*Node       // nodeKey → Node (all scopes)
+	relationships []*Relationship
+	tombstones    map[string]*Tombstone  // tombstone nodeKey → Tombstone
+	Errors        map[string]error       // method name → error to return
+}
+
+// NewMockGraphStore returns an initialised MockGraphStore.
+func NewMockGraphStore() *MockGraphStore {
+	return &MockGraphStore{
+		nodes:      make(map[string]*Node),
+		tombstones: make(map[string]*Tombstone),
+		Errors:     make(map[string]error),
+	}
+}
+
+// storageKey returns a composite key used to store a node by (nodeKey, scopeId).
+func storageKey(nodeKey, scopeID string) string {
+	return nodeKey + "\x00" + scopeID
+}
+
+// UpsertNode stores or updates a node keyed by (NodeKey, ScopeID).
+func (m *MockGraphStore) UpsertNode(ctx context.Context, node *Node) error {
+	if err := m.Errors["UpsertNode"]; err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := storageKey(node.NodeKey, node.ScopeID)
+	m.nodes[key] = node
+	return nil
+}
+
+// UpsertNodes calls UpsertNode for each node in the slice.
+func (m *MockGraphStore) UpsertNodes(ctx context.Context, nodes []*Node) error {
+	if err := m.Errors["UpsertNodes"]; err != nil {
+		return err
+	}
+	for _, n := range nodes {
+		if err := m.UpsertNode(ctx, n); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpsertRelationship appends a relationship to the in-memory store.
+// Duplicate detection is deliberately omitted for simplicity.
+func (m *MockGraphStore) UpsertRelationship(ctx context.Context, rel *Relationship) error {
+	if err := m.Errors["UpsertRelationship"]; err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Replace existing relationship with the same (StartID, EndID, Type) if present.
+	for i, existing := range m.relationships {
+		if existing.StartID == rel.StartID &&
+			existing.EndID == rel.EndID &&
+			existing.Type == rel.Type {
+			m.relationships[i] = rel
+			return nil
+		}
+	}
+	m.relationships = append(m.relationships, rel)
+	return nil
+}
+
+// UpsertRelationships calls UpsertRelationship for each relationship.
+func (m *MockGraphStore) UpsertRelationships(ctx context.Context, rels []*Relationship) error {
+	if err := m.Errors["UpsertRelationships"]; err != nil {
+		return err
+	}
+	for _, rel := range rels {
+		if err := m.UpsertRelationship(ctx, rel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ApplyTombstone stores a tombstone keyed by its NodeKey.
+func (m *MockGraphStore) ApplyTombstone(ctx context.Context, tombstone *Tombstone) error {
+	if err := m.Errors["ApplyTombstone"]; err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tombstones[tombstone.NodeKey] = tombstone
+	return nil
+}
+
+// GetNode retrieves a node by nodeKey and scope. Returns nil if not found.
+func (m *MockGraphStore) GetNode(ctx context.Context, nodeKey string, scope ScopeContext) (*Node, error) {
+	if err := m.Errors["GetNode"]; err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	key := storageKey(nodeKey, scope.ScopeID)
+	node, ok := m.nodes[key]
+	if !ok {
+		return nil, nil
+	}
+	return node, nil
+}
+
+// FindNodes retrieves nodes that match all non-zero fields in the filter.
+func (m *MockGraphStore) FindNodes(ctx context.Context, filter NodeFilter) ([]*Node, error) {
+	if err := m.Errors["FindNodes"]; err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var results []*Node
+	for _, node := range m.nodes {
+		if !nodeMatchesFilter(node, filter) {
+			continue
+		}
+		results = append(results, node)
+		if filter.Limit > 0 && len(results) >= filter.Limit {
+			break
+		}
+	}
+	return results, nil
+}
+
+// FindRelationships retrieves relationships matching the filter.
+func (m *MockGraphStore) FindRelationships(ctx context.Context, filter RelFilter) ([]*Relationship, error) {
+	if err := m.Errors["FindRelationships"]; err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var results []*Relationship
+	for _, rel := range m.relationships {
+		if filter.FromNodeKey != "" && rel.StartID != filter.FromNodeKey {
+			continue
+		}
+		if filter.ToNodeKey != "" && rel.EndID != filter.ToNodeKey {
+			continue
+		}
+		if len(filter.RelTypes) > 0 && !containsRelType(filter.RelTypes, rel.Type) {
+			continue
+		}
+		results = append(results, rel)
+		if filter.Limit > 0 && len(results) >= filter.Limit {
+			break
+		}
+	}
+	return results, nil
+}
+
+// GetWithOverlay resolves a node applying overlay precedence:
+//  1. If an overlay-scope node exists for nodeKey → return it.
+//  2. If a tombstone exists for nodeKey in this scope → return nil (hidden).
+//  3. If a main-scope node exists → return it.
+//  4. Otherwise → return nil.
+func (m *MockGraphStore) GetWithOverlay(ctx context.Context, nodeKey string, scope ScopeContext) (*Node, error) {
+	if err := m.Errors["GetWithOverlay"]; err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// Step 1: overlay node.
+	if scope.ScopeID != "" && scope.ScopeID != ScopeMain {
+		overlayKey := storageKey(nodeKey, scope.ScopeID)
+		if node, ok := m.nodes[overlayKey]; ok {
+			return node, nil
+		}
+	}
+
+	// Step 2: tombstone check.
+	tombstoneKey := TombstoneNodeKey(scope.ScopeID, nodeKey)
+	if _, found := m.tombstones[tombstoneKey]; found {
+		return nil, nil
+	}
+
+	// Step 3: main-scope fallback.
+	mainKey := storageKey(nodeKey, ScopeMain)
+	if node, ok := m.nodes[mainKey]; ok {
+		return node, nil
+	}
+
+	return nil, nil
+}
+
+// Close is a no-op for the mock store.
+func (m *MockGraphStore) Close(ctx context.Context) error {
+	return nil
+}
+
+// --- Inspection helpers (not part of the interface, useful in tests) ---
+
+// AllNodes returns a copy of all stored nodes.
+func (m *MockGraphStore) AllNodes() []*Node {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*Node, 0, len(m.nodes))
+	for _, n := range m.nodes {
+		out = append(out, n)
+	}
+	return out
+}
+
+// AllRelationships returns a copy of all stored relationships.
+func (m *MockGraphStore) AllRelationships() []*Relationship {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*Relationship, len(m.relationships))
+	copy(out, m.relationships)
+	return out
+}
+
+// --- private helpers ---
+
+func nodeMatchesFilter(node *Node, filter NodeFilter) bool {
+	if filter.ScopeID != "" && node.ScopeID != filter.ScopeID {
+		return false
+	}
+	if filter.Scope != "" && node.Scope != filter.Scope {
+		return false
+	}
+	if len(filter.NodeTypes) > 0 && !nodeHasAnyLabel(node, filter.NodeTypes) {
+		return false
+	}
+	return true
+}
+
+func nodeHasAnyLabel(node *Node, types []NodeType) bool {
+	for _, nt := range types {
+		label := string(nt)
+		for _, l := range node.Labels {
+			if l == label {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsRelType(types []RelationshipType, t RelationshipType) bool {
+	for _, rt := range types {
+		if rt == t {
+			return true
+		}
+	}
+	return false
+}

--- a/libs/core-models-go/store_mock_test.go
+++ b/libs/core-models-go/store_mock_test.go
@@ -1,0 +1,362 @@
+package models_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	models "github.com/context-maximiser/code-graph/libs/core-models-go"
+)
+
+// compile-time assertion: MockGraphStore must satisfy GraphStore.
+var _ models.GraphStore = (*models.MockGraphStore)(nil)
+
+func TestMockGraphStore_UpsertNode_GetNode_RoundTrip(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	node := &models.Node{
+		NodeKey: "fn:MyFunc",
+		Labels:  []string{"Function"},
+		Scope:   models.ScopeMain,
+		ScopeID: models.ScopeMain,
+		Props: map[string]any{
+			"name": "MyFunc",
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if err := store.UpsertNode(ctx, node); err != nil {
+		t.Fatalf("UpsertNode: %v", err)
+	}
+
+	got, err := store.GetNode(ctx, "fn:MyFunc", models.DefaultScope())
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetNode: expected a node, got nil")
+	}
+	if got.NodeKey != node.NodeKey {
+		t.Errorf("NodeKey: got %q, want %q", got.NodeKey, node.NodeKey)
+	}
+	if got.Props["name"] != "MyFunc" {
+		t.Errorf("Props[name]: got %v, want %q", got.Props["name"], "MyFunc")
+	}
+}
+
+func TestMockGraphStore_GetNode_NotFound(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	got, err := store.GetNode(ctx, "does-not-exist", models.DefaultScope())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestMockGraphStore_UpsertNodes_FindNodes(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	nodes := []*models.Node{
+		{NodeKey: "fn:FuncA", Labels: []string{"Function"}, Scope: models.ScopeMain, ScopeID: models.ScopeMain},
+		{NodeKey: "fn:FuncB", Labels: []string{"Function"}, Scope: models.ScopeMain, ScopeID: models.ScopeMain},
+		{NodeKey: "cls:ClassA", Labels: []string{"Class"}, Scope: models.ScopeMain, ScopeID: models.ScopeMain},
+	}
+
+	if err := store.UpsertNodes(ctx, nodes); err != nil {
+		t.Fatalf("UpsertNodes: %v", err)
+	}
+
+	filter := models.NodeFilter{
+		ScopeID:   models.ScopeMain,
+		NodeTypes: []models.NodeType{models.FunctionNode},
+	}
+	found, err := store.FindNodes(ctx, filter)
+	if err != nil {
+		t.Fatalf("FindNodes: %v", err)
+	}
+	if len(found) != 2 {
+		t.Errorf("FindNodes: expected 2 Function nodes, got %d", len(found))
+	}
+}
+
+func TestMockGraphStore_UpsertRelationship_FindRelationships(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	rel := &models.Relationship{
+		StartID: "fn:FuncA",
+		EndID:   "fn:FuncB",
+		Type:    models.CallsRel,
+	}
+
+	if err := store.UpsertRelationship(ctx, rel); err != nil {
+		t.Fatalf("UpsertRelationship: %v", err)
+	}
+
+	filter := models.RelFilter{
+		FromNodeKey: "fn:FuncA",
+		RelTypes:    []models.RelationshipType{models.CallsRel},
+	}
+	rels, err := store.FindRelationships(ctx, filter)
+	if err != nil {
+		t.Fatalf("FindRelationships: %v", err)
+	}
+	if len(rels) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(rels))
+	}
+	if rels[0].EndID != "fn:FuncB" {
+		t.Errorf("EndID: got %q, want %q", rels[0].EndID, "fn:FuncB")
+	}
+}
+
+// GetWithOverlay: overlay-scope node wins over main-scope node.
+func TestMockGraphStore_GetWithOverlay_OverlayWins(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	mainNode := &models.Node{
+		NodeKey: "fn:FuncA",
+		Labels:  []string{"Function"},
+		Scope:   models.ScopeMain,
+		ScopeID: models.ScopeMain,
+		Props:   map[string]any{"version": "main"},
+	}
+	overlayNode := &models.Node{
+		NodeKey: "fn:FuncA",
+		Labels:  []string{"Function"},
+		Scope:   models.ScopePR,
+		ScopeID: "pr-42",
+		Props:   map[string]any{"version": "pr-42"},
+	}
+
+	if err := store.UpsertNode(ctx, mainNode); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertNode(ctx, overlayNode); err != nil {
+		t.Fatal(err)
+	}
+
+	prScope := models.NewPRScope("42")
+	got, err := store.GetWithOverlay(ctx, "fn:FuncA", prScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected overlay node, got nil")
+	}
+	if got.ScopeID != "pr-42" {
+		t.Errorf("expected overlay ScopeID=pr-42, got %q", got.ScopeID)
+	}
+	if got.Props["version"] != "pr-42" {
+		t.Errorf("expected overlay version=pr-42, got %v", got.Props["version"])
+	}
+}
+
+// GetWithOverlay: tombstone hides the main-scope node.
+func TestMockGraphStore_GetWithOverlay_TombstoneHides(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	mainNode := &models.Node{
+		NodeKey: "fn:FuncA",
+		Labels:  []string{"Function"},
+		Scope:   models.ScopeMain,
+		ScopeID: models.ScopeMain,
+	}
+	if err := store.UpsertNode(ctx, mainNode); err != nil {
+		t.Fatal(err)
+	}
+
+	scopeID := "pr-42"
+	tombstone := &models.Tombstone{
+		BaseNode: models.BaseNode{
+			NodeKey: models.TombstoneNodeKey(scopeID, "fn:FuncA"),
+			ScopeID: scopeID,
+		},
+		TargetNodeKey: "fn:FuncA",
+		TargetLabel:   "Function",
+		Reason:        models.TombstoneSymbolRemoved,
+	}
+	if err := store.ApplyTombstone(ctx, tombstone); err != nil {
+		t.Fatal(err)
+	}
+
+	prScope := models.NewPRScope("42")
+	got, err := store.GetWithOverlay(ctx, "fn:FuncA", prScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil (tombstoned), got node with key %q", got.NodeKey)
+	}
+}
+
+// GetWithOverlay: falls back to main-scope when no overlay and no tombstone.
+func TestMockGraphStore_GetWithOverlay_FallsBackToMain(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	mainNode := &models.Node{
+		NodeKey: "fn:FuncA",
+		Labels:  []string{"Function"},
+		Scope:   models.ScopeMain,
+		ScopeID: models.ScopeMain,
+		Props:   map[string]any{"version": "main"},
+	}
+	if err := store.UpsertNode(ctx, mainNode); err != nil {
+		t.Fatal(err)
+	}
+
+	// PR scope with no overlay node and no tombstone.
+	prScope := models.NewPRScope("99")
+	got, err := store.GetWithOverlay(ctx, "fn:FuncA", prScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected main-scope fallback, got nil")
+	}
+	if got.ScopeID != models.ScopeMain {
+		t.Errorf("expected ScopeID=main, got %q", got.ScopeID)
+	}
+}
+
+// GetWithOverlay: returns nil when nothing matches at all.
+func TestMockGraphStore_GetWithOverlay_ReturnsNilWhenNotFound(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	prScope := models.NewPRScope("1")
+	got, err := store.GetWithOverlay(ctx, "does-not-exist", prScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+// Error injection via Errors map.
+func TestMockGraphStore_ErrorInjection_UpsertNode(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	injectedErr := errors.New("injected UpsertNode error")
+	store.Errors["UpsertNode"] = injectedErr
+
+	node := &models.Node{NodeKey: "fn:FuncA", ScopeID: models.ScopeMain}
+	if err := store.UpsertNode(ctx, node); !errors.Is(err, injectedErr) {
+		t.Errorf("expected injected error, got %v", err)
+	}
+}
+
+func TestMockGraphStore_ErrorInjection_GetNode(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	injectedErr := errors.New("injected GetNode error")
+	store.Errors["GetNode"] = injectedErr
+
+	_, err := store.GetNode(ctx, "fn:FuncA", models.DefaultScope())
+	if !errors.Is(err, injectedErr) {
+		t.Errorf("expected injected error, got %v", err)
+	}
+}
+
+func TestMockGraphStore_ErrorInjection_GetWithOverlay(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	injectedErr := errors.New("injected GetWithOverlay error")
+	store.Errors["GetWithOverlay"] = injectedErr
+
+	_, err := store.GetWithOverlay(ctx, "fn:FuncA", models.DefaultScope())
+	if !errors.Is(err, injectedErr) {
+		t.Errorf("expected injected error, got %v", err)
+	}
+}
+
+func TestMockGraphStore_ErrorInjection_ApplyTombstone(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	injectedErr := errors.New("injected ApplyTombstone error")
+	store.Errors["ApplyTombstone"] = injectedErr
+
+	tombstone := &models.Tombstone{
+		BaseNode: models.BaseNode{NodeKey: "t:key", ScopeID: "pr-1"},
+	}
+	if err := store.ApplyTombstone(ctx, tombstone); !errors.Is(err, injectedErr) {
+		t.Errorf("expected injected error, got %v", err)
+	}
+}
+
+func TestMockGraphStore_FindNodes_Limit(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		node := &models.Node{
+			NodeKey: "fn:Func" + string(rune('A'+i)),
+			Labels:  []string{"Function"},
+			Scope:   models.ScopeMain,
+			ScopeID: models.ScopeMain,
+		}
+		if err := store.UpsertNode(ctx, node); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	filter := models.NodeFilter{Limit: 3}
+	found, err := store.FindNodes(ctx, filter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(found) > 3 {
+		t.Errorf("expected at most 3 nodes (limit), got %d", len(found))
+	}
+}
+
+func TestMockGraphStore_UpsertRelationship_Idempotent(t *testing.T) {
+	store := models.NewMockGraphStore()
+	ctx := context.Background()
+
+	rel := &models.Relationship{
+		StartID: "fn:A",
+		EndID:   "fn:B",
+		Type:    models.CallsRel,
+		Properties: map[string]any{
+			"line": 10,
+		},
+	}
+
+	// Upsert the same relationship twice.
+	if err := store.UpsertRelationship(ctx, rel); err != nil {
+		t.Fatal(err)
+	}
+	rel2 := &models.Relationship{
+		StartID:    "fn:A",
+		EndID:      "fn:B",
+		Type:       models.CallsRel,
+		Properties: map[string]any{"line": 20},
+	}
+	if err := store.UpsertRelationship(ctx, rel2); err != nil {
+		t.Fatal(err)
+	}
+
+	all := store.AllRelationships()
+	if len(all) != 1 {
+		t.Errorf("expected exactly 1 relationship after duplicate upsert, got %d", len(all))
+	}
+	if all[0].Properties["line"] != 20 {
+		t.Errorf("expected updated line=20, got %v", all[0].Properties["line"])
+	}
+}

--- a/libs/neo4j-client-go/store.go
+++ b/libs/neo4j-client-go/store.go
@@ -1,0 +1,430 @@
+package neo4j
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	models "github.com/context-maximiser/code-graph/libs/core-models-go"
+)
+
+// Neo4jGraphStore implements models.GraphStore using Neo4j.
+type Neo4jGraphStore struct {
+	client *Client
+}
+
+// NewGraphStore creates a new Neo4jGraphStore wrapping the given client.
+func NewGraphStore(client *Client) *Neo4jGraphStore {
+	return &Neo4jGraphStore{client: client}
+}
+
+// UpsertNode creates or updates a node identified by its NodeKey using MERGE on (nodeKey, scopeId).
+func (s *Neo4jGraphStore) UpsertNode(ctx context.Context, node *models.Node) error {
+	if node.NodeKey == "" {
+		return fmt.Errorf("UpsertNode: node.NodeKey must not be empty")
+	}
+
+	// Determine the primary label; fall back to "Node" if no labels provided.
+	label := "Node"
+	if len(node.Labels) > 0 {
+		label = node.Labels[0]
+	}
+
+	// Build the props map by merging all fields.
+	props := buildNodeProps(node)
+
+	item := map[string]any{
+		"nodeKey": node.NodeKey,
+		"scopeId": node.ScopeID,
+		"props":   props,
+	}
+
+	_, err := s.client.MergeNodesBatch(ctx, label, []map[string]any{item}, 1)
+	if err != nil {
+		return fmt.Errorf("UpsertNode(%s): %w", node.NodeKey, err)
+	}
+	return nil
+}
+
+// UpsertNodes batch-upserts a slice of nodes grouped by their primary label.
+func (s *Neo4jGraphStore) UpsertNodes(ctx context.Context, nodes []*models.Node) error {
+	// Group nodes by their primary label so we can call MergeNodesBatch once per label.
+	byLabel := make(map[string][]map[string]any)
+	for _, node := range nodes {
+		if node.NodeKey == "" {
+			return fmt.Errorf("UpsertNodes: encountered node with empty NodeKey")
+		}
+		label := "Node"
+		if len(node.Labels) > 0 {
+			label = node.Labels[0]
+		}
+		item := map[string]any{
+			"nodeKey": node.NodeKey,
+			"scopeId": node.ScopeID,
+			"props":   buildNodeProps(node),
+		}
+		byLabel[label] = append(byLabel[label], item)
+	}
+
+	for label, items := range byLabel {
+		if _, err := s.client.MergeNodesBatch(ctx, label, items, 500); err != nil {
+			return fmt.Errorf("UpsertNodes(%s): %w", label, err)
+		}
+	}
+	return nil
+}
+
+// UpsertRelationship creates or updates a directed relationship by merging on
+// (fromNodeKey, toNodeKey, type). Nodes are matched by their nodeKey.
+func (s *Neo4jGraphStore) UpsertRelationship(ctx context.Context, rel *models.Relationship) error {
+	if rel.StartID == "" || rel.EndID == "" {
+		return fmt.Errorf("UpsertRelationship: StartID and EndID must not be empty")
+	}
+	if rel.Type == "" {
+		return fmt.Errorf("UpsertRelationship: Type must not be empty")
+	}
+
+	relType := string(rel.Type)
+
+	// Use MERGE on nodeKey to find the nodes, then MERGE the relationship.
+	cypher := fmt.Sprintf(`
+		MATCH (a {nodeKey: $fromKey}), (b {nodeKey: $toKey})
+		MERGE (a)-[r:%s]->(b)
+		SET r += $props
+		RETURN elementId(r) AS id
+	`, relType)
+
+	props := rel.Properties
+	if props == nil {
+		props = map[string]any{}
+	}
+
+	_, err := s.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"fromKey": rel.StartID,
+		"toKey":   rel.EndID,
+		"props":   props,
+	})
+	if err != nil {
+		return fmt.Errorf("UpsertRelationship(%s→%s %s): %w", rel.StartID, rel.EndID, relType, err)
+	}
+	return nil
+}
+
+// UpsertRelationships batch-upserts a slice of relationships grouped by type.
+func (s *Neo4jGraphStore) UpsertRelationships(ctx context.Context, rels []*models.Relationship) error {
+	for _, rel := range rels {
+		if err := s.UpsertRelationship(ctx, rel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ApplyTombstone persists a Tombstone node that marks a main-scope node as
+// deleted within the given PR overlay scope.
+func (s *Neo4jGraphStore) ApplyTombstone(ctx context.Context, tombstone *models.Tombstone) error {
+	if tombstone.NodeKey == "" {
+		return fmt.Errorf("ApplyTombstone: tombstone.NodeKey must not be empty")
+	}
+
+	props := map[string]any{
+		"nodeKey":       tombstone.NodeKey,
+		"scopeId":       tombstone.ScopeID,
+		"scope":         tombstone.Scope,
+		"targetNodeKey": tombstone.TargetNodeKey,
+		"targetLabel":   tombstone.TargetLabel,
+		"reason":        string(tombstone.Reason),
+	}
+
+	item := map[string]any{
+		"nodeKey": tombstone.NodeKey,
+		"scopeId": tombstone.ScopeID,
+		"props":   props,
+	}
+
+	_, err := s.client.MergeNodesBatch(ctx, "Tombstone", []map[string]any{item}, 1)
+	if err != nil {
+		return fmt.Errorf("ApplyTombstone(%s): %w", tombstone.NodeKey, err)
+	}
+	return nil
+}
+
+// GetNode retrieves a single node by nodeKey scoped to the given ScopeContext.
+// Returns nil if not found.
+func (s *Neo4jGraphStore) GetNode(ctx context.Context, nodeKey string, scope models.ScopeContext) (*models.Node, error) {
+	cypher := `
+		MATCH (n {nodeKey: $nodeKey, scopeId: $scopeId})
+		RETURN n, labels(n) AS nodeLabels
+		LIMIT 1
+	`
+	records, err := s.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"nodeKey": nodeKey,
+		"scopeId": scope.ScopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetNode(%s): %w", nodeKey, err)
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	return recordToNode(records[0].AsMap()), nil
+}
+
+// FindNodes retrieves nodes matching the given filter.
+func (s *Neo4jGraphStore) FindNodes(ctx context.Context, filter models.NodeFilter) ([]*models.Node, error) {
+	var conditions []string
+	params := map[string]any{}
+
+	if filter.ScopeID != "" {
+		conditions = append(conditions, "n.scopeId = $scopeId")
+		params["scopeId"] = filter.ScopeID
+	}
+	if filter.Scope != "" {
+		conditions = append(conditions, "n.scope = $scope")
+		params["scope"] = filter.Scope
+	}
+	if filter.Service != "" {
+		conditions = append(conditions, "n.service = $service")
+		params["service"] = filter.Service
+	}
+	if filter.TenantID != "" {
+		conditions = append(conditions, "n.tenantId = $tenantId")
+		params["tenantId"] = filter.TenantID
+	}
+	if filter.Repo != "" {
+		conditions = append(conditions, "n.repo = $repo")
+		params["repo"] = filter.Repo
+	}
+
+	// Label filter
+	var labelClauses []string
+	for _, nt := range filter.NodeTypes {
+		labelClauses = append(labelClauses, fmt.Sprintf("n:%s", string(nt)))
+	}
+
+	matchClause := "MATCH (n)"
+	if len(labelClauses) > 0 {
+		matchClause = fmt.Sprintf("MATCH (n) WHERE (%s)", strings.Join(labelClauses, " OR "))
+		if len(conditions) > 0 {
+			matchClause += " AND " + strings.Join(conditions, " AND ")
+		}
+	} else if len(conditions) > 0 {
+		matchClause += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	cypher := matchClause + "\nRETURN n, labels(n) AS nodeLabels"
+	if filter.Limit > 0 {
+		cypher += fmt.Sprintf("\nLIMIT %d", filter.Limit)
+	}
+
+	records, err := s.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("FindNodes: %w", err)
+	}
+
+	nodes := make([]*models.Node, 0, len(records))
+	for _, rec := range records {
+		nodes = append(nodes, recordToNode(rec.AsMap()))
+	}
+	return nodes, nil
+}
+
+// FindRelationships retrieves relationships matching the given filter.
+func (s *Neo4jGraphStore) FindRelationships(ctx context.Context, filter models.RelFilter) ([]*models.Relationship, error) {
+	params := map[string]any{}
+
+	// Build the match clause.
+	fromClause := "(a)"
+	toClause := "(b)"
+	if filter.FromNodeKey != "" {
+		fromClause = "(a {nodeKey: $fromKey})"
+		params["fromKey"] = filter.FromNodeKey
+	}
+	if filter.ToNodeKey != "" {
+		toClause = "(b {nodeKey: $toKey})"
+		params["toKey"] = filter.ToNodeKey
+	}
+
+	relTypeClause := "[r]"
+	if len(filter.RelTypes) > 0 {
+		types := make([]string, len(filter.RelTypes))
+		for i, rt := range filter.RelTypes {
+			types[i] = string(rt)
+		}
+		relTypeClause = fmt.Sprintf("[r:%s]", strings.Join(types, "|"))
+	}
+
+	cypher := fmt.Sprintf(`
+		MATCH %s-%s->%s
+		RETURN a.nodeKey AS fromKey, b.nodeKey AS toKey, type(r) AS relType, properties(r) AS props
+	`, fromClause, relTypeClause, toClause)
+
+	if filter.Limit > 0 {
+		cypher += fmt.Sprintf("\nLIMIT %d", filter.Limit)
+	}
+
+	records, err := s.client.ExecuteQuery(ctx, cypher, params)
+	if err != nil {
+		return nil, fmt.Errorf("FindRelationships: %w", err)
+	}
+
+	rels := make([]*models.Relationship, 0, len(records))
+	for _, rec := range records {
+		m := rec.AsMap()
+		fromKey, _ := m["fromKey"].(string)
+		toKey, _ := m["toKey"].(string)
+		relType, _ := m["relType"].(string)
+		props, _ := m["props"].(map[string]any)
+		if props == nil {
+			props = map[string]any{}
+		}
+		rels = append(rels, &models.Relationship{
+			StartID:    fromKey,
+			EndID:      toKey,
+			Type:       models.RelationshipType(relType),
+			Properties: props,
+		})
+	}
+	return rels, nil
+}
+
+// GetWithOverlay resolves a node applying overlay precedence:
+// 1. Overlay-scope node wins if present.
+// 2. A tombstone in the overlay scope hides the main-scope node.
+// 3. Falls back to the main-scope node.
+// 4. Returns nil if none found.
+func (s *Neo4jGraphStore) GetWithOverlay(ctx context.Context, nodeKey string, scope models.ScopeContext) (*models.Node, error) {
+	// If this is the main scope, just do a direct lookup.
+	if scope.ScopeID == "" || scope.ScopeID == models.ScopeMain {
+		return s.GetNode(ctx, nodeKey, scope)
+	}
+
+	cypher := `
+		// Try overlay node first
+		OPTIONAL MATCH (overlay {nodeKey: $nodeKey, scopeId: $scopeId})
+		// Check for tombstone
+		OPTIONAL MATCH (tombstone:Tombstone {scopeId: $scopeId, targetNodeKey: $nodeKey})
+		// Fallback to main
+		OPTIONAL MATCH (main {nodeKey: $nodeKey, scopeId: 'main'})
+		RETURN
+			overlay, labels(overlay) AS overlayLabels,
+			tombstone,
+			main, labels(main) AS mainLabels
+		LIMIT 1
+	`
+
+	records, err := s.client.ExecuteQuery(ctx, cypher, map[string]any{
+		"nodeKey": nodeKey,
+		"scopeId": scope.ScopeID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetWithOverlay(%s): %w", nodeKey, err)
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	m := records[0].AsMap()
+
+	// Overlay node wins.
+	if overlay, ok := m["overlay"]; ok && overlay != nil {
+		row := map[string]any{}
+		if props, ok := overlay.(map[string]any); ok {
+			for k, v := range props {
+				row[k] = v
+			}
+		}
+		if labels, ok := m["overlayLabels"]; ok {
+			row["nodeLabels"] = labels
+		}
+		return recordToNode(row), nil
+	}
+
+	// Tombstone hides main-scope node.
+	if tombstone, ok := m["tombstone"]; ok && tombstone != nil {
+		return nil, nil
+	}
+
+	// Fall back to main-scope node.
+	if main, ok := m["main"]; ok && main != nil {
+		row := map[string]any{}
+		if props, ok := main.(map[string]any); ok {
+			for k, v := range props {
+				row[k] = v
+			}
+		}
+		if labels, ok := m["mainLabels"]; ok {
+			row["nodeLabels"] = labels
+		}
+		return recordToNode(row), nil
+	}
+
+	return nil, nil
+}
+
+// Close releases the underlying Neo4j connection.
+func (s *Neo4jGraphStore) Close(ctx context.Context) error {
+	return s.client.Close(ctx)
+}
+
+// buildNodeProps merges all BaseNode fields into a flat properties map suitable
+// for storage in Neo4j. Explicitly-set fields take precedence over Props.
+func buildNodeProps(node *models.Node) map[string]any {
+	props := make(map[string]any, len(node.Props)+8)
+	for k, v := range node.Props {
+		props[k] = v
+	}
+	// Always write the identity / scope fields.
+	props["nodeKey"] = node.NodeKey
+	if node.ScopeID != "" {
+		props["scopeId"] = node.ScopeID
+	}
+	if node.Scope != "" {
+		props["scope"] = node.Scope
+	}
+	if !node.CreatedAt.IsZero() {
+		props["createdAt"] = node.CreatedAt.Unix()
+	}
+	if !node.UpdatedAt.IsZero() {
+		props["updatedAt"] = node.UpdatedAt.Unix()
+	}
+	return props
+}
+
+// recordToNode converts a Neo4j record map (as returned by AsMap()) to a *Node.
+func recordToNode(m map[string]any) *models.Node {
+	node := &models.Node{}
+	node.Props = make(map[string]any)
+
+	for k, v := range m {
+		switch k {
+		case "nodeLabels":
+			if labels, ok := v.([]any); ok {
+				for _, l := range labels {
+					if ls, ok := l.(string); ok {
+						node.Labels = append(node.Labels, ls)
+					}
+				}
+			}
+		default:
+			node.Props[k] = v
+		}
+	}
+
+	// Promote well-known properties to struct fields.
+	if nk, ok := node.Props["nodeKey"].(string); ok {
+		node.NodeKey = nk
+	}
+	if sid, ok := node.Props["scopeId"].(string); ok {
+		node.ScopeID = sid
+	}
+	if sc, ok := node.Props["scope"].(string); ok {
+		node.Scope = sc
+	}
+	if id, ok := node.Props["id"].(string); ok {
+		node.ID = id
+	}
+
+	return node
+}


### PR DESCRIPTION
## Summary

Stacked on: #21 (phase2-apps)

Defines the `GraphStore` abstraction layer — the first of the three-store interfaces. All graph database operations are now accessible through a typed interface rather than direct Neo4j driver calls.

## Files added

### `libs/core-models-go/store.go`

`GraphStore` interface with 9 methods:

**Write:** `UpsertNode`, `UpsertNodes`, `UpsertRelationship`, `UpsertRelationships`, `ApplyTombstone`

**Read:** `GetNode`, `FindNodes`, `FindRelationships`, `GetWithOverlay`

**Lifecycle:** `Close`

Supporting types: `NodeFilter`, `RelFilter`

### `libs/neo4j-client-go/store.go`

`Neo4jGraphStore` — wraps the existing `Client`:
- Batch upserts delegate to `client.MergeNodesBatch`
- Relationships use `MERGE` on `(fromKey, toKey, relType)`
- `GetWithOverlay` resolves in a single Cypher query: overlay wins → tombstone hides → main fallback

### `libs/core-models-go/store_mock.go`

`MockGraphStore` — in-memory implementation for unit tests:
- No Neo4j required
- Overlay precedence implemented in pure Go
- `Errors map[string]error` for per-method error injection
- Helper methods `AllNodes()`, `AllRelationships()`

### `libs/core-models-go/store_mock_test.go`

14 tests covering: round-trips, overlay precedence (3 cases), error injection (4 cases), limit, idempotency.

## Validation

```
go build ./...                  ✓
go test ./libs/core-models-go/  ✓  (14/14 pass)
```

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./libs/core-models-go/` — all 14 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)